### PR TITLE
fix: move the HTML escaper into the shared client and escape two diag sinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Validate frontend and installer syntax
         run: |
           find web/static/js -name '*.js' -print0 | xargs -0 -n1 node --check
-          node --test tests/sites_ua_mode.test.js
+          node --test tests/html_escaping.test.js tests/sites_ua_mode.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
           shellcheck install.sh tests/install_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           go test -race ./...
           go vet ./...
           find web/static/js -name '*.js' -print0 | xargs -0 -n1 node --check
-          node --test tests/sites_ua_mode.test.js
+          node --test tests/html_escaping.test.js tests/sites_ua_mode.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
           shellcheck install.sh tests/install_test.sh

--- a/tests/html_escaping.test.js
+++ b/tests/html_escaping.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const STATIC_JS = path.join(__dirname, '..', 'web', 'static', 'js');
+const PAYLOAD = '"><img src=x onerror=alert(1)>';
+
+// Loads browser scripts into one shared sandbox, mirroring how index.html
+// evaluates them as classic <script> tags sharing a single global. Only function
+// declarations become sandbox properties, which is why esc must stay a function.
+function loadScripts(...relativePaths) {
+  const sandbox = { window: {} };
+  vm.createContext(sandbox);
+  for (const relativePath of relativePaths) {
+    const filename = path.join(STATIC_JS, relativePath);
+    vm.runInContext(fs.readFileSync(filename, 'utf8'), sandbox, { filename: relativePath });
+  }
+  return sandbox;
+}
+
+test('esc ships with the shared api client, not a page script', () => {
+  const { esc } = loadScripts('api.js');
+  assert.equal(typeof esc, 'function');
+
+  for (const pageScript of ['pages/dashboard.js', 'pages/sites.js', 'pages/traffic.js', 'pages/diag.js']) {
+    const source = fs.readFileSync(path.join(STATIC_JS, pageScript), 'utf8');
+    assert.ok(
+      !/function\s+esc\s*\(/.test(source),
+      `${pageScript} must not define esc; escaping lives in api.js so a page script failing to load cannot disable it`,
+    );
+  }
+});
+
+test('esc escapes every HTML-significant character', () => {
+  const { esc } = loadScripts('api.js');
+  assert.equal(esc(`&<>"'`), '&amp;&lt;&gt;&quot;&#39;');
+  assert.equal(esc(PAYLOAD), '&quot;&gt;&lt;img src=x onerror=alert(1)&gt;');
+  assert.equal(esc(0), '0');
+  assert.equal(esc(undefined), 'undefined');
+});
+
+test('diagnostics probe type is escaped before it reaches innerHTML', () => {
+  const { probeLabel, renderHealthCard } = loadScripts('api.js', 'pages/diag.js');
+  // probeLabel keeps returning the raw label; escaping belongs at the sink so a
+  // caller that needs plain text is not handed double-escaped markup.
+  assert.equal(probeLabel({ kind: 'metadata_api' }), 'Metadata / API 探针');
+
+  const html = renderHealthCard('主回源健康', '探针结果', { health: { probe: { kind: PAYLOAD } } }, 'stagger-2');
+  assert.ok(!html.includes(PAYLOAD), 'probe.kind must not be interpolated raw');
+  assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), 'probe.kind must be escaped');
+});
+
+test('diagnostics proxy card escapes listen port and keeps its placeholder', () => {
+  const { renderProxyCard } = loadScripts('api.js', 'pages/diag.js');
+
+  const html = renderProxyCard({ running: true, listen_port: PAYLOAD, total_requests: 7 }, 'stagger-6');
+  assert.ok(!html.includes(PAYLOAD), 'proxy.listen_port must not be interpolated raw');
+
+  // Pinned so a later switch to diagText cannot silently turn 0 into "0".
+  assert.ok(renderProxyCard({ listen_port: 8096 }, 'stagger-6').includes('>8096<'));
+  assert.ok(renderProxyCard({ listen_port: 0 }, 'stagger-6').includes('>--<'));
+});

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -54,3 +54,16 @@ const API = {
     this.username = null;
   }
 };
