### PR TITLE
fix: validate the upstream 101 and meter the WebSocket tunnel

### DIFF
--- a/main.go
+++ b/main.go
@@ -1156,8 +1156,79 @@ func (w *rateLimitedWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, fmt.Errorf("hijack not supported")
 }
 
+// tunnelWriter meters, and optionally paces, bytes copied through a hijacked
+// WebSocket tunnel. Accounting has to happen per chunk rather than once the copy
+// returns, otherwise a long-lived tunnel stays invisible to the quota gate and
+// exempt from the site's speed limit for as long as it is open.
+type tunnelWriter struct {
+	dst         io.Writer
+	counter     *atomic.Int64
+	bytesPerSec int64
+	written     int64
+	start       time.Time
+}
+
+func (t *tunnelWriter) Write(b []byte) (int, error) {
+	if t.bytesPerSec <= 0 {
+		n, err := t.dst.Write(b)
+		t.counter.Add(int64(n))
+		return n, err
+	}
+	total := 0
+	for len(b) > 0 {
+		elapsed := time.Since(t.start).Seconds()
+		if elapsed < 0.001 {
+			elapsed = 0.001
+		}
+		allowed := int64(elapsed*float64(t.bytesPerSec)) - t.written
+		if allowed <= 0 {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		chunk := b
+		if int64(len(chunk)) > allowed {
+			chunk = b[:allowed]
+		}
+		n, err := t.dst.Write(chunk)
+		t.counter.Add(int64(n))
+		t.written += int64(n)
+		total += n
+		b = b[n:]
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			return total, io.ErrNoProgress
+		}
+	}
+	return total, nil
+}
+
+// headerHasToken reports whether a comma-separated header such as Connection
+// carries the given token, which is how RFC 9110 requires these be compared.
+func headerHasToken(header http.Header, name, token string) bool {
+	for _, value := range header.Values(name) {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isWebSocketUpgrade reports whether the request is a real RFC 6455 handshake.
+// A bare "Upgrade: websocket" header is not enough to qualify: routing an
+// ordinary request into the hijacked tunnel would skip the metering and
+// speed-limit wrappers that the normal proxy path installs, and would relay raw
+// bytes to an upstream that never agreed to switch protocols. Requests that fail
+// this check fall through to httputil.ReverseProxy, which negotiates protocol
+// switches on its own.
 func isWebSocketUpgrade(r *http.Request) bool {
-	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+	return r.Method == http.MethodGet &&
+		strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		headerHasToken(r.Header, "Connection", "upgrade") &&
+		r.Header.Get("Sec-WebSocket-Key") != ""
 }
 
 func normalizeTargetURL(addr string) (*url.URL, error) {
@@ -1366,6 +1437,10 @@ func prepareUpstreamHeaders(header http.Header, inbound *http.Request, profile U
 func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, profile UAProfile) http.Header {
 	header := inbound.Header.Clone()
 	for _, name := range []string{
+		// Content-Length must go with the other hop-by-hop headers: the upgrade
+		// path never reads r.Body, so letting a length through would tell the
+		// upstream to frame bytes as a body that this side never sends.
+		"Content-Length",
 		"Keep-Alive",
 		"Proxy-Authenticate",
 		"Proxy-Authorization",
@@ -1384,7 +1459,20 @@ func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, pro
 	return header
 }
 
-func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, profile UAProfile, inst *ProxyInstance) {
+// writeWebSocketGatewayError answers a hijacked client directly, since the
+// http.ResponseWriter is no longer usable once the connection is taken over.
+func writeWebSocketGatewayError(conn net.Conn) {
+	const body = `{"error":"upstream refused websocket upgrade"}`
+	_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+}
+
+func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, profile UAProfile, inst *ProxyInstance, speedLimitBytes int64) {
+	// Nothing on this path reads r.Body, so a body would be left sitting in the
+	// hijacked buffer and relayed verbatim to the upstream.
+	if r.ContentLength != 0 || len(r.TransferEncoding) > 0 {
+		http.Error(w, "websocket upgrade must not carry a body", http.StatusBadRequest)
+		return
+	}
 	scheme := "ws"
 	if target.Scheme == "https" {
 		scheme = "wss"
@@ -1421,7 +1509,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, pr
 	}
 	if err != nil {
 		log.Printf("[WS] upstream dial error: %v", err)
-		clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+		writeWebSocketGatewayError(clientConn)
 		return
 	}
 	defer upstreamConn.Close()
@@ -1452,18 +1540,65 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, pr
 		return
 	}
 
+	// Require a real protocol switch before relaying any raw bytes. Without this
+	// check the tunnel starts regardless of what the upstream answered, so if the
+	// upstream ignored the upgrade and stayed in HTTP keep-alive mode, whatever
+	// the client sends next reaches it as requests that never passed through
+	// removeClientForwardingHeaders/setTrustedForwardingHeaders/applyUAProfileHeaders.
+	if err := upstreamConn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		log.Printf("[WS] set handshake read deadline: %v", err)
+		return
+	}
+	// Read through a buffered reader and keep using it below: ReadResponse may
+	// consume bytes past the headers, and those belong to the tunnel.
+	upstreamReader := bufio.NewReader(upstreamConn)
+	resp, err := http.ReadResponse(upstreamReader, r)
+	if err != nil {
+		log.Printf("[WS] read upstream handshake: %v", err)
+		writeWebSocketGatewayError(clientConn)
+		return
+	}
+	defer resp.Body.Close()
+	if err := upstreamConn.SetReadDeadline(time.Time{}); err != nil {
+		log.Printf("[WS] clear handshake read deadline: %v", err)
+		return
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols ||
+		!strings.EqualFold(resp.Header.Get("Upgrade"), "websocket") ||
+		!headerHasToken(resp.Header, "Connection", "upgrade") {
+		// The body is deliberately not relayed. An upstream that answers a
+		// handshake with a normal response must not turn this path into an
+		// unmetered, unthrottled transfer channel.
+		log.Printf("[WS] upstream refused upgrade: status %d", resp.StatusCode)
+		writeWebSocketGatewayError(clientConn)
+		return
+	}
+
+	// Relay the switch verbatim; the client needs Sec-WebSocket-Accept.
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 101 Switching Protocols\r\n"); err != nil {
+		log.Printf("[WS] write handshake response: %v", err)
+		return
+	}
+	if err := resp.Header.Write(clientConn); err != nil {
+		log.Printf("[WS] write handshake headers: %v", err)
+		return
+	}
+	if _, err := io.WriteString(clientConn, "\r\n"); err != nil {
+		log.Printf("[WS] finish handshake response: %v", err)
+		return
+	}
+
 	log.Printf("[WS] tunnel established: client <-> %s", target.Host)
 
-	// Bidirectional copy
+	// Bidirectional copy. Both directions are metered per chunk; only the
+	// download direction is paced, matching rateLimitedWriter on the HTTP path.
 	done := make(chan struct{}, 2)
 	go func() {
-		n, _ := io.Copy(upstreamConn, clientBuf)
-		inst.bytesIn.Add(n)
+		_, _ = io.Copy(&tunnelWriter{dst: upstreamConn, counter: &inst.bytesIn, start: time.Now()}, clientBuf)
 		done <- struct{}{}
 	}()
 	go func() {
-		n, _ := io.Copy(clientConn, upstreamConn)
-		inst.bytesOut.Add(n)
+		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: &inst.bytesOut, bytesPerSec: speedLimitBytes, start: time.Now()}, upstreamReader)
 		done <- struct{}{}
 	}()
 	<-done
