### PR TITLE
fix: keep the setup token reachable so initialization cannot lock out (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ JWT_SECRET=$(openssl rand -hex 32) ./meridian
 
 未配置域名时访问 `http://你的IP:9090`；配置后访问对应的 `https://面板域名`。首次打开会要求输入管理员账号、12–72 字节的密码，以及安装完成时显示的初始化令牌。也可以预先设置 `SETUP_TOKEN` 环境变量。
 
+令牌丢失时不必重装，按部署方式取回即可：
+
+```bash
+# 一键脚本 / systemd 部署
+sudo awk -F= '$1=="SETUP_TOKEN"{print $2}' /opt/meridian/.env
+# 或重新运行 install，尚未创建管理员时会再次打印
+sudo ./install.sh install
+
+# Docker 部署
+docker logs meridian | grep 'Initial setup token'
+```
+
 ---
 
 ## 配置
@@ -152,7 +164,7 @@ unset ADMIN_PASSWORD
 | `PANEL_BIND_ADDR` | `0.0.0.0` | 仅控制管理面板的绑定地址；域名模式由安装器设为 `127.0.0.1`，不影响站点监听端口 |
 | `PANEL_DOMAIN` | 空 | 安装器记录的单个管理面板域名；不作为播放回源配置 |
 | `JWT_SECRET` | 进程启动时随机生成 | 至少 32 字节的 JWT 签名密钥。**生产环境必须显式设置**，否则每次重启后会话全部失效 |
-| `SETUP_TOKEN` | 首次启动时随机生成 | 首次创建管理员所需的一次性初始化令牌；未设置时会写入启动日志 |
+| `SETUP_TOKEN` | 首次启动时随机生成 | 首次创建管理员所需的一次性初始化令牌；未设置时会写入启动日志。一键脚本会将其持久化到 `.env`，并在管理员尚未创建时于每次 `install` 后打印 |
 | `TRUSTED_PROXY_CIDRS` | 空 | 允许提供 `X-Real-IP`/`X-Forwarded-For` 的反向代理 CIDR，多个值用逗号分隔；不要填写不受信任的客户端网段 |
 
 ### Docker Compose

--- a/install.sh
+++ b/install.sh
@@ -306,6 +306,30 @@ append_env_default() {
     install_env_file "$tmp_file"
 }
 
+# Guarantees a non-empty SETUP_TOKEN in .env and echoes the effective value.
+# An existing .env may predate SETUP_TOKEN entirely, or carry it with an empty
+# value. In both cases the panel generates a throwaway token at startup and
+# writes it only to the service log, while the installer used to print nothing,
+# leaving the operator unable to create the first administrator.
+ensure_setup_token() {
+    local tmp_dir="$1" env_file tmp_file token
+    token=$(read_env_value SETUP_TOKEN)
+    if [ -n "$token" ]; then
+        printf '%s\n' "$token"
+        return 0
+    fi
+    env_file=$(env_file_path)
+    token=$(generate_secret)
+    tmp_file="${tmp_dir}/env-setup-token"
+    # $1 is an awk field reference, not a shell variable.
+    # shellcheck disable=SC2016
+    as_root awk -F= '$1 != "SETUP_TOKEN" { print }' "$env_file" > "$tmp_file"
+    printf 'SETUP_TOKEN=%s\n' "$token" >> "$tmp_file"
+    chmod 0600 "$tmp_file"
+    install_env_file "$tmp_file"
+    printf '%s\n' "$token"
+}
+
 set_panel_env() {
     local bind_addr="$1" domain="$2" proxies="$3" tmp_dir="$4" env_file tmp_file
     env_file=$(env_file_path)
@@ -370,6 +394,28 @@ wait_for_health() {
     return 1
 }
 
+# Succeeds only when the panel positively reports an administrator already
+# exists. Probe failures return non-zero so callers keep showing the setup
+# token rather than risk withholding it from an un-provisioned panel.
+panel_setup_complete() {
+    local body
+    command -v curl >/dev/null 2>&1 || return 1
+    body=$(curl --noproxy '*' --proto '=http' --connect-timeout 1 --max-time 2 \
+        -sS "$(health_url)" 2>/dev/null || true)
+    printf '%s' "$body" | grep -q '"needs_setup"[[:space:]]*:[[:space:]]*false'
+}
+
+# Shows the token the panel will demand before the first administrator exists.
+# Both install paths call this: a fresh install falls through to the summary
+# banner, while reinstalling over an existing tree returns early and would
+# otherwise print nothing.
+report_setup_token() {
+    [ -n "$INITIAL_SETUP_TOKEN" ] || return 0
+    panel_setup_complete && return 0
+    printf "  ${YELLOW}首次初始化令牌（请立即保存）:${NC} ${BOLD}%s${NC}\n" "$INITIAL_SETUP_TOKEN"
+    printf '  忘记时可从 %s 的 SETUP_TOKEN 读取\n' "$(env_file_path)"
+}
+
 ensure_service_user() {
     local nologin_shell
     nologin_shell=$(command -v nologin || true)
@@ -413,6 +459,7 @@ prepare_data_and_config() {
         append_env_default PANEL_BIND_ADDR 0.0.0.0 "$tmp_dir"
         append_env_default PANEL_DOMAIN "" "$tmp_dir"
         append_env_default TRUSTED_PROXY_CIDRS "" "$tmp_dir"
+        INITIAL_SETUP_TOKEN=$(ensure_setup_token "$tmp_dir")
         if is_systemd; then
             as_root chown root:"$SERVICE_GROUP" "$env_file"
             as_root chmod 0640 "$env_file"
@@ -922,6 +969,7 @@ do_install() {
         prepare_data_and_config "$tmp_dir"
         rm -rf -- "$tmp_dir"
         apply_domain_choice 1
+        report_setup_token
         return 0
     fi
 
@@ -956,9 +1004,7 @@ do_install() {
         printf '  面板地址: http://服务器IP:%s\n' "$(read_config_port)"
     fi
     printf '  数据目录: %s\n' "$DATA_DIR"
-    if [ -n "$INITIAL_SETUP_TOKEN" ]; then
-        printf "  ${YELLOW}首次初始化令牌（请立即保存）:${NC} ${BOLD}%s${NC}\n" "$INITIAL_SETUP_TOKEN"
-    fi
+    report_setup_token
 }
 
 do_update() {

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -254,6 +254,35 @@ if ! (do_install) >"${TEST_ROOT}/install-existing.log" 2>&1; then
 fi
 assert_eq 'v9.9.9' "$(get_current_version)" 'install must not update existing installation'
 
+# Reinstalling over a config that predates SETUP_TOKEN (or that lost it) must
+# still hand the operator a usable token; otherwise the panel demands one nobody
+# can produce and the first administrator can never be created.
+# $1 is an awk field reference, not a shell variable.
+# shellcheck disable=SC2016
+awk -F= '$1 != "SETUP_TOKEN" { print }' "${DATA_DIR}/.env" > "${TEST_ROOT}/env-legacy"
+cp "${TEST_ROOT}/env-legacy" "${DATA_DIR}/.env"
+assert_eq '' "$(read_env_value SETUP_TOKEN)" 'legacy config starts without a setup token'
+if ! (do_install) >"${TEST_ROOT}/install-legacy-token.log" 2>&1; then
+    cat "${TEST_ROOT}/install-legacy-token.log" >&2
+    exit 1
+fi
+legacy_setup_token=$(read_env_value SETUP_TOKEN)
+if [ -z "$legacy_setup_token" ]; then
+    echo 'FAIL: reinstall over legacy config left SETUP_TOKEN empty' >&2
+    exit 1
+fi
+assert_eq '1' "$(grep -c '^SETUP_TOKEN=' "${DATA_DIR}/.env")" 'setup token key not duplicated'
+assert_contains "${TEST_ROOT}/install-legacy-token.log" "$legacy_setup_token"
+assert_eq '0.0.0.0' "$(read_env_value PANEL_BIND_ADDR)" 'existing settings survive token backfill'
+
+# A token that already works must be reused, not rotated on every reinstall.
+if ! (do_install) >"${TEST_ROOT}/install-token-stable.log" 2>&1; then
+    cat "${TEST_ROOT}/install-token-stable.log" >&2
+    exit 1
+fi
+assert_eq "$legacy_setup_token" "$(read_env_value SETUP_TOKEN)" 'setup token stable across reinstalls'
+assert_contains "${TEST_ROOT}/install-token-stable.log" "$legacy_setup_token"
+
 domain_env_before=$(sha256_file "${DATA_DIR}/.env")
 if ! (do_update) >"${TEST_ROOT}/update.log" 2>&1; then
     cat "${TEST_ROOT}/update.log" >&2


### PR DESCRIPTION
Fixes #13。

## 根因

`prepare_data_and_config` 只在**新建** `.env` 时生成并记录 `SETUP_TOKEN`：

```bash
if ! as_root test -f "$env_file"; then
    INITIAL_SETUP_TOKEN=$(generate_secret)   # 只有这里赋值
    ...
else
    append_env_default PANEL_BIND_ADDR ...   # 只回填这三个键
    append_env_default PANEL_DOMAIN ...
    append_env_default TRUSTED_PROXY_CIDRS ...
fi
```

走 `else` 分支时 `INITIAL_SETUP_TOKEN` 保持为空，结尾横幅的 `[ -n "$INITIAL_SETUP_TOKEN" ]` 判断因此为假，**唯一会显示令牌的地方被跳过**。同时 `SETUP_TOKEN` 从不被回填。由此有两条锁死路径：

1. `.env` 来自引入该功能之前的版本 → 后端在 `main.go:3161-3167` 自行随机生成一个并**只写进服务日志**。README 只为 Docker 流程记录了 `docker logs meridian`，systemd 流程没有任何等价说明。
2. `.env` 已带有旧安装写入的令牌 → 后端要求提交它，但脚本再也不会重新打印，管理员早已丢失当初那一次输出。

两种情况下面板都会持续索要一个无人能提供的令牌，也就是 issue #13 报告的「1.4.3 版本初始化无法注册」。

## 改动

**`ensure_setup_token`** — 保证 `.env` 里存在非空 `SETUP_TOKEN` 并回显最终值。沿用 `write_rotated_env` 的 awk 过滤模式，因此键存在但值为空时是**就地替换而非追加重复键**。已有可用令牌时原样返回且不改文件。

**`panel_setup_complete`** — 查询 `/api/auth/check`（安装脚本已用于健康检查的同一端点）的 `needs_setup`。只在**确认**管理员已存在时返回成功；缺少 curl、服务未启动、请求失败等情况一律返回失败，即**探测失败时保守地仍然展示令牌**，宁可多打印也不冒锁死用户的风险。

**`report_setup_token`** — 前两者的组合，已完成初始化时静默。

## 一个容易漏掉的点

`report_setup_token` 在**两条**安装路径上都调用了。`do_install` 检测到已安装的二进制时走的是提前 return 分支：

```bash
if [ -x "$current_binary" ]; then
    prepare_data_and_config "$tmp_dir"
    apply_domain_choice 1
    report_setup_token   # ← 新增；此分支从不到达结尾横幅
    return 0
fi
```

这条分支根本到不了文件末尾的横幅。所以只做回填是不够的——恰好在 bug 报告描述的「重装」场景下仍然什么都不会打印。

## 测试

`tests/install_test.sh` 新增的用例驱动**真实的 `do_install`**（而非直接单测辅助函数）覆盖一份被剥掉 `SETUP_TOKEN` 的配置，断言：

- 令牌被回填且非空
- `SETUP_TOKEN` 键没有重复
- 令牌出现在安装输出中
- 第二次重装时令牌**保持不变**（不会每次轮换）
- 既有的 `PANEL_BIND_ADDR` 等设置不被破坏
- 面板不可达时 `panel_setup_complete` 失败关闭

## 文档

README 补上了 systemd 部署下的取回方式（`/opt/meridian/.env`、重跑 `install`），并在环境变量表里说明一键脚本会持久化该令牌。此前只有 Docker 流程有说明。

## 本地验证

`bash -n install.sh tests/install_test.sh` 通过。`ensure_setup_token` 与 `report_setup_token` 的全部分支已在本地以 source 方式逐一验证（回填、替换空值、幂等、不可达时打印、已初始化时静默）。完整安装测试套件需要 Linux + sudo，交由本 PR 的 CI 运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)