### PR TITLE
fix: bound speed_limit, reuse the probe transport, flush on site replace

### DIFF
--- a/main.go
+++ b/main.go
@@ -1288,6 +1288,9 @@ func validateSiteSettings(name string, listenPort int, targetURL, playbackTarget
 	if quota < 0 || speedLimit < 0 {
 		return fmt.Errorf("traffic_quota and speed_limit must not be negative")
 	}
+	if speedLimit > maxSpeedLimitMbps {
+		return fmt.Errorf("speed_limit must not exceed %d Mbps", maxSpeedLimitMbps)
+	}
 	if len(streamHosts) > 128 {
 		return fmt.Errorf("stream_hosts must contain at most 128 entries")
 	}
@@ -1610,6 +1613,17 @@ func (pm *ProxyManager) StartSite(site Site) error {
 
 	pm.mu.Lock()
 	if existing, ok := pm.proxies[site.ID]; ok {
+		// Flush before dropping the instance, the way StopSite does. This branch is
+		// reached when a running site's listen_port changes, which is the one
+		// update path handleSiteByID does not pre-stop, so without this everything
+		// counted since the last 60s tick vanishes from traffic_logs and
+		// sites.traffic_used.
+		pm.flushProxyTraffic(existing)
+		// That flush moved bytes into the row `site` was read from, so carry the
+		// authoritative total forward instead of the snapshot taken before it.
+		if flushed := existing.Site.TrafficUsed; flushed > inst.persistedTraffic.Load() {
+			inst.persistedTraffic.Store(flushed)
+		}
 		if existing.server != nil {
 			existing.server.Close()
 		}
@@ -1919,13 +1933,20 @@ func probeStatusRank(status int) int {
 	}
 }
 
+// probeClient is shared by every diagnostics probe. Building a fresh
+// http.Transport per call left idle keep-alive connections with a zero
+// IdleConnTimeout, meaning they never expired, and CloseIdleConnections was never
+// called, so each run stranded upstream sockets along with their read and write
+// goroutines. DefaultTransport.Clone() brings a 90s IdleConnTimeout, matching
+// what StartSite already does for the proxy transport.
+var probeClient = func() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = secureTLSConfig("")
+	return &http.Client{Timeout: 5 * time.Second, Transport: transport}
+}()
+
 func probeTargetHealth(plan diagProbePlan) DiagHealth {
-	client := &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: secureTLSConfig(""),
-		},
-	}
+	client := probeClient
 	var bestReachable DiagHealth
 	bestReachableRank := 0
 	var serverError DiagHealth
@@ -2210,7 +2231,11 @@ type App struct {
 }
 
 const (
-	maxJSONBodyBytes       = 64 << 10
+	maxJSONBodyBytes = 64 << 10
+	// speedLimitBytes multiplies this field by 125000, so an unbounded value
+	// wraps int64 and silently disables the limit instead of tightening it.
+	// 1000000 matches the max the site form already enforces.
+	maxSpeedLimitMbps      = 1000000
 	maxLoginFailures       = 5
 	maxTrackedLoginClients = 10000
 	loginFailureWindow     = 15 * time.Minute

--- a/quality_test.go
+++ b/quality_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestValidateSiteSettingsBoundsSpeedLimit(t *testing.T) {
+	settings := func(speedLimit int) error {
+		return validateSiteSettings("site", 19091, "http://127.0.0.1:8096", "", "direct",
+			nil, "infuse", "", "", "", 0, speedLimit)
+	}
+	if err := settings(maxSpeedLimitMbps); err != nil {
+		t.Fatalf("speed_limit %d must be accepted: %v", maxSpeedLimitMbps, err)
+	}
+	err := settings(maxSpeedLimitMbps + 1)
+	if err == nil {
+		t.Fatal("speed_limit above the cap must be rejected")
+	}
+	if !strings.Contains(err.Error(), "speed_limit") {
+		t.Fatalf("error = %q, want it to name speed_limit", err)
+	}
+	// Kept within int32 so the test compiles on 32-bit targets too.
+	if err := settings(1 << 30); err == nil {
+		t.Fatal("an absurd speed_limit must be rejected before the bytes/sec conversion")
+	}
+}
+
+func TestProbeClientReusesConnectionsWithAnIdleTimeout(t *testing.T) {
+	transport, ok := probeClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("probe transport = %T, want *http.Transport", probeClient.Transport)
+	}
+	// A zero IdleConnTimeout is what stranded sockets: idle keep-alive
+	// connections would never expire and nothing closed them.
+	if transport.IdleConnTimeout == 0 {
+		t.Fatal("probe transport must set IdleConnTimeout so idle connections expire")
+	}
+	if transport.TLSClientConfig == nil || transport.TLSClientConfig.MinVersion == 0 {
+		t.Fatal("probe transport must keep the hardened TLS config")
+	}
+	if probeClient.Timeout == 0 {
+		t.Fatal("probe client must keep its request timeout")
+	}
+}
+
+func TestStartSiteFlushesTrafficWhenReplacingRunningInstance(t *testing.T) {
+	// Changing a running site's listen_port is the one update path that does not
+	// pre-stop, so StartSite has to flush the instance it displaces.
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("replace", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("site did not register a proxy instance")
+	}
+	// Traffic accumulated since the last flush tick.
+	inst.bytesIn.Store(700)
+	inst.bytesOut.Store(300)
+
+	moved, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	moved.ListenPort = freePort(t)
+	if err := app.pm.StartSite(*moved); err != nil {
+		t.Fatalf("StartSite on the new port: %v", err)
+	}
+
+	after, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite after replace: %v", err)
+	}
+	if after.TrafficUsed != 1000 {
+		t.Fatalf("traffic_used = %d, want the 1000 pending bytes persisted", after.TrafficUsed)
+	}
+
+	app.pm.mu.RLock()
+	replacement := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if replacement == nil {
+		t.Fatal("replacement instance missing")
+	}
+	if got := replacement.persistedTraffic.Load(); got != 1000 {
+		t.Fatalf("replacement baseline = %d, want 1000 so the quota gate stays accurate", got)
+	}
+}


