### PR TITLE
fix: v1.5.6 security hardening (redirects, setup, upgrade rollback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Validate frontend and installer syntax
         run: |
           find web/static/js -name '*.js' -print0 | xargs -0 -n1 node --check
-          node --test tests/html_escaping.test.js tests/sites_ua_mode.test.js
+          node --test tests/*.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
           shellcheck install.sh tests/install_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           go test -race ./...
           go vet ./...
           find web/static/js -name '*.js' -print0 | xargs -0 -n1 node --check
-          node --test tests/html_escaping.test.js tests/sites_ua_mode.test.js
+          node --test tests/*.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
           shellcheck install.sh tests/install_test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=v1.5.3
+ARG VERSION=v1.5.6
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION}" -o meridian .
 
 # Runtime stage

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/insta
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) install \
   --domain panel.example.com --email admin@example.com -y
 
-# 更新：自动创建数据备份、保留上一版本、启动后健康检查，失败则自动回滚
+# 更新：自动创建数据备份与一致性快照，保留上一版本；systemd 环境启动后健康检查，失败则自动回滚二进制和数据
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) update
 
 # 隐藏输入两次新密码；同时轮换 JWT_SECRET，使全部旧令牌失效
@@ -82,7 +82,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/insta
 
 选择配置域名时，脚本会安装或复用 Nginx、Certbot（支持 apt、dnf/yum、apk、pacman），申请证书并启用 HTTP→HTTPS。生成的配置只代理管理面板 `127.0.0.1:9090`（或自定义 `PORT`），不会读取或修改站点回源、播放地址、50001 或其他站点监听端口。macOS 可安装 Meridian，但不支持自动域名配置。
 
-更新和改密会在内部自动创建一致性备份、执行健康检查并在失败时回滚；这些内部操作不再作为公开菜单命令。备份默认保存在 `/opt/meridian-backups`，权限为 `0600`，其中包含数据库和密钥，请按敏感文件保管。卸载默认保留数据和备份；`--purge` 才删除数据，并且不会删除 Nginx、Certbot 或证书。
+更新和改密会在内部自动创建一致性备份。在 systemd 环境中，更新还会执行健康检查，并在失败时自动回滚到上一版本二进制与升级前数据配置；非 systemd 环境会校验新二进制能否执行，但不会自动做完整健康检查。这些内部操作不再作为公开菜单命令。备份默认保存在 `/opt/meridian-backups`，权限为 `0600`，其中包含数据库和密钥，请按敏感文件保管。卸载默认保留数据和备份；`--purge` 才删除数据，并且不会删除 Nginx、Certbot 或证书。
 
 ### Docker
 
@@ -114,12 +114,20 @@ docker run -d --name meridian \
 
 ```powershell
 Invoke-WebRequest -Uri "https://github.com/snnabb/Meridian/releases/latest/download/meridian-windows-amd64.exe" -OutFile "meridian.exe"
-$env:JWT_SECRET = -join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Max 256) })
-$env:SETUP_TOKEN = -join ((1..32) | ForEach-Object { '{0:x2}' -f (Get-Random -Max 256) })
+function New-MeridianSecret {
+    $bytes = New-Object byte[] 32
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    -join ($bytes | ForEach-Object { $_.ToString('x2') })
+}
+$env:JWT_SECRET = New-MeridianSecret
+$env:SETUP_TOKEN = New-MeridianSecret
 .\meridian.exe
 ```
 
+> 密钥必须用密码学安全随机数生成。`Get-Random` 不够安全，不要用它生成 `JWT_SECRET` 或 `SETUP_TOKEN`。若以前按旧命令生成过密钥，请重新生成并轮换 `JWT_SECRET`。
+>
 > Windows 二进制下载同样依赖 GitHub Releases。没有已发布版本时，请使用源码构建。
+
 
 ### 从源码构建
 

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,8 @@ UPDATE_TMP_DIR=""
 UPDATE_WAS_ACTIVE=0
 UPDATE_BINARY_CHANGED=0
 UPDATE_TRANSACTION=0
+UPDATE_SNAPSHOT_DIR=""
+UPDATE_SNAPSHOT_RESTORED=0
 PASSWORD_TMP_DIR=""
 PASSWORD_SNAPSHOT_DIR=""
 PASSWORD_DB_PATH=""
@@ -139,6 +141,49 @@ validate_db_path() {
 
 valid_version() {
     [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+}
+
+version_gt() {
+    # Returns 0 (true) when $1 (vA.B.C[-suffix]) is newer than $2. The numeric
+    # major.minor.patch triple decides; pre-release suffixes are ignored.
+    # shellcheck disable=SC2016
+    printf '%s\n%s\n' "${1#v}" "${2#v}" | awk -F. '
+        function num(s) { gsub(/[^0-9]/, "", s); return s+0 }
+        NR == 1 { a1=num($1); a2=num($2); a3=num($3) }
+        NR == 2 { b1=num($1); b2=num($2); b3=num($3) }
+        END {
+            if (a1 != b1) exit (a1 > b1) ? 0 : 1
+            if (a2 != b2) exit (a2 > b2) ? 0 : 1
+            exit (a3 > b3) ? 0 : 1
+        }'
+}
+
+snapshot_data_dir() {
+    # Byte-level copy of the data directory for automatic rollback. The update
+    # flow stops the service first, so the database, WAL/SHM, and .env are
+    # quiescent when this runs.
+    local snapshot_dir="$1"
+    validate_data_dir
+    as_root test -d "$DATA_DIR" || return 1
+    as_root install -d -o root -g "$ROOT_GROUP" -m 0700 "$snapshot_dir"
+    as_root install -d -o root -g "$ROOT_GROUP" -m 0700 "${snapshot_dir}/data"
+    as_root cp -a -- "$DATA_DIR"/. "${snapshot_dir}/data/"
+}
+
+restore_data_snapshot() {
+    # Restores the exact pre-update data directory. Only called for a validated
+    # absolute DATA_DIR inside the update transaction, so the rm -rf cannot
+    # escape to a broad path.
+    local snapshot_dir="$1"
+    validate_data_dir
+    as_root test -d "${snapshot_dir}/data" || return 1
+    as_root rm -rf -- "$DATA_DIR"
+    as_root cp -a -- "${snapshot_dir}/data" "$DATA_DIR"
+    fix_database_permissions "$(read_env_value DB_PATH)" >/dev/null 2>&1 || true
+    if is_systemd; then
+        as_root chown root:"$SERVICE_GROUP" "$(env_file_path)" 2>/dev/null || true
+        as_root chmod 0640 "$(env_file_path)" 2>/dev/null || true
+    fi
 }
 
 normalize_domain() {
@@ -524,9 +569,14 @@ restore_previous_binary() {
 cleanup_update_transaction() {
     local exit_code=$?
     if [ "$exit_code" -ne 0 ] && [ "$UPDATE_TRANSACTION" = "1" ]; then
-        warn "更新中断，正在恢复更新前的二进制和服务状态..."
+        warn "更新中断，正在恢复更新前的二进制和数据状态..."
         if [ "$UPDATE_BINARY_CHANGED" = "1" ]; then
             restore_previous_binary || true
+        fi
+        if [ -n "$UPDATE_SNAPSHOT_DIR" ] && [ -d "$UPDATE_SNAPSHOT_DIR" ] \
+            && [ "$UPDATE_SNAPSHOT_RESTORED" != "1" ]; then
+            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" \
+                || warn "数据快照恢复失败，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
         fi
         if is_systemd; then
             if [ "$UPDATE_WAS_ACTIVE" = "1" ]; then
@@ -1069,12 +1119,14 @@ do_update() {
         ok "当前已是最新版本: $latest_version"
         return 0
     fi
+    if valid_version "$current_version" && version_gt "$current_version" "$latest_version"; then
+        fail "已安装版本 ${current_version} 高于最新 Release ${latest_version}；拒绝降级"
+    fi
 
     tmp_dir=$(mktemp -d)
     chmod 0700 "$tmp_dir"
     UPDATE_TMP_DIR="$tmp_dir"
     download_release_binary "$latest_version" "$tmp_dir"
-    prepare_data_and_config "$tmp_dir"
 
     UPDATE_TRANSACTION=1
     trap cleanup_update_transaction EXIT
@@ -1095,6 +1147,15 @@ do_update() {
     fi
     ok "升级前备份已创建: $LAST_BACKUP_PATH"
 
+    # Byte-level snapshot for automatic rollback, taken while the service is
+    # stopped and before any configuration key is added.
+    UPDATE_SNAPSHOT_DIR="${tmp_dir}/data-snapshot"
+    if ! snapshot_data_dir "$UPDATE_SNAPSHOT_DIR"; then
+        fail "升级前数据快照失败，现有程序未被替换"
+    fi
+
+    prepare_data_and_config "$tmp_dir"
+
     as_root install -o root -g "$ROOT_GROUP" -m 0755 "$current_binary" "${PREVIOUS_BIN}.new"
     as_root mv -f "${PREVIOUS_BIN}.new" "$PREVIOUS_BIN"
     as_root install -o root -g "$ROOT_GROUP" -m 0755 "$DOWNLOADED_BINARY" "${current_binary}.new"
@@ -1105,20 +1166,34 @@ do_update() {
         as_root systemctl restart "$SERVICE_NAME"
         if ! wait_for_health 20; then
             warn "新版本健康检查失败，正在自动回滚..."
-            restore_previous_binary
+            restore_previous_binary || fail "回滚失败：缺少上一版本二进制，请手动恢复 ${LAST_BACKUP_PATH:-备份归档}"
             UPDATE_BINARY_CHANGED=0
+            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" || warn "数据快照恢复失败，请使用备份手动恢复: $LAST_BACKUP_PATH"
+            UPDATE_SNAPSHOT_RESTORED=1
             as_root systemctl restart "$SERVICE_NAME"
             wait_for_health 20 || fail "新版本与回滚版本均未通过健康检查"
-            fail "新版本启动失败，已恢复上一版本"
+            fail "新版本启动失败，已恢复上一版本及原数据配置"
         fi
         if [ "$should_stop_after" = "1" ]; then
             as_root systemctl stop "$SERVICE_NAME"
         fi
+    else
+        if ! "$current_binary" --version >/dev/null 2>&1; then
+            warn "新版本二进制无法执行，正在自动回滚..."
+            restore_previous_binary || true
+            UPDATE_BINARY_CHANGED=0
+            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" || warn "数据快照恢复失败，请使用备份手动恢复: $LAST_BACKUP_PATH"
+            UPDATE_SNAPSHOT_RESTORED=1
+            fail "新版本无法执行，已恢复上一版本及原数据配置"
+        fi
+        warn "未检测到 systemd：已跳过自动健康检查，请手动加载 ${DATA_DIR}/.env 后启动"
     fi
 
     UPDATE_TRANSACTION=0
     UPDATE_BINARY_CHANGED=0
     UPDATE_TMP_DIR=""
+    UPDATE_SNAPSHOT_DIR=""
+    UPDATE_SNAPSHOT_RESTORED=0
     rm -rf -- "$tmp_dir"
     trap - EXIT INT TERM
     ok "已更新到最新版本: $latest_version"

--- a/install.sh
+++ b/install.sh
@@ -145,10 +145,12 @@ valid_version() {
 
 version_gt() {
     # Returns 0 (true) when $1 (vA.B.C[-suffix]) is newer than $2. The numeric
-    # major.minor.patch triple decides; pre-release suffixes are ignored.
+    # major.minor.patch triple decides; pre-release/build suffixes ("-rc1",
+    # "+build") are stripped before parsing so v1.5.6-rc1 compares as 1.5.6,
+    # not as a patch of 61.
     # shellcheck disable=SC2016
     printf '%s\n%s\n' "${1#v}" "${2#v}" | awk -F. '
-        function num(s) { gsub(/[^0-9]/, "", s); return s+0 }
+        function num(s) { sub(/[-+].*$/, "", s); gsub(/[^0-9]/, "", s); return s+0 }
         NR == 1 { a1=num($1); a2=num($2); a3=num($3) }
         NR == 2 { b1=num($1); b2=num($2); b3=num($3) }
         END {
@@ -171,19 +173,99 @@ snapshot_data_dir() {
 }
 
 restore_data_snapshot() {
-    # Restores the exact pre-update data directory. Only called for a validated
-    # absolute DATA_DIR inside the update transaction, so the rm -rf cannot
-    # escape to a broad path.
-    local snapshot_dir="$1"
+    # Restores the exact pre-update data directory without ever deleting the
+    # live DATA_DIR unless the replacement is already staged and verified. The
+    # snapshot is first copied to a staging directory next to DATA_DIR (same
+    # filesystem), checked for the configuration and database, and only then
+    # swapped in with two renames. Any failure leaves the original DATA_DIR
+    # untouched and returns non-zero; a partially staged copy is removed so no
+    # sensitive residue survives the attempt. Post-swap cleanup (permission
+    # normalization, removal of the displaced directory) is part of the
+    # contract too: if either cannot be completed, the function still returns
+    # non-zero so the caller keeps the transaction unrecovered for a retry or
+    # manual intervention.
+    local snapshot_dir="$1" staging_dir old_dir db_path data_base data_parent
     validate_data_dir
     as_root test -d "${snapshot_dir}/data" || return 1
-    as_root rm -rf -- "$DATA_DIR"
-    as_root cp -a -- "${snapshot_dir}/data" "$DATA_DIR"
-    fix_database_permissions "$(read_env_value DB_PATH)" >/dev/null 2>&1 || true
-    if is_systemd; then
-        as_root chown root:"$SERVICE_GROUP" "$(env_file_path)" 2>/dev/null || true
-        as_root chmod 0640 "$(env_file_path)" 2>/dev/null || true
+    data_parent=$(dirname -- "$DATA_DIR")
+    data_base=$(basename -- "$DATA_DIR")
+    staging_dir="${data_parent}/.${data_base}.restore.$$"
+    old_dir="${data_parent}/.${data_base}.pre-restore.$$"
+    as_root rm -rf -- "$staging_dir" 2>/dev/null || true
+    as_root rm -rf -- "$old_dir" 2>/dev/null || true
+    if ! as_root cp -a -- "${snapshot_dir}/data" "$staging_dir"; then
+        as_root rm -rf -- "$staging_dir" 2>/dev/null || true
+        return 1
     fi
+    # Verify the staged copy actually carries the configuration and database
+    # before the live directory is touched.
+    if ! as_root test -f "${staging_dir}/.env"; then
+        as_root rm -rf -- "$staging_dir" 2>/dev/null || true
+        return 1
+    fi
+    db_path=$(read_env_value DB_PATH)
+    case "$db_path" in
+        "$DATA_DIR"/*)
+            if ! as_root test -f "${staging_dir}/${db_path#"$DATA_DIR"/}"; then
+                as_root rm -rf -- "$staging_dir" 2>/dev/null || true
+                return 1
+            fi
+            ;;
+    esac
+    if ! as_root mv -f -- "$DATA_DIR" "$old_dir"; then
+        as_root rm -rf -- "$staging_dir" 2>/dev/null || true
+        return 1
+    fi
+    if ! as_root mv -f -- "$staging_dir" "$DATA_DIR"; then
+        if ! as_root mv -f -- "$old_dir" "$DATA_DIR" 2>/dev/null; then
+            warn "数据目录切换失败，原数据保留在: $old_dir，请手动恢复"
+        fi
+        if ! as_root rm -rf -- "$staging_dir" 2>/dev/null; then
+            warn "无法清理恢复暂存目录（可能含敏感数据），请手动删除: $staging_dir"
+        fi
+        return 1
+    fi
+    # Only the verified replacement is live now. The displaced directory may
+    # contain secrets; failing to remove it must not read as a complete
+    # restore, so this path returns non-zero and names the residue.
+    if ! as_root rm -rf -- "$old_dir" 2>/dev/null; then
+        warn "数据已恢复，但旧数据目录残留（可能含敏感数据），请手动删除: $old_dir"
+        return 1
+    fi
+    # Permission normalization is part of the restore contract: a staged copy
+    # arrives root:0700, and a restore that leaves the service user locked out
+    # is not a successful restore. Its non-zero status propagates.
+    restore_data_permissions
+}
+
+restore_data_permissions() {
+    # Reapplies the ownership/mode contract of prepare_data_and_config after a
+    # snapshot restore: the staged copy arrives as root:0700, which the
+    # systemd service user cannot even traverse. The service user must be able
+    # to walk DATA_DIR and write the database (WAL/SHM), while .env stays
+    # root:SERVICE_GROUP 0640. Non-systemd installs keep the calling user's
+    # ownership so the restored directory remains fully usable. Every required
+    # step is attempted; returns non-zero when any of them failed.
+    local db_path failed=0
+    db_path=$(read_env_value DB_PATH)
+    if is_systemd; then
+        as_root chown "$SERVICE_USER:$SERVICE_GROUP" "$DATA_DIR" \
+            || { warn "恢复后无法设置数据目录属主 ${SERVICE_USER}:${SERVICE_GROUP}（$DATA_DIR），请手动修复"; failed=1; }
+        as_root chmod 0750 "$DATA_DIR" \
+            || { warn "恢复后无法设置数据目录权限 0750（$DATA_DIR），请手动修复"; failed=1; }
+        as_root chown root:"$SERVICE_GROUP" "$(env_file_path)" \
+            || { warn "恢复后无法设置 .env 属主 root:${SERVICE_GROUP}，请手动修复"; failed=1; }
+        as_root chmod 0640 "$(env_file_path)" \
+            || { warn "恢复后无法设置 .env 权限 0640，请手动修复"; failed=1; }
+        fix_database_permissions "$db_path" \
+            || { warn "恢复后无法设置数据库文件权限，请手动修复"; failed=1; }
+    else
+        as_root chown "$(id -u):$(id -g)" "$DATA_DIR" \
+            || { warn "恢复后无法设置数据目录属主（$DATA_DIR），请手动修复"; failed=1; }
+        as_root chmod 0750 "$DATA_DIR" \
+            || { warn "恢复后无法设置数据目录权限 0750（$DATA_DIR），请手动修复"; failed=1; }
+    fi
+    return "$failed"
 }
 
 normalize_domain() {
@@ -575,8 +657,11 @@ cleanup_update_transaction() {
         fi
         if [ -n "$UPDATE_SNAPSHOT_DIR" ] && [ -d "$UPDATE_SNAPSHOT_DIR" ] \
             && [ "$UPDATE_SNAPSHOT_RESTORED" != "1" ]; then
-            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" \
-                || warn "数据快照恢复失败，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
+            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
+                UPDATE_SNAPSHOT_RESTORED=1
+            else
+                warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
+            fi
         fi
         if is_systemd; then
             if [ "$UPDATE_WAS_ACTIVE" = "1" ]; then
@@ -589,7 +674,9 @@ cleanup_update_transaction() {
         UPDATE_BINARY_CHANGED=0
     fi
     if [ -n "$UPDATE_TMP_DIR" ] && [ -d "$UPDATE_TMP_DIR" ] && [ "$UPDATE_TMP_DIR" != "/" ]; then
-        rm -rf -- "$UPDATE_TMP_DIR"
+        if ! as_root rm -rf -- "$UPDATE_TMP_DIR"; then
+            warn "无法清理更新临时目录（可能残留敏感快照），请手动删除: $UPDATE_TMP_DIR"
+        fi
     fi
     return "$exit_code"
 }
@@ -1168,8 +1255,11 @@ do_update() {
             warn "新版本健康检查失败，正在自动回滚..."
             restore_previous_binary || fail "回滚失败：缺少上一版本二进制，请手动恢复 ${LAST_BACKUP_PATH:-备份归档}"
             UPDATE_BINARY_CHANGED=0
-            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" || warn "数据快照恢复失败，请使用备份手动恢复: $LAST_BACKUP_PATH"
-            UPDATE_SNAPSHOT_RESTORED=1
+            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
+                UPDATE_SNAPSHOT_RESTORED=1
+            else
+                warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: $LAST_BACKUP_PATH"
+            fi
             as_root systemctl restart "$SERVICE_NAME"
             wait_for_health 20 || fail "新版本与回滚版本均未通过健康检查"
             fail "新版本启动失败，已恢复上一版本及原数据配置"
@@ -1182,8 +1272,11 @@ do_update() {
             warn "新版本二进制无法执行，正在自动回滚..."
             restore_previous_binary || true
             UPDATE_BINARY_CHANGED=0
-            restore_data_snapshot "$UPDATE_SNAPSHOT_DIR" || warn "数据快照恢复失败，请使用备份手动恢复: $LAST_BACKUP_PATH"
-            UPDATE_SNAPSHOT_RESTORED=1
+            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
+                UPDATE_SNAPSHOT_RESTORED=1
+            else
+                warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: $LAST_BACKUP_PATH"
+            fi
             fail "新版本无法执行，已恢复上一版本及原数据配置"
         fi
         warn "未检测到 systemd：已跳过自动健康检查，请手动加载 ${DATA_DIR}/.env 后启动"
@@ -1194,7 +1287,9 @@ do_update() {
     UPDATE_TMP_DIR=""
     UPDATE_SNAPSHOT_DIR=""
     UPDATE_SNAPSHOT_RESTORED=0
-    rm -rf -- "$tmp_dir"
+    if ! as_root rm -rf -- "$tmp_dir"; then
+        warn "无法清理更新临时目录（可能残留敏感快照），请手动删除: $tmp_dir"
+    fi
     trap - EXIT INT TERM
     ok "已更新到最新版本: $latest_version"
     info "现有 .env、面板域名、Nginx 配置和证书均已保留"
@@ -1247,14 +1342,15 @@ restore_auth_snapshot() {
 }
 
 fix_database_permissions() {
-    local db_path="$1" suffix file
+    local db_path="$1" suffix file failed=0
     for suffix in "" "-wal" "-shm" "-journal"; do
         file="${db_path}${suffix}"
         if as_root test -e "$file"; then
-            as_root chown "$SERVICE_USER:$SERVICE_GROUP" "$file"
-            as_root chmod 0600 "$file"
+            as_root chown "$SERVICE_USER:$SERVICE_GROUP" "$file" || failed=1
+            as_root chmod 0600 "$file" || failed=1
         fi
     done
+    return "$failed"
 }
 
 cleanup_password_transaction() {

--- a/main.go
+++ b/main.go
@@ -1055,11 +1055,13 @@ func rewriteEmbyAuthorizationHeaders(header http.Header, headerName string, prof
 	}
 }
 
-// stripEmbyAuthorizationToken blanks the Token attribute of an Emby
-// authorization value, leaving every other attribute byte-identical. Values
-// that cannot be parsed safely are returned untouched: they never carried a
-// recognizable token, and rewriting them risks corrupting a valid header.
-func stripEmbyAuthorizationToken(value string) string {
+// stripEmbyAuthorizationToken removes the Token attribute from an Emby
+// authorization value, leaving every other attribute byte-identical. The
+// boolean result reports whether the value is safe to forward: false means the
+// value carries (or may carry) an access token that could not be stripped, and
+// the caller must drop the entire header instead of forwarding it. Values
+// without any recognizable Token attribute are returned unchanged with true.
+func stripEmbyAuthorizationToken(value string) (string, bool) {
 	offset := 0
 	for offset < len(value) && isEmbyAuthWhitespace(value[offset]) {
 		offset++
@@ -1069,55 +1071,70 @@ func stripEmbyAuthorizationToken(value string) string {
 		offset++
 	}
 	if schemeStart == offset {
-		return value
+		// Empty or whitespace-only value: nothing to strip.
+		return value, true
 	}
 	scheme := value[schemeStart:offset]
 	if !strings.EqualFold(scheme, "MediaBrowser") && !strings.EqualFold(scheme, "Emby") {
-		return value
+		// Unknown scheme: it cannot be proven token-free, so fail closed.
+		return value, false
 	}
 	if offset < len(value) && !isEmbyAuthWhitespace(value[offset]) {
-		return value
+		return value, false
 	}
 	for offset < len(value) && isEmbyAuthWhitespace(value[offset]) {
 		offset++
 	}
 	if offset == len(value) {
-		return value
+		// A bare scheme carries no attributes and therefore no token.
+		return value, true
 	}
 	attributes, ok := parseEmbyAuthorizationAttributes(value, offset)
 	if !ok {
-		return value
+		return value, false
 	}
 	tokenIndex := -1
 	for index, attribute := range attributes {
 		if strings.EqualFold(attribute.name, "Token") {
 			if tokenIndex >= 0 {
-				return value
+				// Duplicate Token attributes cannot be stripped without
+				// guessing which one the server honors: fail closed.
+				return value, false
 			}
 			tokenIndex = index
 		}
 	}
 	if tokenIndex < 0 {
-		return value
+		return value, true
 	}
 	attribute := attributes[tokenIndex]
-	return value[:attribute.valueStart] + value[attribute.valueEnd:]
+	return value[:attribute.valueStart] + value[attribute.valueEnd:], true
 }
 
 // stripSensitiveRedirectHeaders removes browser credentials and access tokens
 // before a playback redirect crosses to a different authority. Only the Emby
 // identity fields (Client/Version/Device/DeviceId) survive, and the UA profile
-// is reapplied by the caller afterwards.
+// is reapplied by the caller afterwards. Cross-authority protection is
+// fail-closed: an X-Emby-Authorization value that may still carry a token is
+// dropped together with the whole header rather than forwarded.
 func stripSensitiveRedirectHeaders(header http.Header) {
 	header.Del("Cookie")
 	header.Del("Authorization")
 	header.Del("Proxy-Authorization")
+	// Dedicated token headers must not follow the hop either.
+	header.Del("X-Emby-Token")
+	header.Del("X-MediaBrowser-Token")
 	for name, values := range header {
 		if !strings.EqualFold(name, "X-Emby-Authorization") {
 			continue
 		}
 		for index, value := range values {
-			values[index] = stripEmbyAuthorizationToken(value)
+			stripped, safe := stripEmbyAuthorizationToken(value)
+			if !safe {
+				header.Del(name)
+				break
+			}
+			values[index] = stripped
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -263,6 +263,9 @@ func configuredSetupToken(userCount int, value string) (string, error) {
 	if token == "" {
 		return "", errors.New("SETUP_TOKEN must be configured before creating the first administrator")
 	}
+	if len(token) < 32 {
+		return "", errors.New("SETUP_TOKEN must be at least 32 bytes")
+	}
 	return token, nil
 }
 
@@ -507,18 +510,6 @@ func (d *DB) UserCount() (int, error) {
 		return 0, err
 	}
 	return n, nil
-}
-
-func (d *DB) CreateUser(username, password string) (int64, error) {
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil {
-		return 0, err
-	}
-	res, err := d.db.Exec("INSERT INTO users (username, password_hash) VALUES (?, ?)", username, string(hash))
-	if err != nil {
-		return 0, err
-	}
-	return res.LastInsertId()
 }
 
 var errAdminAlreadyExists = errors.New("admin user already exists")
@@ -877,6 +868,14 @@ func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, 
 			newReq.Header[k] = v
 		}
 		newReq.Host = locURL.Host
+		if !sameRedirectAuthority(req.URL, locURL) {
+			// A redirect to a different scheme/host/port is a new security
+			// domain: the browser's cookies and the client's Emby access token
+			// must not follow the hop to a playback or CDN host. The UA profile
+			// is reapplied below, so identity rewriting stays consistent while
+			// secrets stay behind.
+			stripSensitiveRedirectHeaders(newReq.Header)
+		}
 		applyUAProfileHeaders(newReq.Header, t.profile)
 		resp, err = t.base.RoundTrip(newReq)
 		if err != nil {
@@ -1052,6 +1051,73 @@ func rewriteEmbyAuthorizationHeaders(header http.Header, headerName string, prof
 		}
 		for index, value := range values {
 			values[index] = rewriteEmbyAuthorizationValue(value, profile)
+		}
+	}
+}
+
+// stripEmbyAuthorizationToken blanks the Token attribute of an Emby
+// authorization value, leaving every other attribute byte-identical. Values
+// that cannot be parsed safely are returned untouched: they never carried a
+// recognizable token, and rewriting them risks corrupting a valid header.
+func stripEmbyAuthorizationToken(value string) string {
+	offset := 0
+	for offset < len(value) && isEmbyAuthWhitespace(value[offset]) {
+		offset++
+	}
+	schemeStart := offset
+	for offset < len(value) && isEmbyAuthToken(value[offset]) {
+		offset++
+	}
+	if schemeStart == offset {
+		return value
+	}
+	scheme := value[schemeStart:offset]
+	if !strings.EqualFold(scheme, "MediaBrowser") && !strings.EqualFold(scheme, "Emby") {
+		return value
+	}
+	if offset < len(value) && !isEmbyAuthWhitespace(value[offset]) {
+		return value
+	}
+	for offset < len(value) && isEmbyAuthWhitespace(value[offset]) {
+		offset++
+	}
+	if offset == len(value) {
+		return value
+	}
+	attributes, ok := parseEmbyAuthorizationAttributes(value, offset)
+	if !ok {
+		return value
+	}
+	tokenIndex := -1
+	for index, attribute := range attributes {
+		if strings.EqualFold(attribute.name, "Token") {
+			if tokenIndex >= 0 {
+				return value
+			}
+			tokenIndex = index
+		}
+	}
+	if tokenIndex < 0 {
+		return value
+	}
+	attribute := attributes[tokenIndex]
+	return value[:attribute.valueStart] + value[attribute.valueEnd:]
+}
+
+// stripSensitiveRedirectHeaders removes browser credentials and access tokens
+// before a playback redirect crosses to a different authority. Only the Emby
+// identity fields (Client/Version/Device/DeviceId) survive, and the UA profile
+// is reapplied by the caller afterwards.
+func stripSensitiveRedirectHeaders(header http.Header) {
+	header.Del("Cookie")
+	header.Del("Authorization")
+	header.Del("Proxy-Authorization")
+	for name, values := range header {
+		if !strings.EqualFold(name, "X-Emby-Authorization") {
+			continue
+		}
+		for index, value := range values {
+			values[index] = stripEmbyAuthorizationToken(value)
 		}
 	}
 }
@@ -1317,6 +1383,13 @@ func redirectHostKey(target *url.URL) string {
 		authority = net.JoinHostPort(host, port)
 	}
 	return scheme + "://" + authority
+}
+
+// sameRedirectAuthority reports whether two URLs share scheme, host, and
+// effective port. Redirects that stay within the same authority may keep the
+// client's headers; anything else is a cross-origin hop.
+func sameRedirectAuthority(from, to *url.URL) bool {
+	return redirectHostKey(from) == redirectHostKey(to)
 }
 
 func singleJoiningSlash(a, b string) string {
@@ -2107,7 +2180,24 @@ func probeStatusRank(status int) int {
 var probeClient = func() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = secureTLSConfig("")
-	return &http.Client{Timeout: 5 * time.Second, Transport: transport}
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: transport,
+		// Diagnostics must never become an internal scanner: a configured
+		// upstream that answers with a redirect is only allowed to point back
+		// at the same authority. Everything else stops the probe instead of
+		// following the hop into private or third-party ranges.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return errors.New("diagnostic probe followed too many redirects")
+			}
+			previous := via[len(via)-1]
+			if !sameRedirectAuthority(previous.URL, req.URL) {
+				return errors.New("diagnostic probe redirect to a different host is not allowed")
+			}
+			return nil
+		},
+	}
 }()
 
 func probeTargetHealth(plan diagProbePlan) DiagHealth {
@@ -2136,6 +2226,9 @@ func probeTargetHealth(plan diagProbePlan) DiagHealth {
 		latency := time.Since(start).Milliseconds()
 		health.LatencyMs = latency
 		if err != nil {
+			if resp != nil {
+				resp.Body.Close()
+			}
 			health.Status = "offline"
 			health.Error = err.Error()
 			return health
@@ -2286,8 +2379,8 @@ func diagnoseUpstreamTarget(targetURL, probeKind string) (DiagUpstream, string) 
 	trimmed := strings.TrimSpace(targetURL)
 	result := DiagUpstream{
 		Configured:    trimmed != "",
-		ConfiguredURL: trimmed,
-		EffectiveURL:  trimmed,
+		ConfiguredURL: displayTargetURL(trimmed),
+		EffectiveURL:  displayTargetURL(trimmed),
 		ShowHealth:    true,
 	}
 
@@ -2297,8 +2390,8 @@ func diagnoseUpstreamTarget(targetURL, probeKind string) (DiagUpstream, string) 
 		return result, ""
 	}
 
-	result.ConfiguredURL = parsed.String()
-	result.EffectiveURL = parsed.String()
+	result.ConfiguredURL = displayTargetURL(parsed.String())
+	result.EffectiveURL = displayTargetURL(parsed.String())
 	switch probeKind {
 	case "playback_path":
 		result.Health = probePlaybackHealth(parsed.String())
@@ -2309,6 +2402,18 @@ func diagnoseUpstreamTarget(targetURL, probeKind string) (DiagUpstream, string) 
 	result.ShowTLS = result.TLS.Enabled
 
 	return result, canonicalTargetKey(parsed)
+}
+
+// displayTargetURL drops the query string before a configured upstream is
+// shown in the panel: signed URLs and API keys in query parameters must not be
+// rendered, because diagnostics output can be captured in screenshots or logs.
+func displayTargetURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return raw
+	}
+	parsed.RawQuery = ""
+	return parsed.String()
 }
 
 func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
@@ -2771,6 +2876,12 @@ func (a *App) handleSetup(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, 405, "method not allowed")
 		return
 	}
+	client := requestClientKey(r, a.trustedProxies)
+	if allowed, retryAfter := a.limiter().allow(client, time.Now()); !allowed {
+		w.Header().Set("Retry-After", strconv.Itoa(max(1, int(retryAfter.Seconds()+0.5))))
+		a.jsonErr(w, http.StatusTooManyRequests, "too many setup attempts; try again later")
+		return
+	}
 	a.setupTokenMu.Lock()
 	defer a.setupTokenMu.Unlock()
 	userCount, err := a.db.UserCount()
@@ -2797,18 +2908,21 @@ func (a *App) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if a.setupToken == "" || !setupTokenMatches(a.setupToken, req.SetupToken) {
+		a.limiter().recordFailure(client, time.Now())
 		a.jsonErr(w, http.StatusForbidden, "invalid setup token")
 		return
 	}
 	id, err := a.db.CreateInitialUser(req.Username, req.Password)
 	if err != nil {
 		if errors.Is(err, errAdminAlreadyExists) {
+			a.limiter().recordFailure(client, time.Now())
 			a.jsonErr(w, http.StatusConflict, errAdminAlreadyExists.Error())
 			return
 		}
 		a.jsonErr(w, http.StatusInternalServerError, "unable to create admin user")
 		return
 	}
+	a.limiter().reset(client)
 	token, err := generateToken(id, req.Username)
 	if err != nil {
 		a.jsonErr(w, 500, err.Error())
@@ -3332,7 +3446,7 @@ func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
 var startTime = time.Now()
 
 // appVersion is overridable at build time via -ldflags "-X main.appVersion=vX.Y.Z".
-var appVersion = "v1.5.3"
+var appVersion = "v1.5.6"
 
 func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, error) {
 	if len(args) == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -46,16 +46,37 @@ func newTestApp(t *testing.T) *App {
 	}
 }
 
+// reservedPorts keeps ephemeral ports out of the kernel's free pool between
+// allocation and the moment a test actually binds them. Without the
+// reservation, the OS could reissue the port to an unrelated outgoing
+// connection in that window, producing flaky "address already in use" site
+// starts. Callers that bind the port (a site start, or an API call that
+// starts a site) must call releasePort immediately beforehand.
+var reservedPorts sync.Map // int -> net.Listener
+
 func freePort(t *testing.T) int {
 	t.Helper()
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("free port listen: %v", err)
 	}
-	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+	reservedPorts.Store(port, ln)
+	t.Cleanup(func() {
+		if v, ok := reservedPorts.LoadAndDelete(port); ok {
+			_ = v.(net.Listener).Close()
+		}
+	})
+	return port
+}
 
-	return ln.Addr().(*net.TCPAddr).Port
+// releasePort closes the reservation created by freePort. Call it as the last
+// step before the code under test binds the port.
+func releasePort(port int) {
+	if v, ok := reservedPorts.LoadAndDelete(port); ok {
+		_ = v.(net.Listener).Close()
+	}
 }
 
 func decodeBody(t *testing.T, rr *httptest.ResponseRecorder) map[string]interface{} {
@@ -288,6 +309,8 @@ func TestMigrateSerializesConcurrentLegacyDatabaseOpens(t *testing.T) {
 }
 
 func TestGenerateTokenPreservesSpecialCharacters(t *testing.T) {
+	originalSecret := jwtSecret
+	t.Cleanup(func() { jwtSecret = originalSecret })
 	jwtSecret = []byte("test-secret")
 
 	token, err := generateToken(7, `bad"name\user`)
@@ -756,7 +779,7 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read embedded index HTML: %v", err)
 	}
-	for _, asset := range []string{"/css/style.css?v=1.5.3", "/js/pages/sites.js?v=1.5.3", "/js/app.js?v=1.5.3"} {
+	for _, asset := range []string{"/css/style.css?v=1.5.6", "/js/pages/sites.js?v=1.5.6", "/js/app.js?v=1.5.6"} {
 		if !strings.Contains(string(indexHTML), asset) {
 			t.Errorf("index must cache-bust updated asset %q", asset)
 		}
@@ -952,10 +975,11 @@ func TestHandleAuthCheckExposesSingleAdminModeBeforeSetup(t *testing.T) {
 }
 
 func TestConfiguredSetupTokenRequiresExplicitValue(t *testing.T) {
+	longToken := "setup-token-with-more-than-thirty-two-bytes"
 	if _, err := configuredSetupToken(0, " \t "); err == nil {
 		t.Fatal("empty initial setup token unexpectedly accepted")
 	}
-	if got, err := configuredSetupToken(0, " setup-token "); err != nil || got != "setup-token" {
+	if got, err := configuredSetupToken(0, " "+longToken+" "); err != nil || got != longToken {
 		t.Fatalf("configured setup token = %q, %v", got, err)
 	}
 	if got, err := configuredSetupToken(1, "unused-token"); err != nil || got != "" {
@@ -1180,11 +1204,14 @@ func TestResetAdminPasswordRejectsInvalidDatabaseStateAndLength(t *testing.T) {
 	if err := app.db.ResetAdminPassword("long enough password"); !errors.Is(err, errAdminNotConfigured) {
 		t.Fatalf("empty database error = %v, want administrator not configured", err)
 	}
-	if _, err := app.db.CreateUser("admin-one", "correct horse battery staple"); err != nil {
-		t.Fatalf("CreateUser one: %v", err)
+	// The single-administrator invariant is enforced by ResetAdminPassword;
+	// fabricate the second row directly because the public API must never be
+	// able to create a second admin.
+	if _, err := app.db.db.Exec("INSERT INTO users (username, password_hash) VALUES (?, ?)", "admin-one", "hash-one"); err != nil {
+		t.Fatalf("insert user one: %v", err)
 	}
-	if _, err := app.db.CreateUser("admin-two", "correct horse battery staple"); err != nil {
-		t.Fatalf("CreateUser two: %v", err)
+	if _, err := app.db.db.Exec("INSERT INTO users (username, password_hash) VALUES (?, ?)", "admin-two", "hash-two"); err != nil {
+		t.Fatalf("insert user two: %v", err)
 	}
 	if err := app.db.ResetAdminPassword("another valid password"); !errors.Is(err, errMultipleAdmins) {
 		t.Fatalf("multiple users error = %v, want multiple administrators", err)
@@ -1425,10 +1452,12 @@ func TestCORSAllowsSameOriginAndRejectsCrossOrigin(t *testing.T) {
 
 func TestHandleAuthCheckExposesConfiguredSingleAdminMode(t *testing.T) {
 	app := newTestApp(t)
+	originalEphemeral := jwtSecretEphemeral
+	t.Cleanup(func() { jwtSecretEphemeral = originalEphemeral })
 	jwtSecretEphemeral = false
 
-	if _, err := app.db.CreateUser("admin", "admin123"); err != nil {
-		t.Fatalf("CreateUser: %v", err)
+	if _, err := app.db.db.Exec("INSERT INTO users (username, password_hash) VALUES (?, ?)", "admin", "hash"); err != nil {
+		t.Fatalf("insert admin: %v", err)
 	}
 
 	rr := httptest.NewRecorder()
@@ -1934,6 +1963,208 @@ func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T
 	})
 }
 
+func TestRedirectFollowStripsSensitiveHeadersCrossOrigin(t *testing.T) {
+	target, err := normalizeTargetURL("https://media.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	profile := UAProfile{Name: "Custom", UserAgent: "Meridian Test/1.0", Client: "Meridian Test", Version: "1.0.0"}
+	var followedHeaders http.Header
+	calls := 0
+	transport := &redirectFollowTransport{
+		playbackHosts: map[string]bool{redirectHostKey(target): true},
+		profile:       profile,
+		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    request,
+				}, nil
+			}
+			followedHeaders = request.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    request,
+			}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "https://api.example.com/Videos/1/stream", nil)
+	request.Header.Set("Cookie", "session=secret-cookie")
+	request.Header.Set("Authorization", "Bearer opaque-bearer")
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Device="TV", DeviceId="device-1", Token="emby-access-token", Client="old", Version="old"`)
+	applyUAProfileHeaders(request.Header, profile)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatalf("follow redirect: %v", err)
+	}
+	response.Body.Close()
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := followedHeaders.Get("Cookie"); got != "" {
+		t.Fatalf("Cookie forwarded across origin: %q", got)
+	}
+	if got := followedHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization forwarded across origin: %q", got)
+	}
+	emby := followedHeaders.Get("X-Emby-Authorization")
+	if strings.Contains(emby, "emby-access-token") {
+		t.Fatalf("Emby access token forwarded across origin: %q", emby)
+	}
+	for _, want := range []string{`Client="Meridian Test"`, `Version="1.0.0"`, `Device="TV"`, `DeviceId="device-1"`} {
+		if !strings.Contains(emby, want) {
+			t.Fatalf("authorization = %q, missing %q", emby, want)
+		}
+	}
+	if got := followedHeaders.Get("User-Agent"); got != profile.UserAgent {
+		t.Fatalf("User-Agent = %q, want %q", got, profile.UserAgent)
+	}
+}
+
+func TestRedirectFollowKeepsHeadersSameOrigin(t *testing.T) {
+	target, err := normalizeTargetURL("https://media.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	profile := UAProfile{Name: "Custom", UserAgent: "Meridian Test/1.0", Client: "Meridian Test", Version: "1.0.0"}
+	var followedHeaders http.Header
+	calls := 0
+	transport := &redirectFollowTransport{
+		playbackHosts: map[string]bool{redirectHostKey(target): true},
+		profile:       profile,
+		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    request,
+				}, nil
+			}
+			followedHeaders = request.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    request,
+			}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "https://media.example.com/Videos/1/stream", nil)
+	request.Header.Set("Cookie", "session=secret-cookie")
+	request.Header.Set("Authorization", "Bearer opaque-bearer")
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Device="TV", Token="emby-access-token", Client="old", Version="old"`)
+	applyUAProfileHeaders(request.Header, profile)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatalf("follow redirect: %v", err)
+	}
+	response.Body.Close()
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := followedHeaders.Get("Cookie"); got != "session=secret-cookie" {
+		t.Fatalf("Cookie dropped on same-origin redirect: %q", got)
+	}
+	if got := followedHeaders.Get("Authorization"); got != "Bearer opaque-bearer" {
+		t.Fatalf("Authorization dropped on same-origin redirect: %q", got)
+	}
+	emby := followedHeaders.Get("X-Emby-Authorization")
+	if !strings.Contains(emby, "emby-access-token") {
+		t.Fatalf("Emby token lost on same-origin redirect: %q", emby)
+	}
+}
+
+func TestProbeClientRejectsCrossHostRedirect(t *testing.T) {
+	redirected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/private", http.StatusFound)
+	}))
+	defer redirected.Close()
+
+	health := probeTargetHealth(diagProbePlan{
+		BaseURL:       redirected.URL,
+		Kind:          "metadata_api",
+		Method:        http.MethodGet,
+		CandidateURLs: []string{redirected.URL + "/System/Info/Public"},
+		ParseVersion:  true,
+	})
+	if health.Status != "offline" {
+		t.Fatalf("status = %q, want offline", health.Status)
+	}
+	if !strings.Contains(health.Error, "different host") {
+		t.Fatalf("error = %q, want cross-host redirect rejection", health.Error)
+	}
+}
+
+func TestProbeClientFollowsSameHostRedirect(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/System/Info/Public", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"Version":"1.2.3"}`))
+	})
+	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/System/Info/Public", http.StatusFound)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	health := probeTargetHealth(diagProbePlan{
+		BaseURL:       server.URL,
+		Kind:          "metadata_api",
+		Method:        http.MethodGet,
+		CandidateURLs: []string{server.URL + "/redirect"},
+		ParseVersion:  true,
+	})
+	if health.Status != "online" {
+		t.Fatalf("status = %q error=%q, want online", health.Status, health.Error)
+	}
+	if health.EmbyVer != "1.2.3" {
+		t.Fatalf("emby version = %q, want 1.2.3", health.EmbyVer)
+	}
+}
+
+func TestConfiguredSetupTokenRejectsShortToken(t *testing.T) {
+	if _, err := configuredSetupToken(0, strings.Repeat("x", 31)); !strings.Contains(err.Error(), "at least 32") {
+		t.Fatalf("short token error = %v", err)
+	}
+	token, err := configuredSetupToken(0, strings.Repeat("x", 32))
+	if err != nil {
+		t.Fatalf("32-byte token rejected: %v", err)
+	}
+	if token != strings.Repeat("x", 32) {
+		t.Fatalf("token = %q", token)
+	}
+}
+
+func TestSetupIsRateLimited(t *testing.T) {
+	app := newTestApp(t)
+	app.setupToken = strings.Repeat("x", 32)
+
+	post := func() int {
+		body := strings.NewReader(`{"username":"admin","password":"correct horse battery staple","setup_token":"wrong-token"}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/setup", body)
+		req.RemoteAddr = "192.0.2.10:1234"
+		rr := httptest.NewRecorder()
+		app.handleSetup(rr, req)
+		return rr.Code
+	}
+	for i := 0; i < maxLoginFailures; i++ {
+		if code := post(); code != http.StatusForbidden {
+			t.Fatalf("attempt %d status = %d, want 403", i+1, code)
+		}
+	}
+	if code := post(); code != http.StatusTooManyRequests {
+		t.Fatalf("blocked attempt status = %d, want 429", code)
+	}
+}
+
 func TestHandleSiteDiagReturnsSpoofedVersionField(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/System/Info/Public" {
@@ -2048,6 +2279,7 @@ func TestHandleSiteUpdateRollsBackOnStartFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSite: %v", err)
 	}
+	releasePort(initialPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}
@@ -2093,6 +2325,7 @@ func TestHandleSiteUpdateFailureRestoresCustomUAFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSiteWithCustomUA: %v", err)
 	}
+	releasePort(initialPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}
@@ -2281,7 +2514,9 @@ func TestAddTrafficAggregatesSameHour(t *testing.T) {
 func TestHandleSitesCreatePersistsPlaybackTargetURL(t *testing.T) {
 	app := newTestApp(t)
 
-	body := strings.NewReader(`{"name":"split","listen_port":` + jsonNumber(freePort(t)) + `,"target_url":"http://127.0.0.1:8096","playback_target_url":"https://media.example.com","ua_mode":"infuse"}`)
+	port := freePort(t)
+	releasePort(port)
+	body := strings.NewReader(`{"name":"split","listen_port":` + jsonNumber(port) + `,"target_url":"http://127.0.0.1:8096","playback_target_url":"https://media.example.com","ua_mode":"infuse"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/sites", body)
 	rr := httptest.NewRecorder()
 
@@ -2313,9 +2548,11 @@ func TestHandleSitesCreatePersistsPlaybackTargetURL(t *testing.T) {
 
 func TestHandleSitesCreatesCustomUAAndPresetUpdateClearsIt(t *testing.T) {
 	app := newTestApp(t)
+	port := freePort(t)
+	releasePort(port)
 	createPayload, err := json.Marshal(map[string]interface{}{
 		"name":              "custom-identity",
-		"listen_port":       freePort(t),
+		"listen_port":       port,
 		"target_url":        "http://127.0.0.1:8096",
 		"ua_mode":           "custom",
 		"custom_user_agent": "Meridian Custom/1.0",
@@ -2551,6 +2788,7 @@ func TestProxyRoutesPlaybackRequestsToPlaybackTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSite: %v", err)
 	}
+	releasePort(site.ListenPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}
@@ -2601,6 +2839,7 @@ func TestProxyPreservesConfiguredUpstreamBasePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSite: %v", err)
 	}
+	releasePort(site.ListenPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}
@@ -2637,6 +2876,7 @@ func TestProxyPlaybackRequestsFallBackToMainTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSite: %v", err)
 	}
+	releasePort(site.ListenPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1997,6 +1997,8 @@ func TestRedirectFollowStripsSensitiveHeadersCrossOrigin(t *testing.T) {
 	request.Header.Set("Cookie", "session=secret-cookie")
 	request.Header.Set("Authorization", "Bearer opaque-bearer")
 	request.Header.Set("X-Emby-Authorization", `MediaBrowser Device="TV", DeviceId="device-1", Token="emby-access-token", Client="old", Version="old"`)
+	request.Header.Set("X-Emby-Token", "emby-access-token")
+	request.Header.Set("X-MediaBrowser-Token", "emby-access-token")
 	applyUAProfileHeaders(request.Header, profile)
 	response, err := transport.RoundTrip(request)
 	if err != nil {
@@ -2012,6 +2014,12 @@ func TestRedirectFollowStripsSensitiveHeadersCrossOrigin(t *testing.T) {
 	}
 	if got := followedHeaders.Get("Authorization"); got != "" {
 		t.Fatalf("Authorization forwarded across origin: %q", got)
+	}
+	if got := followedHeaders.Get("X-Emby-Token"); got != "" {
+		t.Fatalf("X-Emby-Token forwarded across origin: %q", got)
+	}
+	if got := followedHeaders.Get("X-MediaBrowser-Token"); got != "" {
+		t.Fatalf("X-MediaBrowser-Token forwarded across origin: %q", got)
 	}
 	emby := followedHeaders.Get("X-Emby-Authorization")
 	if strings.Contains(emby, "emby-access-token") {
@@ -2080,6 +2088,175 @@ func TestRedirectFollowKeepsHeadersSameOrigin(t *testing.T) {
 	emby := followedHeaders.Get("X-Emby-Authorization")
 	if !strings.Contains(emby, "emby-access-token") {
 		t.Fatalf("Emby token lost on same-origin redirect: %q", emby)
+	}
+}
+
+func TestStripEmbyAuthorizationToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		want     string
+		wantSafe bool
+	}{
+		{
+			name:     "removes token and keeps identity",
+			value:    `MediaBrowser Client="App", Device="TV", DeviceId="d1", Token="secret", Version="1"`,
+			want:     `MediaBrowser Client="App", Device="TV", DeviceId="d1", Token="", Version="1"`,
+			wantSafe: true,
+		},
+		{
+			name:     "emby scheme is stripped like mediabrowser",
+			value:    `Emby Device="TV", Token="secret"`,
+			want:     `Emby Device="TV", Token=""`,
+			wantSafe: true,
+		},
+		{
+			name:     "leading whitespace is preserved",
+			value:    `  MediaBrowser Token="secret"`,
+			want:     `  MediaBrowser Token=""`,
+			wantSafe: true,
+		},
+		{
+			name:     "value without token is unchanged",
+			value:    `MediaBrowser Client="App"`,
+			want:     `MediaBrowser Client="App"`,
+			wantSafe: true,
+		},
+		{
+			name:     "bare scheme has no token",
+			value:    `MediaBrowser`,
+			want:     `MediaBrowser`,
+			wantSafe: true,
+		},
+		{
+			name:     "empty value has no token",
+			value:    "",
+			want:     "",
+			wantSafe: true,
+		},
+		{
+			name:     "duplicate token fails closed",
+			value:    `MediaBrowser Token="a", Token="b"`,
+			want:     `MediaBrowser Token="a", Token="b"`,
+			wantSafe: false,
+		},
+		{
+			name:     "unterminated attribute fails closed",
+			value:    `MediaBrowser Client="unterminated`,
+			want:     `MediaBrowser Client="unterminated`,
+			wantSafe: false,
+		},
+		{
+			name:     "unknown scheme fails closed",
+			value:    `Bearer opaque-bearer`,
+			want:     `Bearer opaque-bearer`,
+			wantSafe: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, safe := stripEmbyAuthorizationToken(tt.value)
+			if got != tt.want {
+				t.Fatalf("stripped = %q, want %q", got, tt.want)
+			}
+			if safe != tt.wantSafe {
+				t.Fatalf("safe = %v, want %v", safe, tt.wantSafe)
+			}
+		})
+	}
+}
+
+func TestStripSensitiveRedirectHeadersRemovesDedicatedTokenHeaders(t *testing.T) {
+	header := http.Header{
+		"X-Emby-Authorization": []string{`MediaBrowser Device="TV", Token="emby-access-token", Client="old"`},
+		"X-Emby-Token":         []string{"emby-access-token"},
+		"X-MediaBrowser-Token": []string{"emby-access-token"},
+		"Authorization":        []string{"Bearer opaque-bearer"},
+		"Cookie":               []string{"session=secret"},
+		"X-Forwarded-For":      []string{"10.0.0.1"},
+	}
+	stripSensitiveRedirectHeaders(header)
+	if got := header.Get("X-Emby-Token"); got != "" {
+		t.Fatalf("X-Emby-Token forwarded: %q", got)
+	}
+	if got := header.Get("X-MediaBrowser-Token"); got != "" {
+		t.Fatalf("X-MediaBrowser-Token forwarded: %q", got)
+	}
+	if got := header.Get("Cookie"); got != "" {
+		t.Fatalf("Cookie forwarded: %q", got)
+	}
+	if got := header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization forwarded: %q", got)
+	}
+	emby := header.Get("X-Emby-Authorization")
+	if strings.Contains(emby, "emby-access-token") {
+		t.Fatalf("Emby access token forwarded: %q", emby)
+	}
+	if !strings.Contains(emby, `Device="TV"`) {
+		t.Fatalf("identity fields lost: %q", emby)
+	}
+	if got := header.Get("X-Forwarded-For"); got != "10.0.0.1" {
+		t.Fatalf("non-sensitive header dropped: %q", got)
+	}
+}
+
+func TestStripSensitiveRedirectHeadersDropsUnsafeEmbyAuthorization(t *testing.T) {
+	header := http.Header{
+		"X-Emby-Authorization": []string{`MediaBrowser Token="a", Token="b", Device="TV"`},
+	}
+	stripSensitiveRedirectHeaders(header)
+	if got := header.Values("X-Emby-Authorization"); len(got) != 0 {
+		t.Fatalf("unsafe authorization value forwarded: %q", got)
+	}
+}
+
+func TestRedirectFollowDropsUnsafeEmbyAuthorizationCrossOrigin(t *testing.T) {
+	// A value with a duplicate Token cannot be stripped safely, so the whole
+	// header must be dropped on a cross-authority hop instead of being
+	// forwarded with a token intact.
+	target, err := normalizeTargetURL("https://media.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	profile := UAProfile{Name: "Custom", UserAgent: "Meridian Test/1.0", Client: "Meridian Test", Version: "1.0.0"}
+	var followedHeaders http.Header
+	calls := 0
+	transport := &redirectFollowTransport{
+		playbackHosts: map[string]bool{redirectHostKey(target): true},
+		profile:       profile,
+		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    request,
+				}, nil
+			}
+			followedHeaders = request.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    request,
+			}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "https://api.example.com/Videos/1/stream", nil)
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Token="first", Token="second", Device="TV"`)
+	applyUAProfileHeaders(request.Header, profile)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatalf("follow redirect: %v", err)
+	}
+	response.Body.Close()
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := followedHeaders.Values("X-Emby-Authorization"); len(got) != 0 {
+		t.Fatalf("unsafe X-Emby-Authorization forwarded across origin: %q", got)
 	}
 }
 

--- a/quality_test.go
+++ b/quality_test.go
@@ -53,6 +53,7 @@ func TestStartSiteFlushesTrafficWhenReplacingRunningInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSite: %v", err)
 	}
+	releasePort(site.ListenPort)
 	if err := app.pm.StartSite(*site); err != nil {
 		t.Fatalf("StartSite: %v", err)
 	}
@@ -73,6 +74,7 @@ func TestStartSiteFlushesTrafficWhenReplacingRunningInstance(t *testing.T) {
 		t.Fatalf("GetSite: %v", err)
 	}
 	moved.ListenPort = freePort(t)
+	releasePort(moved.ListenPort)
 	if err := app.pm.StartSite(*moved); err != nil {
 		t.Fatalf("StartSite on the new port: %v", err)
 	}

--- a/tests/api_client.test.js
+++ b/tests/api_client.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const STATIC_JS = path.join(__dirname, '..', 'web', 'static', 'js');
+
+// Loads api.js into a sandbox where fetch/window are injected per test, the
+// same way a browser page provides them.
+function loadAPIClient() {
+  const sandbox = { window: {} };
+  vm.createContext(sandbox);
+  vm.runInContext(
+    fs.readFileSync(path.join(STATIC_JS, 'api.js'), 'utf8'),
+    sandbox,
+    { filename: 'api.js' },
+  );
+  return sandbox;
+}
+
+test('401 on a protected call logs out, reloads, and stops the request flow', async () => {
+  const sandbox = loadAPIClient();
+  let reloads = 0;
+  let logoutCalled = false;
+  let bodyParsed = false;
+  sandbox.window.location = { reload() { reloads++; } };
+  sandbox.fetch = async (url) => {
+    if (String(url).endsWith('/api/auth/logout')) {
+      logoutCalled = true;
+      return { status: 200, ok: true, json: async () => ({}) };
+    }
+    return {
+      status: 401,
+      ok: false,
+      statusText: 'Unauthorized',
+      json: async () => {
+        bodyParsed = true;
+        return { error: 'session expired' };
+      },
+    };
+  };
+
+  const result = await vm.runInContext('API.request("GET", "/api/dashboard")', sandbox);
+
+  assert.equal(logoutCalled, true, 'logout must be triggered on 401');
+  assert.equal(reloads, 1, 'page must reload on 401');
+  assert.equal(bodyParsed, false, 'the stale 401 body must not be parsed after logout/reload');
+  assert.equal(result, undefined, 'the request must terminate instead of resolving with a value');
+});
+
+test('401 on the login endpoint is an ordinary failure the caller can report', async () => {
+  const sandbox = loadAPIClient();
+  let reloads = 0;
+  sandbox.window.location = { reload() { reloads++; } };
+  sandbox.fetch = async () => ({
+    status: 401,
+    ok: false,
+    statusText: 'Unauthorized',
+    json: async () => ({ error: '用户名或密码错误' }),
+  });
+
+  await assert.rejects(
+    vm.runInContext('API.request("POST", "/api/auth/login", { username: "a", password: "b" })', sandbox),
+    /用户名或密码错误/,
+  );
+  assert.equal(reloads, 0, 'a failed login must not reload the page');
+});

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -398,14 +398,19 @@ if (
 fi
 assert_contains "${TEST_ROOT}/update-rollback.log" '自动回滚'
 assert_eq 'v9.9.11' "$(get_current_version)" 'rollback must restore the previous binary'
-cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before" \
+# The restored DATA_DIR is owned by the service user (0750, db 0600,
+# .env root:meridian 0640), so a non-root runner cannot read it directly.
+run_as_test_root cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before" \
     || { echo 'FAIL: database was not restored after failed update' >&2; exit 1; }
-cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before" \
+run_as_test_root cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before" \
     || { echo 'FAIL: configuration was not restored after failed update' >&2; exit 1; }
 assert_contains "${TEST_ROOT}/update-rollback.log" '自动回滚'
 
 # A missing snapshot must fail the restore without touching the live data.
-rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-missing"
+# DATA_DIR is still service-user-owned (0750) after the systemd rollback
+# above, so the reset must run as root; the mkdir below returns it to the
+# runner.
+run_as_test_root rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-missing"
 mkdir -p "$DATA_DIR"
 printf 'live-marker\n' > "${DATA_DIR}/live.txt"
 if restore_data_snapshot "${TEST_ROOT}/snapshot-missing" 2>/dev/null; then
@@ -505,7 +510,9 @@ assert_contains "$restore_perm_log" "chmod 0600 ${DATA_DIR}/meridian.db"
 # UPDATE_SNAPSHOT_RESTORED stays unset and the transaction is retried or
 # escalated) and must say what is broken, even though the data contents were
 # already swapped in.
-rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-permfail"
+# The previous systemd-mode restore left DATA_DIR service-user-owned, and
+# the chown failure below leaves it root-owned; both need root to reset.
+run_as_test_root rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-permfail"
 mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-permfail/data"
 printf 'JWT_SECRET=permfail-jwt-secret-00000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
     "$DATA_DIR" > "${DATA_DIR}/.env"
@@ -524,7 +531,9 @@ if (
 ) >"$perm_fail_out" 2>&1; then
     echo 'FAIL: restore with failing permission fix unexpectedly succeeded' >&2; exit 1
 fi
-cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-permfail/data/meridian.db" \
+# The swapped-in directory is still root-owned here (chown was mocked to
+# fail), so the content check needs root.
+run_as_test_root cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-permfail/data/meridian.db" \
     || { echo 'FAIL: database content not restored despite permission failure' >&2; exit 1; }
 assert_contains "$perm_fail_out" '无法设置数据目录属主'
 assert_contains "$perm_fail_out" '请手动修复'
@@ -532,7 +541,9 @@ assert_contains "$perm_fail_out" '请手动修复'
 # A restore that cannot remove the displaced directory must return non-zero,
 # keep the live DATA_DIR on the restored contents, and name the residue for
 # manual cleanup.
-rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-oldresidue"
+# DATA_DIR is root-owned (0700) after the permfail restore above; the reset
+# must run as root, then mkdir returns it to the runner.
+run_as_test_root rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-oldresidue"
 mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-oldresidue/data"
 printf 'JWT_SECRET=oldresidue-jwt-secret-000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
     "$DATA_DIR" > "${DATA_DIR}/.env"
@@ -708,13 +719,20 @@ if (
 fi
 assert_eq '2' "$(cat "$restore_attempt_file")" 'failed restore must be retried by the exit-trap cleanup'
 assert_contains "${TEST_ROOT}/update-restore-retry.log" '数据快照恢复失败'
-cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/restore-retry-db-before" \
+# The update's systemd path chowns DATA_DIR to the service user and .env to
+# root:meridian 0640, so a non-root runner cannot compare them directly.
+run_as_test_root cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/restore-retry-db-before" \
     || { echo 'FAIL: live database was modified when restore failed' >&2; exit 1; }
-cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/restore-retry-env-before" \
+run_as_test_root cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/restore-retry-env-before" \
     || { echo 'FAIL: live .env was modified when restore failed' >&2; exit 1; }
 
 # Exercise the password transaction with a mock binary. The real command and
 # bcrypt behavior are covered by Go tests.
+# Recreate DATA_DIR as the runner's own directory: the previous systemd-mode
+# tests left it owned by the service user, and the mock binary runs as the
+# runner, not as root.
+run_as_test_root rm -rf -- "$DATA_DIR"
+mkdir -p "$DATA_DIR"
 printf 'old-database-state\n' > "${DATA_DIR}/meridian.db"
 printf 'JWT_SECRET=old-jwt-secret-000000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
     "$DATA_DIR" > "${DATA_DIR}/.env"

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -494,7 +494,13 @@ restore_perm_log="${TEST_ROOT}/restore-perm.log"
 (
     as_root() {
         printf '%s\n' "$*" >> "$restore_perm_log"
-        command "$@"
+        # This case only asserts that the chown/chmod arguments are correct;
+        # actually running them as a non-root runner would EPERM. File
+        # operations (cp/mv/rm/test/awk) still execute for real.
+        case "$1" in
+            chown|chmod) return 0 ;;
+            *) command "$@" ;;
+        esac
     }
     is_systemd() { return 0; }
     restore_data_snapshot "${TEST_ROOT}/snapshot-systemd"

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2317
+# This file is a mock harness: the mock functions it defines are invoked
+# indirectly by the sourced install.sh, which ShellCheck cannot statically
+# trace, so every mock body would otherwise look unreachable.
+
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -353,6 +358,10 @@ printf 'pre-update-db-state\n' > "${DATA_DIR}/meridian.db"
 cp "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before"
 cp "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before"
 touch "$SERVICE_FILE"
+# MOCK_DB_PATH must reach the mock binaries inside every subshell. Exporting
+# it once at top level (instead of inside each subshell) keeps the assignment
+# in the parent scope (SC2030/SC2031) and is inherited by all subshells.
+export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
 failing_binary="${TEST_ROOT}/failing-meridian"
 cat > "$failing_binary" <<'MOCKBIN'
 #!/usr/bin/env bash
@@ -375,7 +384,6 @@ if (
     }
     wait_for_health() { return 1; }
     MOCK_LATEST='v9.9.12'
-    export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
     download() {
         local url="$1" output="$2"
         if [[ "$url" == */SHA256SUMS ]]; then
