### PR TITLE
fix: stop PUT /api/sites/{id} from silently clearing traffic_quota

### DIFF
--- a/main.go
+++ b/main.go
@@ -2757,7 +2757,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			CustomUserAgent   *string   `json:"custom_user_agent"`
 			CustomClient      *string   `json:"custom_client"`
 			CustomVersion     *string   `json:"custom_version"`
-			Quota             int64     `json:"traffic_quota"`
+			Quota             *int64    `json:"traffic_quota"`
 			SpeedLimit        *int      `json:"speed_limit"`
 		}
 		if err := decodeJSONBody(w, r, &req); err != nil {
@@ -2780,6 +2780,10 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		speedLimit := oldSite.SpeedLimit
 		if req.SpeedLimit != nil {
 			speedLimit = *req.SpeedLimit
+		}
+		quota := oldSite.TrafficQuota
+		if req.Quota != nil {
+			quota = *req.Quota
 		}
 		uaMode, customUserAgent, customClient, customVersion, uaErr := mergeSiteUAConfig(*oldSite, req.UAMode, req.CustomUserAgent, req.CustomClient, req.CustomVersion)
 		if uaErr != nil {
@@ -2804,7 +2808,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		candidate.CustomUserAgent = customUserAgent
 		candidate.CustomClient = customClient
 		candidate.CustomVersion = customVersion
-		candidate.TrafficQuota = req.Quota
+		candidate.TrafficQuota = quota
 		candidate.SpeedLimit = speedLimit
 		if err := validateSiteSettings(candidate.Name, candidate.ListenPort, candidate.TargetURL, candidate.PlaybackTargetURL, candidate.PlaybackMode, streamHostList, candidate.UAMode, candidate.CustomUserAgent, candidate.CustomClient, candidate.CustomVersion, candidate.TrafficQuota, candidate.SpeedLimit); err != nil {
 			a.jsonErr(w, http.StatusBadRequest, err.Error())

--- a/main_test.go
+++ b/main_test.go
@@ -1891,6 +1891,64 @@ func TestHandleSiteUpdatePreservesOmittedSpeedLimit(t *testing.T) {
 	}
 }
 
+func TestHandleSiteUpdatePreservesOmittedTrafficQuota(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	site, err := app.db.CreateSite("quota", port, "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 5<<30, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	if enabled, err := app.db.ToggleSite(site.ID); err != nil || enabled {
+		t.Fatalf("disable site: enabled=%v err=%v", enabled, err)
+	}
+
+	body := strings.NewReader(`{"name":"quota","listen_port":` + jsonNumber(port) + `,"target_url":"http://127.0.0.1:8096","ua_mode":"infuse"}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(site.ID), body)
+	rr := httptest.NewRecorder()
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficQuota != 5<<30 {
+		t.Fatalf("traffic_quota = %d, want preserved value %d", reloaded.TrafficQuota, int64(5<<30))
+	}
+}
+
+// Omitting the field preserves the quota, but sending an explicit 0 must still
+// clear it, so the pointer merge cannot be mistaken for "always ignore".
+func TestHandleSiteUpdateAppliesExplicitZeroTrafficQuota(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	site, err := app.db.CreateSite("quota-clear", port, "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 5<<30, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	if enabled, err := app.db.ToggleSite(site.ID); err != nil || enabled {
+		t.Fatalf("disable site: enabled=%v err=%v", enabled, err)
+	}
+
+	body := strings.NewReader(`{"name":"quota-clear","listen_port":` + jsonNumber(port) + `,"target_url":"http://127.0.0.1:8096","ua_mode":"infuse","traffic_quota":0}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(site.ID), body)
+	rr := httptest.NewRecorder()
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficQuota != 0 {
+		t.Fatalf("traffic_quota = %d, want explicit 0", reloaded.TrafficQuota)
+	}
+}
+
 func TestFlushTrafficUpdatesBaselineAndStopPersistsPendingUsage(t *testing.T) {
 	app := newTestApp(t)
 	site, err := app.db.CreateSite("traffic", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 1024, 0)


### PR DESCRIPTION
## 问题

站点更新 DTO 里**其他所有**可选字段都是指针，这样省略某个键时就能保留库里的原值：

```go
PlaybackTargetURL *string   `json:"playback_target_url"`
PlaybackMode      *string   `json:"playback_mode"`
StreamHosts       *[]string `json:"stream_hosts"`
UAMode            *string   `json:"ua_mode"`
...
Quota             int64     `json:"traffic_quota"`   // ← 唯一的值类型
SpeedLimit        *int      `json:"speed_limit"`
```

`Quota` 是裸 `int64`，所以任何不带 `traffic_quota` 的 PUT 请求体都会解码成 0，随后 `main.go:2807` 无条件写回：

```go
candidate.TrafficQuota = req.Quota
```

而代理侧把 0 解读为「无限制」（`main.go:1555` 的配额闸门），于是运营者设置的滥用上限**静默停止生效**：没有报错，界面把 0 显示为无限制，配额就这样消失了。

对比之下 `speed_limit` 就是对的，甚至已经有一个 `TestHandleSiteUpdatePreservesOmittedSpeedLimit` 在守着它——`traffic_quota` 只是被漏掉了。

## 影响范围

这是**潜伏**缺陷而非正在发生的故障：随包发布的前端总是发送 `traffic_quota`（`web/static/js/pages/sites.js:329`），所以只有手写请求、脚本化调用或部分更新的 PUT 才会触发。没有攻击者参与——需要已认证的管理员——所以严重性是「静默数据丢失」而不是权限绕过。

## 改动

改成 `*int64`，并沿用 `speed_limit` 现成的归并写法：

```go
quota := oldSite.TrafficQuota
if req.Quota != nil {
    quota = *req.Quota
}
```

创建（POST）路径的 `Quota` 保持裸 `int64` 不变——新建站点没有需要保留的原值。

## 测试

两个方向各一个，因为只测一边会让修复本身变成新 bug：

- `TestHandleSiteUpdatePreservesOmittedTrafficQuota` — 省略字段时保留原配额（镜像现有的 speed_limit 测试）
- `TestHandleSiteUpdateAppliesExplicitZeroTrafficQuota` — 显式传 `"traffic_quota":0` 仍然会清零，确保指针归并不被误解成「永远忽略这个字段」

## 验证说明

本地无 Go 工具链，未做本地构建；结构体标签对齐已手工核对为 gofmt 一致（`*int64` 与 `*[]string` 同宽）。**依赖本 PR 的 CI 验证**（`go build`、`go test -race`、`go vet`、`gosec`）。合并前请确认 CI 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)