### PR DESCRIPTION
审查里剩下的三个小缺陷,都不可被攻击者触发,但都是真实问题。

## 1. `speed_limit` 只有下界,乘算会静默溢出

`StartSite` 用 `int64(site.SpeedLimit) * 125000` 换算成字节/秒,而 `validateSiteSettings` 原来只拒绝负数。足够大的值会绕回 int64 变成 `<= 0`,而写入器把 `<= 0` 当作**无限制**——这是运营者自己带宽策略上的 fail-open。

现在上界设为 `1000000` Mbps,与站点表单 input 上已有的 `max="1000000"` 完全一致:后端不再单方面信任前端,而是和它达成一致。

## 2. 诊断探针每次新建 transport 且从不关闭

`probeTargetHealth` 每次调用都构造一个全新的 `&http.Transport{}`。零值 Transport 的 `IdleConnTimeout` 为 0,意味着空闲 keep-alive 连接**永不过期**,而且没有任何地方调用 `CloseIdleConnections`,所以每次诊断都会遗留上游 socket 及其 readLoop / writeLoop goroutine。

改为共享一个由 `http.DefaultTransport.Clone()` 构建的 client(自带 90s `IdleConnTimeout`)——这正是 `StartSite` 早已用于代理 transport 的写法。加固过的 TLS 配置与 5s 请求超时都保留。

## 3. `StartSite` 替换实例时丢弃未刷盘流量

替换分支直接 `Close()` 并 `delete()` 掉运行中的实例,不调用 `flushProxyTraffic`,把上次 60 秒 tick 之后累积的字节全部丢掉。

**范围比初看更窄**:`handleSiteByID` 在端口未变时会先 `StopSite`(而 `StopSite` 是会刷盘的),所以丢失窗口具体是"**修改一个运行中站点的 listen_port**"。我在实现时才发现这一点,已相应修正代码注释与提交信息。

现在按 `StopSite` 同样的方式刷盘,并把刷盘后的总量带入新实例的 `persistedTraffic` 基线——否则新实例会从刷盘**之前**拍下的快照起算,配额闸门会正好少算刚刚落库的那部分。

## 刻意不做

把请求 context 透传进探针以便中止的诊断请求能提前停止。client 的 5s 超时已经限住了它,而这条管线要穿过 `diagnoseSite`、`probeSiteHealth`、`probePlaybackHealth`,没有安全收益。

## 测试

`quality_test.go`:上界的接受/拒绝边界(含一个绝对值极大的输入)、探针 transport 的 `IdleConnTimeout` 非零且 TLS 配置与超时仍在、以及一个端到端测试——真实启动站点、塞入 1000 字节待刷流量、**换端口**重启,断言 `traffic_used` 为 1000 且新实例基线也是 1000。

## 验证说明

本地无 Go 工具链,**依赖本 PR 的 CI 验证**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)