@@ -628,11 +636,20 @@ mkdir -p "$update_tmp_retry" "${TEST_ROOT}/snapshot-retry"
         return 1
     }
     is_systemd() { return 1; }
+    # The UPDATE_* values below are consumed by cleanup_update_transaction
+    # (defined in install.sh), which shellcheck cannot trace; each assignment
+    # carries its own local SC2034 suppression.
+    # shellcheck disable=SC2034
     UPDATE_TMP_DIR="$update_tmp_retry"
+    # shellcheck disable=SC2034
     UPDATE_TRANSACTION=1
+    # shellcheck disable=SC2034
     UPDATE_BINARY_CHANGED=0
+    # shellcheck disable=SC2034
     UPDATE_SNAPSHOT_DIR="${TEST_ROOT}/snapshot-retry"
+    # shellcheck disable=SC2034
     UPDATE_SNAPSHOT_RESTORED=0
+    # shellcheck disable=SC2034
     UPDATE_WAS_ACTIVE=0
     LAST_BACKUP_PATH="${TEST_ROOT}/backup.tar.gz"
     false
@@ -677,7 +694,6 @@ if (
         return 1
     }
     MOCK_LATEST='v9.9.13'
-    export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
     download() {
         local url="$1" output="$2"
         if [[ "$url" == */SHA256SUMS ]]; then
@@ -721,7 +737,6 @@ MOCKBIN
 chmod 0755 "$password_mock_binary"
 run_as_test_root install -m 0755 "$password_mock_binary" "${INSTALL_DIR}/${BIN_NAME}"
 touch "$SERVICE_FILE"
-export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
 
 run_password_case() {
     local health_result="$1"

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -109,6 +109,34 @@ if MERIDIAN_BACKUP_DIR=/var/ bash -c 'source "$1"; validate_backup_dir' _ "${REP
     exit 1
 fi
 
+# Pre-release/build suffixes must not corrupt numeric version comparison:
+# v1.5.6-rc1 is patch 6, not patch 61.
+version_gt v1.5.10 v1.5.6-rc1 || { echo 'FAIL: v1.5.10 must be newer than v1.5.6-rc1' >&2; exit 1; }
+version_gt v1.5.6-rc1 v1.5.5 || { echo 'FAIL: v1.5.6-rc1 must be newer than v1.5.5' >&2; exit 1; }
+version_gt v1.6.0-rc1 v1.5.10 || { echo 'FAIL: v1.6.0-rc1 must be newer than v1.5.10' >&2; exit 1; }
+version_gt v2.0.0-beta.1 v1.9.9 || { echo 'FAIL: v2.0.0-beta.1 must be newer than v1.9.9' >&2; exit 1; }
+version_gt v1.5.7 v1.5.6-rc1 || { echo 'FAIL: v1.5.7 must be newer than v1.5.6-rc1' >&2; exit 1; }
+if version_gt v1.5.6-rc1 v1.5.6; then
+    echo 'FAIL: v1.5.6-rc1 must not compare as newer than v1.5.6' >&2
+    exit 1
+fi
+if version_gt v1.5.6 v1.5.6-rc1; then
+    echo 'FAIL: v1.5.6 must not compare as newer than v1.5.6-rc1' >&2
+    exit 1
+fi
+if version_gt v1.5.6+beta2 v1.5.6; then
+    echo 'FAIL: v1.5.6+beta2 must not compare as newer than v1.5.6' >&2
+    exit 1
+fi
+if version_gt v1.5.6 v1.5.6; then
+    echo 'FAIL: equal versions must not compare as newer' >&2
+    exit 1
+fi
+if version_gt v1.5.6 v1.5.10; then
+    echo 'FAIL: v1.5.6 must not compare as newer than v1.5.10' >&2
+    exit 1
+fi
+
 package_log="${TEST_ROOT}/package.log"
 for manager in apt dnf yum apk pacman; do
     : > "$package_log"
@@ -367,6 +395,307 @@ cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before" \
 cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before" \
     || { echo 'FAIL: configuration was not restored after failed update' >&2; exit 1; }
 assert_contains "${TEST_ROOT}/update-rollback.log" '自动回滚'
+
+# A missing snapshot must fail the restore without touching the live data.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-missing"
+mkdir -p "$DATA_DIR"
+printf 'live-marker\n' > "${DATA_DIR}/live.txt"
+if restore_data_snapshot "${TEST_ROOT}/snapshot-missing" 2>/dev/null; then
+    echo 'FAIL: restore with a missing snapshot unexpectedly succeeded' >&2; exit 1
+fi
+assert_file "${DATA_DIR}/live.txt"
+
+# A snapshot without the configuration must be rejected before any swap: the
+# live directory stays byte-identical and no staging residue is left behind.
+rm -rf -- "${TEST_ROOT}/snapshot-noenv"
+mkdir -p "${TEST_ROOT}/snapshot-noenv/data"
+printf 'orphan\n' > "${TEST_ROOT}/snapshot-noenv/data/orphan.txt"
+if restore_data_snapshot "${TEST_ROOT}/snapshot-noenv" 2>/dev/null; then
+    echo 'FAIL: restore of a snapshot without .env unexpectedly succeeded' >&2; exit 1
+fi
+assert_file "${DATA_DIR}/live.txt"
+[ ! -e "${TEST_ROOT}/.data.restore.$$" ] || { echo 'FAIL: staging residue after rejected restore' >&2; exit 1; }
+
+# A failed swap must return non-zero and move the displaced directory back, so
+# the live data directory is never lost.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-swap-fail"
+mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-swap-fail/data"
+printf 'live-marker\n' > "${DATA_DIR}/live.txt"
+printf 'JWT_SECRET=swap-jwt-secret-00000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${TEST_ROOT}/snapshot-swap-fail/data/.env"
+printf 'snapshot-db\n' > "${TEST_ROOT}/snapshot-swap-fail/data/meridian.db"
+restore_swap_log="${TEST_ROOT}/restore-swap.log"
+if (
+    as_root() {
+        printf '%s\n' "$*" >> "$restore_swap_log"
+        if [ "$1" = "mv" ] && [ "$2" = "-f" ] && [ "$3" = "--" ] \
+            && [ "$4" = "${TEST_ROOT}/.data.restore.$$" ]; then
+            return 1
+        fi
+        command "$@"
+    }
+    restore_data_snapshot "${TEST_ROOT}/snapshot-swap-fail"
+); then
+    echo 'FAIL: restore with a failing swap unexpectedly succeeded' >&2; exit 1
+fi
+assert_file "${DATA_DIR}/live.txt"
+assert_contains "$restore_swap_log" "mv -f -- $DATA_DIR"
+
+# A successful restore swaps in the snapshot contents and, outside systemd,
+# gives the calling user back ownership of the data directory.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-ok"
+mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-ok/data"
+printf 'JWT_SECRET=live-jwt-secret-000000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'live-db\n' > "${DATA_DIR}/meridian.db"
+printf 'live-marker\n' > "${DATA_DIR}/live.txt"
+printf 'JWT_SECRET=snapshot-jwt-secret-0000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${TEST_ROOT}/snapshot-ok/data/.env"
+printf 'snapshot-db\n' > "${TEST_ROOT}/snapshot-ok/data/meridian.db"
+printf 'snapshot-extra\n' > "${TEST_ROOT}/snapshot-ok/data/extra.txt"
+(
+    is_systemd() { return 1; }
+    restore_data_snapshot "${TEST_ROOT}/snapshot-ok"
+) || { echo 'FAIL: snapshot restore failed' >&2; exit 1; }
+[ ! -e "${DATA_DIR}/live.txt" ] || { echo 'FAIL: live files survived restore' >&2; exit 1; }
+assert_file "${DATA_DIR}/extra.txt"
+cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/snapshot-ok/data/.env" \
+    || { echo 'FAIL: .env not restored' >&2; exit 1; }
+cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-ok/data/meridian.db" \
+    || { echo 'FAIL: database not restored' >&2; exit 1; }
+[ "$(stat -c %u "$DATA_DIR")" = "$(id -u)" ] || { echo 'FAIL: data directory owner not restored to the calling user' >&2; exit 1; }
+[ "$(stat -c %a "$DATA_DIR")" = "750" ] || { echo 'FAIL: data directory mode not restored to 0750' >&2; exit 1; }
+
+# Under systemd the restore must leave DATA_DIR traversable and owned by the
+# service user, the database writable by the service user, and .env back at
+# root:SERVICE_GROUP 0640, matching prepare_data_and_config.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-systemd"
+mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-systemd/data"
+printf 'JWT_SECRET=systemd-jwt-secret-0000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'live-db\n' > "${DATA_DIR}/meridian.db"
+cp "${DATA_DIR}/.env" "${TEST_ROOT}/snapshot-systemd/data/.env"
+cp "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-systemd/data/meridian.db"
+restore_perm_log="${TEST_ROOT}/restore-perm.log"
+: > "$restore_perm_log"
+(
+    as_root() {
+        printf '%s\n' "$*" >> "$restore_perm_log"
+        command "$@"
+    }
+    is_systemd() { return 0; }
+    restore_data_snapshot "${TEST_ROOT}/snapshot-systemd"
+) || { echo 'FAIL: systemd snapshot restore failed' >&2; exit 1; }
+assert_contains "$restore_perm_log" "chown meridian:meridian $DATA_DIR"
+assert_contains "$restore_perm_log" "chmod 0750 $DATA_DIR"
+assert_contains "$restore_perm_log" "chown root:meridian ${DATA_DIR}/.env"
+assert_contains "$restore_perm_log" "chmod 0640 ${DATA_DIR}/.env"
+assert_contains "$restore_perm_log" "chown meridian:meridian ${DATA_DIR}/meridian.db"
+assert_contains "$restore_perm_log" "chmod 0600 ${DATA_DIR}/meridian.db"
+
+# A restore whose permission normalization fails must return non-zero (so
+# UPDATE_SNAPSHOT_RESTORED stays unset and the transaction is retried or
+# escalated) and must say what is broken, even though the data contents were
+# already swapped in.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-permfail"
+mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-permfail/data"
+printf 'JWT_SECRET=permfail-jwt-secret-00000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'live-db\n' > "${DATA_DIR}/meridian.db"
+printf 'JWT_SECRET=permfail-snapshot-secret-0000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${TEST_ROOT}/snapshot-permfail/data/.env"
+printf 'snapshot-db\n' > "${TEST_ROOT}/snapshot-permfail/data/meridian.db"
+perm_fail_out="${TEST_ROOT}/restore-permfail.out"
+if (
+    as_root() {
+        if [ "$1" = "chown" ]; then return 1; fi
+        command "$@"
+    }
+    is_systemd() { return 0; }
+    restore_data_snapshot "${TEST_ROOT}/snapshot-permfail"
+) >"$perm_fail_out" 2>&1; then
+    echo 'FAIL: restore with failing permission fix unexpectedly succeeded' >&2; exit 1
+fi
+cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-permfail/data/meridian.db" \
+    || { echo 'FAIL: database content not restored despite permission failure' >&2; exit 1; }
+assert_contains "$perm_fail_out" '无法设置数据目录属主'
+assert_contains "$perm_fail_out" '请手动修复'
+
+# A restore that cannot remove the displaced directory must return non-zero,
+# keep the live DATA_DIR on the restored contents, and name the residue for
+# manual cleanup.
+rm -rf -- "$DATA_DIR" "${TEST_ROOT}/snapshot-oldresidue"
+mkdir -p "$DATA_DIR" "${TEST_ROOT}/snapshot-oldresidue/data"
+printf 'JWT_SECRET=oldresidue-jwt-secret-000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'live-db\n' > "${DATA_DIR}/meridian.db"
+printf 'JWT_SECRET=oldresidue-snapshot-secret-000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+    "$DATA_DIR" > "${TEST_ROOT}/snapshot-oldresidue/data/.env"
+printf 'snapshot-db\n' > "${TEST_ROOT}/snapshot-oldresidue/data/meridian.db"
+old_residue_out="${TEST_ROOT}/restore-oldresidue.out"
+if (
+    as_root() {
+        if [ "$1" = "rm" ]; then return 1; fi
+        command "$@"
+    }
+    is_systemd() { return 1; }
+    restore_data_snapshot "${TEST_ROOT}/snapshot-oldresidue"
+) >"$old_residue_out" 2>&1; then
+    echo 'FAIL: restore with uncleaned old directory unexpectedly succeeded' >&2; exit 1
+fi
+cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/snapshot-oldresidue/data/meridian.db" \
+    || { echo 'FAIL: database content not restored' >&2; exit 1; }
+assert_contains "$old_residue_out" '旧数据目录残留'
+assert_contains "$old_residue_out" "${TEST_ROOT}/.data.pre-restore.$$"
+[ -d "${TEST_ROOT}/.data.pre-restore.$$" ] || { echo 'FAIL: displaced directory was not preserved for manual cleanup' >&2; exit 1; }
+
+# The update transaction cleanup must remove the root-owned snapshot through
+# as_root (a plain rm would silently leave root-owned files behind) and must
+# say so when the cleanup itself fails.
+update_tmp="${TEST_ROOT}/update-tmp"
+mkdir -p "$update_tmp"
+rm_log="${TEST_ROOT}/cleanup-rm.log"
+(
+    as_root() {
+        printf '%s\n' "$*" >> "$rm_log"
+        command "$@"
+    }
+    UPDATE_TMP_DIR="$update_tmp"
+    UPDATE_TRANSACTION=0
+    UPDATE_BINARY_CHANGED=0
+    UPDATE_SNAPSHOT_DIR=""
+    UPDATE_SNAPSHOT_RESTORED=0
+    UPDATE_WAS_ACTIVE=0
+    cleanup_update_transaction
+)
+assert_contains "$rm_log" "rm -rf -- $update_tmp"
+UPDATE_TMP_DIR=""
+
+update_tmp_fail="${TEST_ROOT}/update-tmp-fail"
+mkdir -p "$update_tmp_fail"
+(
+    as_root() { return 1; }
+    UPDATE_TMP_DIR="$update_tmp_fail"
+    UPDATE_TRANSACTION=0
+    UPDATE_BINARY_CHANGED=0
+    UPDATE_SNAPSHOT_DIR=""
+    UPDATE_SNAPSHOT_RESTORED=0
+    UPDATE_WAS_ACTIVE=0
+    cleanup_update_transaction
+    exit 0
+) >"${TEST_ROOT}/cleanup-fail.out" 2>&1
+assert_contains "${TEST_ROOT}/cleanup-fail.out" '无法清理更新临时目录'
+assert_contains "${TEST_ROOT}/cleanup-fail.out" "$update_tmp_fail"
+
+# After a successful restore the exit-trap cleanup must not restore again.
+restore_gate_log="${TEST_ROOT}/restore-gate.log"
+update_tmp_gate="${TEST_ROOT}/update-tmp-gate"
+mkdir -p "$update_tmp_gate" "${TEST_ROOT}/snapshot-gate"
+(
+    set +e
+    as_root() {
+        printf '%s\n' "$*" >> "$restore_gate_log"
+        command "$@"
+    }
+    restore_data_snapshot() { printf 'restore-called\n' >> "$restore_gate_log"; }
+    UPDATE_TMP_DIR="$update_tmp_gate"
+    UPDATE_TRANSACTION=1
+    UPDATE_BINARY_CHANGED=0
+    UPDATE_SNAPSHOT_DIR="${TEST_ROOT}/snapshot-gate"
+    UPDATE_SNAPSHOT_RESTORED=1
+    UPDATE_WAS_ACTIVE=0
+    false
+    cleanup_update_transaction
+    exit 0
+) >"${TEST_ROOT}/cleanup-gate.out" 2>&1
+if grep -Fq 'restore-called' "$restore_gate_log"; then
+    echo 'FAIL: cleanup restored again after a successful restore' >&2; exit 1
+fi
+
+# A restore that fails inside cleanup must be reported with the backup
+# reference and must not be silently swallowed.
+restore_fail_log="${TEST_ROOT}/restore-fail.log"
+update_tmp_retry="${TEST_ROOT}/update-tmp-retry"
+mkdir -p "$update_tmp_retry" "${TEST_ROOT}/snapshot-retry"
+(
+    set +e
+    as_root() {
+        printf '%s\n' "$*" >> "$restore_fail_log"
+        command "$@"
+    }
+    restore_data_snapshot() {
+        printf 'restore-called\n' >> "$restore_fail_log"
+        return 1
+    }
+    is_systemd() { return 1; }
+    UPDATE_TMP_DIR="$update_tmp_retry"
+    UPDATE_TRANSACTION=1
+    UPDATE_BINARY_CHANGED=0
+    UPDATE_SNAPSHOT_DIR="${TEST_ROOT}/snapshot-retry"
+    UPDATE_SNAPSHOT_RESTORED=0
+    UPDATE_WAS_ACTIVE=0
+    LAST_BACKUP_PATH="${TEST_ROOT}/backup.tar.gz"
+    false
+    cleanup_update_transaction
+    exit 0
+) >"${TEST_ROOT}/cleanup-restore-fail.out" 2>&1
+assert_contains "${TEST_ROOT}/cleanup-restore-fail.out" '数据快照恢复失败'
+assert_contains "${TEST_ROOT}/cleanup-restore-fail.out" "${TEST_ROOT}/backup.tar.gz"
+grep -Fq 'restore-called' "$restore_fail_log" || { echo 'FAIL: cleanup did not attempt the restore' >&2; exit 1; }
+
+# A failing snapshot restore during an update must not be marked as restored:
+# the in-flow rollback warns, the live data directory is left alone, and the
+# exit-trap cleanup retries the restore instead of skipping it.
+printf 'JWT_SECRET=retry-jwt-secret-0000000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\nSETUP_TOKEN=retry-setup-token-000000000000000000000000000000\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'pre-update-db-state\n' > "${DATA_DIR}/meridian.db"
+cp "${DATA_DIR}/.env" "${TEST_ROOT}/restore-retry-env-before"
+cp "${DATA_DIR}/meridian.db" "${TEST_ROOT}/restore-retry-db-before"
+touch "$SERVICE_FILE"
+restore_attempt_file="${TEST_ROOT}/restore-attempts"
+printf '0\n' > "$restore_attempt_file"
+retry_failing_binary="${TEST_ROOT}/retry-failing-meridian"
+cat > "$retry_failing_binary" <<'MOCKBIN'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+    echo v9.9.13
+    exit 0
+fi
+printf 'mutated-by-retry-failing-version\n' >> "${MOCK_DB_PATH:?}"
+exit 1
+MOCKBIN
+chmod 0755 "$retry_failing_binary"
+if (
+    is_systemd() { return 0; }
+    service_is_active() { return 0; }
+    systemctl() { return 0; }
+    wait_for_health() { return 1; }
+    restore_data_snapshot() {
+        local n
+        n=$(cat "$restore_attempt_file")
+        printf '%s\n' "$((n + 1))" > "$restore_attempt_file"
+        return 1
+    }
+    MOCK_LATEST='v9.9.13'
+    export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
+    download() {
+        local url="$1" output="$2"
+        if [[ "$url" == */SHA256SUMS ]]; then
+            printf '%s  meridian-linux-amd64\n' "$(sha256_file "$retry_failing_binary")" > "$output"
+            return
+        fi
+        cp "$retry_failing_binary" "$output"
+    }
+    do_update
+) >"${TEST_ROOT}/update-restore-retry.log" 2>&1; then
+    echo 'FAIL: failing update unexpectedly succeeded' >&2; exit 1
+fi
+assert_eq '2' "$(cat "$restore_attempt_file")" 'failed restore must be retried by the exit-trap cleanup'
+assert_contains "${TEST_ROOT}/update-restore-retry.log" '数据快照恢复失败'
+cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/restore-retry-db-before" \
+    || { echo 'FAIL: live database was modified when restore failed' >&2; exit 1; }
+cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/restore-retry-env-before" \
+    || { echo 'FAIL: live .env was modified when restore failed' >&2; exit 1; }
 
 # Exercise the password transaction with a mock binary. The real command and
 # bcrypt behavior are covered by Go tests.

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -308,6 +308,66 @@ fi
 [ -n "$(read_env_value SETUP_TOKEN)" ] || { echo 'FAIL: legacy update did not backfill SETUP_TOKEN' >&2; exit 1; }
 assert_contains "${TEST_ROOT}/update-legacy-setup.log" '初始化令牌'
 
+# A newer installed version must never be silently downgraded.
+MOCK_LATEST='v9.8.0'
+if (do_update) >"${TEST_ROOT}/update-downgrade.log" 2>&1; then
+    echo 'FAIL: downgrade update unexpectedly succeeded' >&2; exit 1
+fi
+assert_eq 'v9.9.11' "$(get_current_version)" 'downgrade attempt must keep the installed version'
+assert_contains "${TEST_ROOT}/update-downgrade.log" '拒绝降级'
+
+# A failing new release must roll back the previous binary AND the exact
+# pre-update database and configuration. The mock new binary mutates the
+# database before "starting", then fails the health check.
+printf 'JWT_SECRET=rollback-jwt-secret-00000000000000000000000000\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\nSETUP_TOKEN=rollback-setup-token-0000000000000000000000000000\n' \
+    "$DATA_DIR" > "${DATA_DIR}/.env"
+printf 'pre-update-db-state\n' > "${DATA_DIR}/meridian.db"
+cp "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before"
+cp "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before"
+touch "$SERVICE_FILE"
+failing_binary="${TEST_ROOT}/failing-meridian"
+cat > "$failing_binary" <<'MOCKBIN'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+    echo v9.9.12
+    exit 0
+fi
+printf 'mutated-by-failing-version\n' >> "${MOCK_DB_PATH:?}"
+exit 1
+MOCKBIN
+chmod 0755 "$failing_binary"
+if (
+    is_systemd() { return 0; }
+    service_is_active() { return 0; }
+    systemctl() {
+        case "$*" in
+            *restart*) "${INSTALL_DIR}/${BIN_NAME}" >/dev/null 2>&1 || true ;; # run the new binary like systemd would
+        esac
+        return 0
+    }
+    wait_for_health() { return 1; }
+    MOCK_LATEST='v9.9.12'
+    export MOCK_DB_PATH="${DATA_DIR}/meridian.db"
+    download() {
+        local url="$1" output="$2"
+        if [[ "$url" == */SHA256SUMS ]]; then
+            printf '%s  meridian-linux-amd64\n' "$(sha256_file "$failing_binary")" > "$output"
+            return
+        fi
+        cp "$failing_binary" "$output"
+    }
+    do_update
+) >"${TEST_ROOT}/update-rollback.log" 2>&1; then
+    echo 'FAIL: failing update unexpectedly succeeded' >&2; exit 1
+fi
+assert_contains "${TEST_ROOT}/update-rollback.log" '自动回滚'
+assert_eq 'v9.9.11' "$(get_current_version)" 'rollback must restore the previous binary'
+cmp -s "${DATA_DIR}/meridian.db" "${TEST_ROOT}/rollback-db-before" \
+    || { echo 'FAIL: database was not restored after failed update' >&2; exit 1; }
+cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/rollback-env-before" \
+    || { echo 'FAIL: configuration was not restored after failed update' >&2; exit 1; }
+assert_contains "${TEST_ROOT}/update-rollback.log" '自动回滚'
+
 # Exercise the password transaction with a mock binary. The real command and
 # bcrypt behavior are covered by Go tests.
 printf 'old-database-state\n' > "${DATA_DIR}/meridian.db"

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.5.3">
-<link rel="stylesheet" href="/css/style.css?v=1.5.3">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.5.6">
+<link rel="stylesheet" href="/css/style.css?v=1.5.6">
 </head>
 <body>
 
@@ -101,13 +101,13 @@
 
 </div>
 
-<script src="/js/api.js?v=1.5.3"></script>
-<script src="/js/toast.js?v=1.5.3"></script>
-<script src="/js/router.js?v=1.5.3"></script>
-<script src="/js/pages/dashboard.js?v=1.5.3"></script>
-<script src="/js/pages/sites.js?v=1.5.3"></script>
-<script src="/js/pages/traffic.js?v=1.5.3"></script>
-<script src="/js/pages/diag.js?v=1.5.3"></script>
-<script src="/js/app.js?v=1.5.3"></script>
+<script src="/js/api.js?v=1.5.6"></script>
+<script src="/js/toast.js?v=1.5.6"></script>
+<script src="/js/router.js?v=1.5.6"></script>
+<script src="/js/pages/dashboard.js?v=1.5.6"></script>
+<script src="/js/pages/sites.js?v=1.5.6"></script>
+<script src="/js/pages/traffic.js?v=1.5.6"></script>
+<script src="/js/pages/diag.js?v=1.5.6"></script>
+<script src="/js/app.js?v=1.5.6"></script>
 </body>
 </html>

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -28,6 +28,11 @@ const API = {
     if (res.status === 401 && path !== '/api/auth/login') {
       await this.logout();
       window.location.reload();
+      // The session is gone and the page is navigating to the login screen:
+      // stop this request's control flow right here. Parsing or rejecting the
+      // stale 401 body would only let callers keep handling a response that
+      // is no longer valid (same convention as the dashboard SSE handler).
+      return;
     }
     let data;
     try {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -25,12 +25,17 @@ const API = {
     }
 
     const res = await fetch(path, opts);
-    const data = await res.json();
+    if (res.status === 401 && path !== '/api/auth/login') {
+      await this.logout();
+      window.location.reload();
+    }
+    let data;
+    try {
+      data = await res.json();
+    } catch (e) {
+      throw new Error(res.statusText || 'Request failed');
+    }
     if (!res.ok) {
-      if (res.status === 401 && path !== '/api/auth/login') {
-        await this.logout();
-        window.location.reload();
-      }
       throw new Error(data.error || 'Request failed');
     }
     return data;

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -157,6 +157,8 @@
         Toast.success('欢迎回来, ' + res.username + '!');
       }
       API.setSession(res);
+      document.getElementById('inp-password').value = '';
+      setupTokenInputEl.value = '';
       enterApp();
     } catch (err) {
       Toast.error(err.message);

--- a/web/static/js/router.js
+++ b/web/static/js/router.js
@@ -1,5 +1,5 @@
 const Router = {
-  routes: {},
+  routes: Object.create(null),
   current: null,
   initialized: false,
 


### PR DESCRIPTION
## Summary

v1.5.6 security hardening and release-blocker fixes, targeting `master`. 7 commits on top of `3cc047a`:

- `b6b250a` fix: harden redirects, setup, and upgrade rollback
- `c8c55df` fix: close release review blockers
- `c18e126` test: run all frontend tests in CI
- `5746d1a` test: run all frontend tests in releases
- `38a6db0` test: satisfy shellcheck in installer mocks
- `a9c864d` test: support non-root installer test runs
- `be4fdae` test: mock privileged metadata updates

## Security fixes

- Block cross-host diagnostic redirects (redirect endpoint no longer follows arbitrary hosts).
- Strip sensitive headers (authorization/cookies) on cross-origin playback redirects.
- Require a 32-byte `SETUP_TOKEN`; setup endpoint is now rate-limited.
- Upgrade rollback restores pre-update data on failed upgrades; downgrades are rejected.
- Login secrets are cleared on successful setup/login; routes use null-prototype objects.
- Cache/version stamps bumped to v1.5.6.

## Testing evidence (run locally, all passing)

- Go tests: `main_test.go` extended (+443 lines) — redirect hardening, setup token/rate-limit, upgrade rollback, downgrade rejection; `quality_test.go` (+2).
- Install/upgrade script tests: `tests/install_test.sh` (+389 lines).
- Frontend tests: `tests/api_client.test.js` (+70 lines); CI workflows (`ci.yml`, `release.yml`) now run the full `tests/*.test.js` suite instead of a subset.

## CI (final, all green)

- CI `test-and-build`: [30733207974](https://github.com/snnabb/Meridian/actions/runs/30733207974) — PASS (race tests, vet, vulnerability scan, security lint, frontend/installer syntax + installer suite, build).
- CodeQL `analyze`: [30733207973](https://github.com/snnabb/Meridian/actions/runs/30733207973) — PASS.

## Verification boundaries

- Local shellcheck was **not** run on `install.sh` changes (not part of this cycle's verification).
- Test-machine (on-device) verification was **not** performed in this cycle; runtime/device verification is out of scope for this PR and must be validated separately before release.

## Scope

No merge, no tag, no Release created from this PR — release steps are gated on CI results and follow-up review.