+
+// Shared HTML escaper. It lives in the first-loaded script that every page
+// already depends on, so no page can render markup before escaping exists.
+// Keep it a function declaration: pages reach it as a global.
+function esc(str) {
+  return String(str).replace(/[&<>"']/g, char => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[char]);
+}

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -209,13 +209,3 @@ function formatBytes(bytes) {
   const i = Math.floor(Math.log(bytes) / Math.log(1024));
   return (bytes / Math.pow(1024, i)).toFixed(i > 1 ? 1 : 0) + ' ' + units[i];
 }
-
-function esc(str) {
-  return String(str).replace(/[&<>"']/g, char => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-  })[char]);
-}

--- a/web/static/js/pages/diag.js
+++ b/web/static/js/pages/diag.js
@@ -127,7 +127,7 @@ function renderHealthCard(title, subtitle, upstream, staggerClass) {
         <div class="diag-row"><span class="diag-key">连接状态</span><span class="diag-val ${statusClass(health.status)}">${statusText(health.status)}</span></div>
         <div class="diag-row"><span class="diag-key">Emby 版本</span><span class="diag-val">${diagText(health.emby_version)}</span></div>
         <div class="diag-row"><span class="diag-key">响应延迟</span><span class="diag-val ${latencyClass(latency)}">${latencyText}</span></div>
-        <div class="diag-row"><span class="diag-key">探针类型</span><span class="diag-val">${probeLabel(probe)}</span></div>
+        <div class="diag-row"><span class="diag-key">探针类型</span><span class="diag-val">${esc(probeLabel(probe))}</span></div>
         <div class="diag-row"><span class="diag-key">探针请求</span><span class="diag-val diag-wrap">${diagText(probeRequestText(probe))}</span></div>
         ${typeof probe.http_status === 'number' && probe.http_status > 0 ? `<div class="diag-row"><span class="diag-key">探针响应</span><span class="diag-val">${probe.http_status}</span></div>` : ''}
         ${health.error ? `<div class="diag-row"><span class="diag-key">探针结果</span><span class="diag-val bad diag-wrap">${esc(health.error)}</span></div>` : ''}
@@ -207,7 +207,7 @@ function renderProxyCard(proxy, staggerClass) {
       </div>
       <div class="diag-rows">
         <div class="diag-row"><span class="diag-key">代理运行</span><span class="diag-val ${proxy.running ? 'good' : 'bad'}">${proxy.running ? '运行中' : '已停止'}</span></div>
-        <div class="diag-row"><span class="diag-key">监听端口</span><span class="diag-val">${proxy.listen_port || '--'}</span></div>
+        <div class="diag-row"><span class="diag-key">监听端口</span><span class="diag-val">${esc(proxy.listen_port || '--')}</span></div>
         <div class="diag-row"><span class="diag-key">总请求数</span><span class="diag-val">${typeof proxy.total_requests === 'number' ? proxy.total_requests : '--'}</span></div>
       </div>
     </div>


### PR DESCRIPTION
## 问题

`esc()` 定义在 `web/static/js/pages/dashboard.js`,但被 `sites.js`、`traffic.js`、`diag.js` 调用——18 个调用点里有 **15 个在定义它的文件之外**。于是每个页面都隐式依赖一个它本无理由加载的页面模块,而 `app.js:187` 的容错逻辑说明项目本来就预期"某个页面脚本可能加载失败"。

现在它移到 `api.js`:那是 `index.html` 里的**第一个** script 标签,而且每个页面都已经为了 `API.listSites()` 硬依赖它。所以转义能力现在继承一个**无法回避的**依赖,而不是自己新造一个脆弱依赖。**没有任何 script 标签移动,`index.html` 完全未改。**

刻意保持 `function` 声明形式:页面把它当全局取用,而且 `node:vm` 只会把函数声明暴露到 sandbox 上——新测试依赖这一点。

## 两个未转义的 sink

- `diag.js:130` `${probeLabel(probe)}` — `probeLabel` 的兜底分支返回 `probe.kind`,在 JSON 契约里是 **string**。今天不可达,因为 `main.go` 里每个 `Kind` 赋值都是服务端字面量(`"metadata_api"` / `"reachability_fallback"`),但离"可利用"只差一次后端改动。
- `diag.js:210` `${proxy.listen_port}` — Go `int`,结构上不可能出问题。

转义放在 **sink 处**而非 `probeLabel` 内部,这样需要纯文本标签的调用方不会拿到双重转义的结果。端口用 `esc(x || '--')` 而不是 `diagText(x)`:`diagText` 只在 `undefined`/`null`/`''` 时兜底,换过去会让端口 0 从今天的 `--` 变成 `0`。

## 严重性说明(诚实版)

两个 sink 都不可利用。而且加载顺序的失败模式是 **fail-closed**:缺少 `esc` 会抛 `ReferenceError`,被外层 try/catch 捕获后变成空面板 + 一个 Toast,**不会**静默渲染未转义内容。`main.go:2386` 的 CSP 也没有 `unsafe-inline`,注入的脚本本来就不会执行。

所以这是纵深防御 / 架构修复,不是活跃漏洞。**值得做的理由**是:转义正是那些**真正**受攻击者控制的字段的保护措施,而它们今天都依赖 `esc`——`health.emby_version`(来自上游 body 的 `json.Unmarshal`,无任何过滤)和 `tls.issuer`(来自上游出示的 X.509 证书)都由恶意/被控上游完全控制;`custom_user_agent` 的校验器允许 `< > / = '`;`site.name` 只校验长度和换行,所以 `<script>alert(1)</script>` 会被原样入库。让 `esc` 可靠存在,就是这些字段的控制措施。

## 顺带做的全量排查

23 处 `innerHTML`;全仓库**没有** `insertAdjacentHTML` / `outerHTML` / `document.write` / `eval` / `new Function` / 字符串形式的 `setTimeout`;没有 `href="${…}"` 这类 URL 上下文插值(那种场景 5 字符转义器是不够的)。`toast.js` 正确使用 `textContent` 渲染服务端错误串。其余所有未转义插值均为客户端字面量、`typeof === 'number'` 守卫过的值,或 Go 的 `int`/`int64`/`bool`。

## 测试

`tests/html_escaping.test.js` 沿用 `sites_ua_mode.test.js` 的 `node:vm` 模式,并**在同一个 context 上多次 `runInContext`**,精确模拟经典 script 标签共享单一全局的方式。

**本地已验证:旧代码下 4/4 失败,修复后 4/4 通过**(连同既有测试共 7/7 通过)。第一个测试锁定的是架构约束本身——任何人把 `function esc(` 重新塞回页面模块都会让它失败。

已在 `ci.yml` 和 `release.yml` **两处**注册:runner 是显式列出测试文件的,不会自动发现(我实测 `node --test tests/` 会失败,因为它会去执行 `tests/install_test.sh`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)