@@ -1567,7 +1702,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			if isRedirectMode {
 				wsTarget = target
 			}
-			handleWebSocket(w, r, wsTarget, profile, inst)
+			handleWebSocket(w, r, wsTarget, profile, inst, speedLimitBytes)
 			return
 		}
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -199,7 +199,10 @@ func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
 	if !strings.Contains(seen, "101 Switching Protocols") {
 		t.Fatalf("client response = %q, want a relayed 101", seen)
 	}
-	if !strings.Contains(seen, "Sec-WebSocket-Accept:") {
+	// Case-insensitive on purpose: http.ReadResponse canonicalises the key to
+	// "Sec-Websocket-Accept", header names are case-insensitive on the wire, and
+	// this is exactly what httputil.ReverseProxy relays too.
+	if !strings.Contains(strings.ToLower(seen), "sec-websocket-accept:") {
 		t.Fatalf("handshake response dropped Sec-WebSocket-Accept: %q", seen)
 	}
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// handleWebSocket hijacks the connection and speaks HTTP by hand, so it needs a
+// real listener on both sides; httptest.NewRecorder cannot hijack. fakeWSUpstream
+// stands in for an Emby instance: it replies with a canned handshake answer and
+// records everything the proxy sends it, which is what lets a test prove that
+// particular client bytes never reached the upstream.
+
+const wsClientHandshake = "GET /embywebsocket HTTP/1.1\r\n" +
+	"Host: proxy.test\r\n" +
+	"Upgrade: websocket\r\n" +
+	"Connection: Upgrade\r\n" +
+	"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+	"Sec-WebSocket-Version: 13\r\n\r\n"
+
+type fakeWSUpstream struct {
+	ln   net.Listener
+	mu   sync.Mutex
+	got  []byte
+	done chan struct{}
+}
+
+func startFakeWSUpstream(t *testing.T, reply string) *fakeWSUpstream {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen upstream: %v", err)
+	}
+	u := &fakeWSUpstream{ln: ln, done: make(chan struct{})}
+	go func() {
+		defer close(u.done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		if _, err := io.WriteString(conn, reply); err != nil {
+			return
+		}
+		buf := make([]byte, 4096)
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+				return
+			}
+			n, err := conn.Read(buf)
+			if n > 0 {
+				u.mu.Lock()
+				u.got = append(u.got, buf[:n]...)
+				u.mu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return u
+}
+
+func (u *fakeWSUpstream) received() string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return string(u.got)
+}
+
+func (u *fakeWSUpstream) waitFor(t *testing.T, marker string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(u.received(), marker) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("upstream never received %q; got %q", marker, u.received())
+}
+
+func newWSProxyServer(t *testing.T, upstreamAddr string, inst *ProxyInstance, speedLimitBytes int64) *httptest.Server {
+	t.Helper()
+	target, err := normalizeTargetURL("http://" + upstreamAddr)
+	if err != nil {
+		t.Fatalf("normalizeTargetURL: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handleWebSocket(w, r, target, getUAProfile("infuse"), inst, speedLimitBytes)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Metering happens once the underlying write returns, so a reader can observe the
+// bytes a moment before the counter moves.
+func waitForTunnelCounter(t *testing.T, counter *atomic.Int64, min int64, label string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if counter.Load() >= min {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("%s = %d, want >= %d", label, counter.Load(), min)
+}
+
+func TestHandleWebSocketRefusesTunnelWhenUpstreamDoesNotSwitchProtocols(t *testing.T) {
+	// An upstream that ignores the upgrade and answers normally must not get a raw
+	// tunnel. Otherwise bytes the client pipelined behind the handshake reach it as
+	// requests that skipped every forwarding-header sanitizer.
+	upstream := startFakeWSUpstream(t, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+	inst := &ProxyInstance{server: &http.Server{}}
+	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	const smuggled = "GET /SMUGGLED-MUST-NOT-ARRIVE HTTP/1.1\r\n" +
+		"Host: internal-emby\r\n" +
+		"X-Forwarded-For: 10.0.0.1\r\n\r\n"
+	if _, err := io.WriteString(conn, wsClientHandshake+smuggled); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
+	raw, err := io.ReadAll(conn)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Logf("client read ended with: %v", err)
+	}
+	// Closing a socket that still holds our unread pipelined bytes can reset the
+	// connection and discard the queued response, so this half is best-effort.
+	// The security properties asserted below are not.
+	if got := string(raw); got != "" {
+		if !strings.Contains(got, "502 Bad Gateway") {
+			t.Fatalf("client response = %q, want 502 Bad Gateway", got)
+		}
+		if strings.Contains(got, "200 OK") {
+			t.Fatalf("client response relayed the upstream answer: %q", got)
+		}
+	}
+
+	<-upstream.done
+	if strings.Contains(upstream.received(), "SMUGGLED-MUST-NOT-ARRIVE") {
+		t.Fatalf("pipelined request reached the upstream: %q", upstream.received())
+	}
+	if n := inst.bytesOut.Load(); n != 0 {
+		t.Fatalf("bytesOut = %d, want 0 when the upgrade was refused", n)
+	}
+}
+
+func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
+	const serverPayload = "UPSTREAM-FRAMES"
+	upstream := startFakeWSUpstream(t, "HTTP/1.1 101 Switching Protocols\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"+
+		serverPayload)
+	inst := &ProxyInstance{server: &http.Server{}}
+	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+	if _, err := io.WriteString(conn, wsClientHandshake); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
+
+	buf := make([]byte, 1024)
+	seen := ""
+	for !strings.Contains(seen, serverPayload) {
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Fatalf("read from tunnel: %v (so far %q)", err, seen)
+		}
+		seen += string(buf[:n])
+	}
+	if !strings.Contains(seen, "101 Switching Protocols") {
+		t.Fatalf("client response = %q, want a relayed 101", seen)
+	}
+	if !strings.Contains(seen, "Sec-WebSocket-Accept:") {
+		t.Fatalf("handshake response dropped Sec-WebSocket-Accept: %q", seen)
+	}
+
+	const clientPayload = "CLIENT-FRAMES"
+	if _, err := io.WriteString(conn, clientPayload); err != nil {
+		t.Fatalf("write into tunnel: %v", err)
+	}
+	upstream.waitFor(t, clientPayload)
+
+	waitForTunnelCounter(t, &inst.bytesOut, int64(len(serverPayload)), "bytesOut")
+	waitForTunnelCounter(t, &inst.bytesIn, int64(len(clientPayload)), "bytesIn")
+}
+
+func TestHandleWebSocketRejectsUpgradeCarryingBody(t *testing.T) {
+	// Nothing on the upgrade path reads r.Body, so a body would be left in the
+	// hijacked buffer and relayed to the upstream verbatim.
+	inst := &ProxyInstance{server: &http.Server{}}
+	srv := newWSProxyServer(t, "127.0.0.1:9", inst, 0)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+	request := "GET /embywebsocket HTTP/1.1\r\n" +
+		"Host: proxy.test\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+		"Content-Length: 5\r\n\r\nhello"
+	if _, err := io.WriteString(conn, request); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
+	// A single read: the rejection is not hijacked, so the connection stays in
+	// keep-alive and io.ReadAll would block until the deadline.
+	buf := make([]byte, 512)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read rejection: %v", err)
+	}
+	if !strings.Contains(string(buf[:n]), "400 Bad Request") {
+		t.Fatalf("client response = %q, want 400 Bad Request", string(buf[:n]))
+	}
+}
+
+func TestIsWebSocketUpgradeRequiresCompleteHandshake(t *testing.T) {
+	full := map[string]string{
+		"Upgrade":           "websocket",
+		"Connection":        "Upgrade",
+		"Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+	}
+	cases := []struct {
+		name    string
+		method  string
+		headers map[string]string
+		want    bool
+	}{
+		{"complete handshake", http.MethodGet, full, true},
+		{"connection list carrying other tokens", http.MethodGet, map[string]string{
+			"Upgrade": "websocket", "Connection": "keep-alive, Upgrade", "Sec-WebSocket-Key": "k",
+		}, true},
+		{"bare upgrade header only", http.MethodGet, map[string]string{"Upgrade": "websocket"}, false},
+		{"missing sec-websocket-key", http.MethodGet, map[string]string{
+			"Upgrade": "websocket", "Connection": "Upgrade",
+		}, false},
+		{"connection token absent", http.MethodGet, map[string]string{
+			"Upgrade": "websocket", "Connection": "keep-alive", "Sec-WebSocket-Key": "k",
+		}, false},
+		{"not a GET", http.MethodPost, full, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/embywebsocket", nil)
+			for name, value := range tc.headers {
+				req.Header.Set(name, value)
+			}
+			if got := isWebSocketUpgrade(req); got != tc.want {
+				t.Fatalf("isWebSocketUpgrade = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrepareWebSocketUpstreamHeadersDropsContentLength(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/embywebsocket", nil)
+	req.Header.Set("Content-Length", "42")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	target, err := normalizeTargetURL("http://127.0.0.1:8096")
+	if err != nil {
+		t.Fatalf("normalizeTargetURL: %v", err)
+	}
+	header := prepareWebSocketUpstreamHeaders(req, target, getUAProfile("infuse"))
+	if got := header.Get("Content-Length"); got != "" {
+		t.Fatalf("Content-Length = %q, want it dropped before the upstream handshake", got)
+	}
+	if header.Get("Sec-WebSocket-Key") == "" {
+		t.Fatal("Sec-WebSocket-Key must survive to the upstream")
+	}
+}
+
+func TestHeaderHasToken(t *testing.T) {
+	header := http.Header{}
+	header.Add("Connection", "keep-alive, Upgrade")
+	header.Add("Connection", "close")
+	if !headerHasToken(header, "Connection", "upgrade") {
+		t.Fatal("upgrade token in a comma list must be found, case-insensitively")
+	}
+	if !headerHasToken(header, "Connection", "CLOSE") {
+		t.Fatal("token in a second header line must be found")
+	}
+	if headerHasToken(header, "Connection", "upgrad") {
+		t.Fatal("partial token must not match")
+	}
+	if headerHasToken(http.Header{}, "Connection", "upgrade") {
+		t.Fatal("absent header must not match")
+	}
+}
+
+func TestTunnelWriterMetersAndPaces(t *testing.T) {
+	var counter atomic.Int64
+	var sink bytes.Buffer
+	w := &tunnelWriter{dst: &sink, counter: &counter, start: time.Now()}
+	if _, err := w.Write([]byte("0123456789")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := counter.Load(); got != 10 {
+		t.Fatalf("counter = %d, want 10", got)
+	}
+	if sink.String() != "0123456789" {
+		t.Fatalf("sink = %q", sink.String())
+	}
+
+	// At 1000 bytes/sec, 200 bytes cannot complete in much under 200ms.
+	sink.Reset()
+	counter.Store(0)
+	paced := &tunnelWriter{dst: &sink, counter: &counter, bytesPerSec: 1000, start: time.Now()}
+	began := time.Now()
+	if _, err := paced.Write(make([]byte, 200)); err != nil {
+		t.Fatalf("paced Write: %v", err)
+	}
+	if elapsed := time.Since(began); elapsed < 100*time.Millisecond {
+		t.Fatalf("paced write took %v, want the speed limit to slow it down", elapsed)
+	}
+	if got := counter.Load(); got != 200 {
+		t.Fatalf("paced counter = %d, want 200", got)
+	}
+}


### PR DESCRIPTION
审查里存活的 8 条发现中有 3 条都落在 WebSocket 隧道上——而这恰好是全项目**唯一零测试覆盖**的代码路径(2375 行测试里,两个 websocket 测试只覆盖了纯函数 `prepareWebSocketUpstreamHeaders`,`handleWebSocket` 本身从未被执行过)。本 PR 一并修掉,并补上这条路径缺失的测试。

## 1. 从不校验上游是否真的切换了协议

`handleWebSocket` 写完握手请求后直接开始双向 `io.Copy`,中间**没有 `http.ReadResponse`、没有 101 检查**。而 `Hijack()` 返回的 `*bufio.ReadWriter` 是刻意保留已缓冲的流水线字节的,所以如果上游忽略了这个升级请求、继续以 HTTP keep-alive 模式处理连接,客户端跟在握手后面的字节就会作为**完全由攻击者控制的 HTTP 请求**到达上游,绕过 `removeClientForwardingHeaders` / `setTrustedForwardingHeaders` / `applyUAProfileHeaders` 这整套头部信任模型。

现在会在超时限制下读取响应,只有状态码为 101 且 `Upgrade` / `Connection` token 确认切换后才建立隧道——这个校验方式与标准库 `httputil.ReverseProxy.handleUpgradeResponse` 完全一致。后续读取继续走同一个 `bufio.Reader`,因为 `ReadResponse` 可能已经缓冲了头部之后的字节,那些字节属于隧道。

升级被拒时返回 502 且**不转发响应体**,避免这条路径本身变成不计量的批量传输通道。

## 2. 裸 `Upgrade` 头就能逃过计量和限速

`isWebSocketUpgrade` 原来只检查一个头:

```go
return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
```

于是任何请求只要加上这一个头,就能选择进入 hijack 路径,跳过正常路径安装的 `meteredWriter` 与 `rateLimitedWriter`。现在要求 GET 方法、`Connection` 头携带 `upgrade` token、以及存在 `Sec-WebSocket-Key`。

没达标的请求会**落到 `httputil.ReverseProxy`**,而它自己就能协商协议切换,所以即使出现误判,退化结果是走标准库路径而不是功能损坏。

## 3. 隧道流量在关闭前完全不可见

字节数原来只在 `io.Copy` 返回**之后**才累加进 `inst.bytesIn/bytesOut`,所以一条开着的隧道在其整个生命周期内对配额闸门是隐形的,也完全不受限速约束。

新增的 `tunnelWriter` 按块计量,并对下行方向限速,复用了 `rateLimitedWriter` 已被测试固定的配速算法。只对下行限速,与 HTTP 路径的行为一致。

## 附带:`Content-Length` 未被剥离

`prepareWebSocketUpstreamHeaders` 删掉了七个逐跳头部,但 `Content-Length` 存活进了手写握手。而这条路径从不读取 `r.Body`,所以这个长度是在告诉上游去切分本端根本不会发送的字节——这让攻击者能精确对齐上面第 1 条里的那个流水线请求。现在它和其他逐跳头部一起被删除,并且携带请求体的升级请求会被直接拒绝。

## 刻意不做的两件事

- **配额超限时中断进行中的隧道。** 按块计量之后配额闸门已经能正确拒绝**新**请求;而 HTTP 路径同样不会中断进行中的响应(`meteredWriter`/`rateLimitedWriter` 都不做响应中途的配额检查)。中断隧道会与既有行为不一致,属于产品决策而非缺陷修复。
- **空闲读超时。** 原审查中「隧道无空闲超时」那一条在对抗性验证阶段已被推翻。给长时间空闲的连接引入超时是有回归风险的行为变更,背后没有已确认的缺陷支撑。

## 测试

新增 `websocket_test.go`。因为 `handleWebSocket` 会 hijack 连接并手写 HTTP,`httptest.NewRecorder` 无法胜任(它不支持 Hijack),所以两侧都用真实 listener:`fakeWSUpstream` 扮演 Emby,回复预设的握手应答并记录代理发给它的**全部**字节——这正是能够证明"某些客户端字节从未到达上游"的手段。

- `TestHandleWebSocketRefusesTunnelWhenUpstreamDoesNotSwitchProtocols` — 上游回 200 时,客户端流水线塞进去的 `/SMUGGLED-MUST-NOT-ARRIVE` 请求**从未出现在上游收到的字节里**,且 `bytesOut` 为 0
- `TestHandleWebSocketRelaysSwitchAndMetersBothDirections` — 真实 101 被原样转发且 `Sec-WebSocket-Accept` 完好,隧道**运行期间**两个方向都被计量
- `TestHandleWebSocketRejectsUpgradeCarryingBody` — 带 `Content-Length` 的升级请求返回 400
- `TestIsWebSocketUpgradeRequiresCompleteHandshake` — 6 个用例的表驱动测试,含 `Connection: keep-alive, Upgrade` 这类多 token 列表
- `TestHeaderHasToken` — 逗号列表、多行同名头、部分匹配不成立
- `TestPrepareWebSocketUpstreamHeadersDropsContentLength` — 顺带确认 `Sec-WebSocket-Key` 仍会传给上游
- `TestTunnelWriterMetersAndPaces` — 计量准确,且 1000 B/s 下写 200 字节确实被拖慢

第一个测试里对客户端响应的断言是**有条件的**:当代理关闭一个仍持有我们未读流水线字节的 socket 时,TCP 可能以 RST 收场并丢弃已排队的响应。安全属性的断言(上游从未收到、字节未被计量)是无条件的。

## 验证说明

本地无 Go 工具链,**依赖本 PR 的 CI 验证**(`go build`、`go test -race`、`go vet`、`gosec`、`govulncheck`)。合并前请确认 CI 全绿,尤其是新增的 6 个测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)