### PR TITLE
fix: make live traffic snapshots consistent

### DIFF
--- a/main.go
+++ b/main.go
@@ -504,6 +504,41 @@ type TrafficLog struct {
 	RecordedAt string `json:"recorded_at"`
 }
 
+// SiteTraffic is the authoritative per-site traffic state: the persisted
+// baseline plus in-memory pending bytes. TrafficUsed is always
+// PersistedTraffic + BytesIn + BytesOut (pending, not yet flushed).
+type SiteTraffic struct {
+	ID               int64  `json:"id"`
+	Name             string `json:"name"`
+	Running          bool   `json:"running"`
+	TrafficQuota     int64  `json:"traffic_quota"`
+	PersistedTraffic int64  `json:"persisted_traffic"`
+	BytesIn          int64  `json:"bytes_in"`
+	BytesOut         int64  `json:"bytes_out"`
+	TrafficUsed      int64  `json:"traffic_used"`
+	Requests         int64  `json:"requests"`
+}
+
+// TrafficSnapshot is the single authoritative global traffic payload shared by
+// /api/dashboard, /api/traffic/overview and SSE events.
+type TrafficSnapshot struct {
+	TotalSites    int           `json:"total_sites"`
+	OnlineSites   int           `json:"online_sites"`
+	RunningSites  int           `json:"running_sites"`
+	TotalTraffic  int64         `json:"total_traffic"`
+	TotalRequests int64         `json:"total_requests"`
+	UptimeSeconds int64         `json:"uptime_seconds"`
+	LiveSites     []SiteTraffic `json:"live_sites"`
+}
+
+// TrafficHistory is the single-site envelope returned by
+// /api/traffic/{id}/snapshot: an atomically captured live snapshot plus the
+// log window with pending bytes merged into the current-hour bucket.
+type TrafficHistory struct {
+	Snapshot SiteTraffic  `json:"snapshot"`
+	Logs     []TrafficLog `json:"logs"`
+}
+
 func (d *DB) UserCount() (int, error) {
 	var n int
 	if err := d.db.QueryRow("SELECT COUNT(*) FROM users").Scan(&n); err != nil {
@@ -807,25 +842,6 @@ func (d *DB) GetTrafficLogs(siteID int64, hours int) ([]TrafficLog, error) {
 		logs = []TrafficLog{}
 	}
 	return logs, nil
-}
-
-func (d *DB) DashboardStats() (map[string]interface{}, error) {
-	var total, online int
-	var totalTraffic int64
-	if err := d.db.QueryRow(`
-		SELECT
-			COUNT(*),
-			COALESCE(SUM(CASE WHEN enabled = 1 THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(traffic_used), 0)
-		FROM sites
-	`).Scan(&total, &online, &totalTraffic); err != nil {
-		return nil, err
-	}
-	return map[string]interface{}{
-		"total_sites":   total,
-		"online_sites":  online,
-		"total_traffic": totalTraffic,
-	}, nil
 }
 
 type redirectFollowTransport struct {
@@ -1140,10 +1156,15 @@ func stripSensitiveRedirectHeaders(header http.Header) {
 }
 
 type ProxyInstance struct {
-	Site             Site
-	server           *http.Server
-	listener         net.Listener
-	startedAt        time.Time
+	Site      Site
+	server    *http.Server
+	listener  net.Listener
+	startedAt time.Time
+	// trafficMu serializes this instance's traffic state transitions: flush,
+	// single-site history snapshot and the live overlay in global snapshots.
+	// Lock order is pm.mu -> trafficMu; helpers that take trafficMu (e.g.
+	// flushProxyTraffic) must never be called from code that already holds it.
+	trafficMu        sync.Mutex
 	bytesIn          atomic.Int64
 	bytesOut         atomic.Int64
 	reqCount         atomic.Int64
@@ -1872,7 +1893,15 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		// update path handleSiteByID does not pre-stop, so without this everything
 		// counted since the last 60s tick vanishes from traffic_logs and
 		// sites.traffic_used.
-		pm.flushProxyTraffic(existing)
+		if err := pm.flushProxyTraffic(existing); err != nil {
+			// Fail closed: keep the old instance and its pending bytes, release
+			// the new instance's freshly bound listener, and leave the proxies
+			// map untouched. The Serve goroutine below never starts, so closing
+			// the raw listener is enough.
+			pm.mu.Unlock()
+			_ = listener.Close()
+			return fmt.Errorf("flush traffic of the instance being replaced: %w", err)
+		}
 		// That flush moved bytes into the row `site` was read from, so carry the
 		// authoritative total forward instead of the snapshot taken before it.
 		if flushed := existing.Site.TrafficUsed; flushed > inst.persistedTraffic.Load() {
@@ -1905,16 +1934,24 @@ func (pm *ProxyManager) StartSite(site Site) error {
 	return nil
 }
 
-func (pm *ProxyManager) StopSite(id int64) {
+func (pm *ProxyManager) StopSite(id int64) error {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	if inst, ok := pm.proxies[id]; ok {
-		pm.flushProxyTraffic(inst)
-		if inst.server != nil {
-			inst.server.Close()
-		}
-		delete(pm.proxies, id)
+	inst, ok := pm.proxies[id]
+	if !ok {
+		return nil
 	}
+	// Flush before dropping the instance so pending bytes reach the DB. If the
+	// flush fails the instance stays running with its pending bytes intact and
+	// the caller must abort (or retry) so instance and DB remain consistent.
+	if err := pm.flushProxyTraffic(inst); err != nil {
+		return err
+	}
+	if inst.server != nil {
+		inst.server.Close()
+	}
+	delete(pm.proxies, id)
+	return nil
 }
 
 func (pm *ProxyManager) IsRunning(id int64) bool {
@@ -1939,30 +1976,226 @@ func (pm *ProxyManager) StartAllEnabled() (int, error) {
 	return len(sites), nil
 }
 
-// Flush traffic counters to DB periodically
+// FlushTraffic flushes every running instance's pending traffic to the DB. It
+// is driven by the periodic ticker: a failed flush restores the pending
+// counters and is logged here, so the next tick retries the same bytes.
 func (pm *ProxyManager) FlushTraffic() {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	for _, inst := range pm.proxies {
-		pm.flushProxyTraffic(inst)
+		if err := pm.flushProxyTraffic(inst); err != nil {
+			log.Printf("[%s] failed to flush traffic: %v", inst.Site.Name, err)
+		}
 	}
 }
 
-func (pm *ProxyManager) flushProxyTraffic(inst *ProxyInstance) {
+// flushProxyTraffic persists inst's pending bytes into the DB and moves them
+// into the persisted baseline. The caller must hold pm.mu (read or write);
+// inst.trafficMu is acquired here. On failure the pending counters are fully
+// restored so the next flush retries the same bytes. Never call this from
+// code that already holds inst.trafficMu (no nested re-entry).
+func (pm *ProxyManager) flushProxyTraffic(inst *ProxyInstance) error {
+	inst.trafficMu.Lock()
+	defer inst.trafficMu.Unlock()
+	return pm.flushProxyTrafficLocked(inst)
+}
+
+// flushProxyTrafficLocked is the body of flushProxyTraffic and assumes
+// inst.trafficMu is held. Order is swap -> DB -> persisted baseline: the
+// pending counters are zeroed first, the baseline moves only after the DB
+// transaction commits, and the counters are restored verbatim on any error.
+func (pm *ProxyManager) flushProxyTrafficLocked(inst *ProxyInstance) error {
 	in := inst.bytesIn.Swap(0)
 	out := inst.bytesOut.Swap(0)
 	if in == 0 && out == 0 {
-		return
+		return nil
 	}
 	if err := pm.database.addTraffic(inst.Site.ID, in, out); err != nil {
 		inst.bytesIn.Add(in)
 		inst.bytesOut.Add(out)
-		log.Printf("[%s] failed to flush traffic: %v", inst.Site.Name, err)
-		return
+		return err
 	}
 	delta := in + out
 	inst.persistedTraffic.Add(delta)
 	inst.Site.TrafficUsed += delta
+	return nil
+}
+
+// sameTrafficHour reports whether a persisted recorded_at value falls in the
+// same wall-clock hour as now. Stored rows are wall-clock values: legacy
+// "2006-01-02 15:04:05" rows carry the writer's local time, and the modernc
+// SQLite driver re-serializes DATETIME columns as RFC3339 with the stored
+// wall clock in UTC (it attaches Z to whatever text was written). The
+// year/month/day/hour components of the stored value are therefore compared
+// against the current local wall clock, never the instants: an instant-based
+// comparison would shift the bucket by the zone offset in non-UTC
+// deployments. Values that parse as neither format never match, so a corrupt
+// or foreign string cannot swallow pending bytes.
+func sameTrafficHour(recordedAt string, now time.Time) bool {
+	t, err := time.Parse(time.RFC3339Nano, recordedAt)
+	if err != nil {
+		if t, err = time.ParseInLocation("2006-01-02 15:04:05", recordedAt, time.Local); err != nil {
+			return false
+		}
+	}
+	nowLocal := now.In(time.Local)
+	y, m, d := t.Date()
+	ny, nm, nd := nowLocal.Date()
+	return y == ny && m == nm && d == nd && t.Hour() == nowLocal.Hour()
+}
+
+// mergePendingIntoLogs merges live pending bytes into the current-hour bucket
+// of the returned log copy: it adds to the existing bucket when present, or
+// appends a synthetic bucket with ID 0 when the hour has no bucket yet and
+// pending bytes are non-zero. A zero pending pair is a no-op. The input slice
+// must be a private copy (GetTrafficLogs always returns one). The current
+// hour is matched by wall-clock semantics via sameTrafficHour, so rows
+// persisted in either the RFC3339 form the SQLite driver returns or the
+// legacy SQL layout merge correctly. The synthetic bucket is built from the
+// current local wall hour stamped as UTC, exactly the representation the next
+// addTraffic row will carry after the driver re-serializes it, with ID 0.
+func mergePendingIntoLogs(logs []TrafficLog, siteID, pendingIn, pendingOut int64) []TrafficLog {
+	if pendingIn == 0 && pendingOut == 0 {
+		return logs
+	}
+	now := time.Now()
+	for i := range logs {
+		if sameTrafficHour(logs[i].RecordedAt, now) {
+			logs[i].BytesIn += pendingIn
+			logs[i].BytesOut += pendingOut
+			return logs
+		}
+	}
+	nowLocal := now.In(time.Local)
+	return append(logs, TrafficLog{
+		ID:         0,
+		SiteID:     siteID,
+		BytesIn:    pendingIn,
+		BytesOut:   pendingOut,
+		RecordedAt: time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), nowLocal.Hour(), 0, 0, 0, time.UTC).Format(time.RFC3339),
+	})
+}
+
+// SiteTrafficHistory captures a single site's traffic history as a consistent
+// point-in-time view: the DB log window plus live pending bytes merged into
+// the returned copy's current-hour bucket, alongside the authoritative live
+// state. For a running site the DB read and the live counters happen under
+// inst.trafficMu (with pm.mu held read-only to pin the instance), so the view
+// never interleaves with a concurrent flush.
+func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistory, error) {
+	snap := SiteTraffic{
+		ID:               site.ID,
+		Name:             site.Name,
+		TrafficQuota:     site.TrafficQuota,
+		PersistedTraffic: site.TrafficUsed,
+		TrafficUsed:      site.TrafficUsed,
+	}
+
+	pm.mu.RLock()
+	inst, running := pm.proxies[site.ID]
+	if !running {
+		pm.mu.RUnlock()
+		logs, err := pm.database.GetTrafficLogs(site.ID, hours)
+		if err != nil {
+			return nil, err
+		}
+		return &TrafficHistory{Snapshot: snap, Logs: logs}, nil
+	}
+	// pm.mu -> trafficMu lock order. trafficMu stays held across the DB read
+	// so the logs and the live counters describe the same instant.
+	inst.trafficMu.Lock()
+	defer inst.trafficMu.Unlock()
+	defer pm.mu.RUnlock()
+
+	logs, err := pm.database.GetTrafficLogs(site.ID, hours)
+	if err != nil {
+		return nil, err
+	}
+	snap.Running = true
+	snap.PersistedTraffic = inst.persistedTraffic.Load()
+	snap.BytesIn = inst.bytesIn.Load()
+	snap.BytesOut = inst.bytesOut.Load()
+	snap.TrafficUsed = snap.PersistedTraffic + snap.BytesIn + snap.BytesOut
+	snap.Requests = inst.reqCount.Load()
+	logs = mergePendingIntoLogs(logs, site.ID, snap.BytesIn, snap.BytesOut)
+	return &TrafficHistory{Snapshot: snap, Logs: logs}, nil
+}
+
+// overlaySiteTrafficLocked fills st with the authoritative live per-instance
+// state for a running site: persistedTraffic + pending bytes, exactly the same
+// merge every traffic view renders. The caller must hold pm.mu (read or
+// write); inst.trafficMu is acquired here following the pm.mu -> trafficMu
+// lock order, so the overlay never interleaves with a concurrent flush. This
+// is the single per-site merge algorithm for all live traffic payloads.
+func (pm *ProxyManager) overlaySiteTrafficLocked(s Site, st *SiteTraffic) {
+	if inst, ok := pm.proxies[s.ID]; ok {
+		inst.trafficMu.Lock()
+		st.Running = true
+		st.PersistedTraffic = inst.persistedTraffic.Load()
+		st.BytesIn = inst.bytesIn.Load()
+		st.BytesOut = inst.bytesOut.Load()
+		st.TrafficUsed = st.PersistedTraffic + st.BytesIn + st.BytesOut
+		st.Requests = inst.reqCount.Load()
+		inst.trafficMu.Unlock()
+	}
+}
+
+// LiveSiteTraffic overlays the authoritative live traffic state (persisted
+// baseline plus pending bytes, under each instance's trafficMu) onto the given
+// DB sites and returns it as a map keyed by site ID. One pm.mu read lock is
+// taken for the whole map, so the view is consistent and there is no N+1 lock
+// churn; the lock order is pm.mu -> trafficMu.
+func (pm *ProxyManager) LiveSiteTraffic(sites []Site) map[int64]SiteTraffic {
+	live := make(map[int64]SiteTraffic, len(sites))
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	for _, s := range sites {
+		st := SiteTraffic{
+			ID:               s.ID,
+			Name:             s.Name,
+			TrafficQuota:     s.TrafficQuota,
+			PersistedTraffic: s.TrafficUsed,
+			TrafficUsed:      s.TrafficUsed,
+		}
+		pm.overlaySiteTrafficLocked(s, &st)
+		live[s.ID] = st
+	}
+	return live
+}
+
+// TrafficSnapshot builds the authoritative global traffic payload: every DB
+// site, overlaid with live per-instance state for running sites. Dashboard,
+// traffic overview and SSE events all render this single payload.
+func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
+	sites, err := pm.database.ListSites()
+	if err != nil {
+		return nil, err
+	}
+	snap := &TrafficSnapshot{
+		TotalSites: len(sites),
+		LiveSites:  make([]SiteTraffic, 0, len(sites)),
+	}
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	snap.RunningSites = len(pm.proxies)
+	for _, s := range sites {
+		st := SiteTraffic{
+			ID:               s.ID,
+			Name:             s.Name,
+			TrafficQuota:     s.TrafficQuota,
+			PersistedTraffic: s.TrafficUsed,
+			TrafficUsed:      s.TrafficUsed,
+		}
+		if s.Enabled {
+			snap.OnlineSites++
+		}
+		pm.overlaySiteTrafficLocked(s, &st)
+		snap.TotalTraffic += st.TrafficUsed
+		snap.TotalRequests += st.Requests
+		snap.LiveSites = append(snap.LiveSites, st)
+	}
+	snap.UptimeSeconds = int64(time.Since(startTime).Seconds())
+	return snap, nil
 }
 
 func (pm *ProxyManager) GetRunningCount() int {
@@ -1991,17 +2224,6 @@ func (pm *ProxyManager) GracefulShutdown(ctx context.Context) {
 		inst.server.Shutdown(ctx)
 		delete(pm.proxies, id)
 	}
-}
-
-// GetTotalRequests returns total request count across all proxies
-func (pm *ProxyManager) GetTotalRequests() int64 {
-	pm.mu.RLock()
-	defer pm.mu.RUnlock()
-	var total int64
-	for _, inst := range pm.proxies {
-		total += inst.reqCount.Load()
-	}
-	return total
 }
 
 type DiagResult struct {
@@ -3043,13 +3265,12 @@ func (a *App) handleAuthCheck(w http.ResponseWriter, r *http.Request) {
 
 // GET /api/dashboard
 func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	stats, err := a.db.DashboardStats()
+	snap, err := a.pm.TrafficSnapshot()
 	if err != nil {
 		a.jsonErr(w, http.StatusInternalServerError, "dashboard unavailable")
 		return
 	}
-	stats["running_sites"] = a.pm.GetRunningCount()
-	a.jsonOK(w, stats)
+	a.jsonOK(w, snap)
 }
 
 // GET/POST /api/sites
@@ -3061,6 +3282,11 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
+		// Overlay the authoritative live traffic state (persisted + pending)
+		// for running sites, exactly the merge TrafficSnapshot renders; every
+		// non-traffic field keeps its DB value. One pm.mu read lock covers the
+		// whole map, so there is no N+1 lock handoff per site.
+		live := a.pm.LiveSiteTraffic(sites)
 		// Add running status
 		type SiteWithStatus struct {
 			Site
@@ -3068,7 +3294,9 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 		}
 		result := make([]SiteWithStatus, len(sites))
 		for i, s := range sites {
-			result[i] = SiteWithStatus{Site: s, Running: a.pm.IsRunning(s.ID)}
+			st := live[s.ID]
+			result[i] = SiteWithStatus{Site: s, Running: st.Running}
+			result[i].TrafficUsed = st.TrafficUsed
 		}
 		a.jsonOK(w, result)
 
@@ -3177,33 +3405,57 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	case action == "toggle" && r.Method == "POST":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
-		newState, err := a.db.ToggleSite(id)
+		site, err := a.db.GetSite(id)
 		if err != nil {
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
-		if newState {
-			site, err := a.db.GetSite(id)
-			if err != nil {
-				if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
-					a.jsonErr(w, 500, fmt.Sprintf("load site: %v; rollback toggle: %v", err, revertErr))
-					return
-				}
+		if site.Enabled {
+			// Turning off: stop (and flush) before flipping the flag, so a failed
+			// flush aborts with the instance still running and the flag still on
+			// - instance and DB stay consistent.
+			if err := a.pm.StopSite(id); err != nil {
 				a.jsonErr(w, 500, err.Error())
 				return
 			}
-			if err := a.pm.StartSite(*site); err != nil {
-				if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
-					a.jsonErr(w, 500, fmt.Sprintf("start site: %v; rollback toggle: %v", err, revertErr))
-					return
+			if _, err := a.db.ToggleSite(id); err != nil {
+				// The instance is stopped but the flag stayed on: restart it so the
+				// DB and the running set stay consistent.
+				if restarted, getErr := a.db.GetSite(id); getErr == nil {
+					if startErr := a.pm.StartSite(*restarted); startErr == nil {
+						a.jsonErr(w, 500, fmt.Sprintf("toggle off: %v", err))
+						return
+					}
 				}
-				a.jsonErr(w, 500, err.Error())
+				a.jsonErr(w, 500, fmt.Sprintf("toggle off: %v; site stopped but flag update failed", err))
 				return
 			}
-		} else {
-			a.pm.StopSite(id)
+			a.jsonOK(w, map[string]interface{}{"enabled": false})
+			return
 		}
-		a.jsonOK(w, map[string]interface{}{"enabled": newState})
+		// Turning on: flip the flag first so a failed start can roll it back.
+		if _, err := a.db.ToggleSite(id); err != nil {
+			a.jsonErr(w, 500, err.Error())
+			return
+		}
+		site, err = a.db.GetSite(id)
+		if err != nil {
+			if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("load site: %v; rollback toggle: %v", err, revertErr))
+				return
+			}
+			a.jsonErr(w, 500, err.Error())
+			return
+		}
+		if err := a.pm.StartSite(*site); err != nil {
+			if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("start site: %v; rollback toggle: %v", err, revertErr))
+				return
+			}
+			a.jsonErr(w, 500, err.Error())
+			return
+		}
+		a.jsonOK(w, map[string]interface{}{"enabled": true})
 
 	case action == "diag" && r.Method == "GET":
 		site, err := a.db.GetSite(id)
@@ -3290,20 +3542,61 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			a.jsonErr(w, http.StatusBadRequest, err.Error())
 			return
 		}
+		needsPreStop := oldSite.Enabled && oldSite.ListenPort == candidate.ListenPort && a.pm.IsRunning(id)
+		if needsPreStop {
+			// Stop (and flush) before the DB update, so a failed flush aborts with
+			// the old config still in the DB and the old instance still running -
+			// instance and DB stay consistent.
+			if err := a.pm.StopSite(id); err != nil {
+				a.jsonErr(w, 500, err.Error())
+				return
+			}
+		}
 		if err := a.db.UpdateSiteRecord(candidate); err != nil {
+			if needsPreStop {
+				// The instance is stopped; bring it back from a fresh read (which
+				// includes the flushed traffic) so the DB flag and the running set
+				// stay consistent. If even the reload fails, say so explicitly:
+				// the enabled row must never silently sit without an instance.
+				restored, getErr := a.db.GetSite(id)
+				if getErr != nil {
+					a.jsonErr(w, 500, fmt.Sprintf("update site: %v; site stopped and reload failed: %v", err, getErr))
+					return
+				}
+				if restartErr := a.pm.StartSite(*restored); restartErr != nil {
+					a.jsonErr(w, 500, fmt.Sprintf("update site: %v; restore instance: %v", err, restartErr))
+					return
+				}
+			}
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
 		site, err := a.db.GetSite(id)
 		if err != nil {
+			// The record was already updated but cannot be reloaded for the
+			// restart: roll the DB back to the old record so the enabled flag
+			// never points at a configuration that never ran, then bring the
+			// pre-stopped instance back from a fresh read. Any failure in the
+			// rollback itself is reported explicitly.
+			if rollbackErr := a.db.UpdateSiteRecord(*oldSite); rollbackErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; rollback update: %v", err, rollbackErr))
+				return
+			}
+			restoredSite, getErr := a.db.GetSite(id)
+			if getErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; reload rollback site: %v", err, getErr))
+				return
+			}
+			if needsPreStop {
+				if restartErr := a.pm.StartSite(*restoredSite); restartErr != nil {
+					a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; restored configuration is enabled but proxy is not running: %v", err, restartErr))
+					return
+				}
+			}
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
 		if site.Enabled {
-			needsPreStop := oldSite.Enabled && oldSite.ListenPort == site.ListenPort && a.pm.IsRunning(id)
-			if needsPreStop {
-				a.pm.StopSite(id)
-			}
 			if err := a.pm.StartSite(*site); err != nil {
 				if rollbackErr := a.db.UpdateSiteRecord(*oldSite); rollbackErr != nil {
 					a.jsonErr(w, 500, fmt.Sprintf("start updated site: %v; rollback update: %v", err, rollbackErr))
@@ -3329,8 +3622,28 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	case action == "" && r.Method == "DELETE":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
-		a.pm.StopSite(id)
+		// Only delete the DB row after the instance stopped cleanly (flush
+		// succeeded); a failed flush aborts with the instance and row intact.
+		if err := a.pm.StopSite(id); err != nil {
+			a.jsonErr(w, 500, err.Error())
+			return
+		}
 		if err := a.db.DeleteSite(id); err != nil {
+			// The row survived the delete, so an enabled site must not be left
+			// without a running instance: restart it from a fresh read (which
+			// includes the traffic StopSite flushed). Failures in the restore
+			// are reported explicitly instead of claiming success.
+			restored, getErr := a.db.GetSite(id)
+			if getErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("delete site: %v; site stopped and reload failed: %v", err, getErr))
+				return
+			}
+			if restored.Enabled {
+				if restartErr := a.pm.StartSite(*restored); restartErr != nil {
+					a.jsonErr(w, 500, fmt.Sprintf("delete site: %v; restore instance: %v", err, restartErr))
+					return
+				}
+			}
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
@@ -3341,18 +3654,24 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GET /api/traffic/{site_id}
+// GET /api/traffic/{site_id} and GET /api/traffic/{site_id}/snapshot
 func (a *App) handleTraffic(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/traffic/")
 
 	if path == "overview" {
-		stats, err := a.db.DashboardStats()
+		snap, err := a.pm.TrafficSnapshot()
 		if err != nil {
 			a.jsonErr(w, http.StatusInternalServerError, "traffic overview unavailable")
 			return
 		}
-		a.jsonOK(w, stats)
+		a.jsonOK(w, snap)
 		return
+	}
+
+	envelope := false
+	if strings.HasSuffix(path, "/snapshot") {
+		envelope = true
+		path = strings.TrimSuffix(path, "/snapshot")
 	}
 
 	siteID, err := strconv.ParseInt(path, 10, 64)
@@ -3371,12 +3690,32 @@ func (a *App) handleTraffic(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	logs, err := a.db.GetTrafficLogs(siteID, hours)
+	site, err := a.db.GetSite(siteID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			if envelope {
+				a.jsonErr(w, http.StatusNotFound, "site not found")
+				return
+			}
+			// The legacy endpoint keeps returning an empty log array for
+			// unknown sites.
+			a.jsonOK(w, []TrafficLog{})
+			return
+		}
+		a.jsonErr(w, 500, err.Error())
+		return
+	}
+
+	history, err := a.pm.SiteTrafficHistory(*site, hours)
 	if err != nil {
 		a.jsonErr(w, 500, err.Error())
 		return
 	}
-	a.jsonOK(w, logs)
+	if envelope {
+		a.jsonOK(w, history)
+		return
+	}
+	a.jsonOK(w, history.Logs)
 }
 
 // GET /api/ua-profiles
@@ -3425,31 +3764,12 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
-	stats, err := a.db.DashboardStats()
+	snap, err := a.pm.TrafficSnapshot()
 	if err != nil {
 		return err
 	}
-	stats["running_sites"] = a.pm.GetRunningCount()
-	stats["total_requests"] = a.pm.GetTotalRequests()
-	stats["uptime_seconds"] = int(time.Since(startTime).Seconds())
 
-	// Collect per-site live stats
-	a.pm.mu.RLock()
-	siteStats := make([]map[string]interface{}, 0)
-	for _, inst := range a.pm.proxies {
-		siteStats = append(siteStats, map[string]interface{}{
-			"id":        inst.Site.ID,
-			"name":      inst.Site.Name,
-			"bytes_in":  inst.bytesIn.Load(),
-			"bytes_out": inst.bytesOut.Load(),
-			"requests":  inst.reqCount.Load(),
-			"running":   true,
-		})
-	}
-	a.pm.mu.RUnlock()
-	stats["live_sites"] = siteStats
-
-	data, err := json.Marshal(stats)
+	data, err := json.Marshal(snap)
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1487,8 +1487,8 @@ func TestDatabaseReadFailuresAreReported(t *testing.T) {
 	if _, err := app.db.UserCount(); err == nil {
 		t.Fatal("UserCount unexpectedly ignored a closed database")
 	}
-	if _, err := app.db.DashboardStats(); err == nil {
-		t.Fatal("DashboardStats unexpectedly ignored a closed database")
+	if _, err := app.pm.TrafficSnapshot(); err == nil {
+		t.Fatal("TrafficSnapshot unexpectedly ignored a closed database")
 	}
 	if _, err := app.pm.StartAllEnabled(); err == nil {
 		t.Fatal("StartAllEnabled unexpectedly ignored a closed database")
@@ -2685,6 +2685,1234 @@ func TestAddTrafficAggregatesSameHour(t *testing.T) {
 	}
 	if logs[0].BytesIn != 15 || logs[0].BytesOut != 27 {
 		t.Fatalf("aggregated log = in:%d out:%d", logs[0].BytesIn, logs[0].BytesOut)
+	}
+}
+
+// setDBReadonly flips the single pooled connection's query_only pragma, making
+// every DB write fail while reads keep working. openDB pins SetMaxOpenConns(1),
+// so the connection-scoped pragma is deterministic.
+func setDBReadonly(t *testing.T, app *App, readonly bool) {
+	t.Helper()
+	value := "OFF"
+	if readonly {
+		value = "ON"
+	}
+	if _, err := app.db.db.Exec("PRAGMA query_only=" + value); err != nil {
+		t.Fatalf("PRAGMA query_only=%s: %v", value, err)
+	}
+}
+
+// execTestSQL runs a one-off statement on the test app's single pooled
+// connection, so schema-level failure injection (SQLite triggers) is
+// deterministic. Used to make one specific write fail while the flush's own
+// writes keep succeeding - the granularity query_only cannot express.
+func execTestSQL(t *testing.T, app *App, statement string) {
+	t.Helper()
+	if _, err := app.db.db.Exec(statement); err != nil {
+		t.Fatalf("exec %q: %v", statement, err)
+	}
+}
+
+func findLiveSite(t *testing.T, snap *TrafficSnapshot, id int64) SiteTraffic {
+	t.Helper()
+	for _, st := range snap.LiveSites {
+		if st.ID == id {
+			return st
+		}
+	}
+	t.Fatalf("site %d missing from TrafficSnapshot live sites: %+v", id, snap.LiveSites)
+	return SiteTraffic{}
+}
+
+// Pending bytes are flushed to the DB exactly once, the authoritative total
+// traffic_used = persisted + pending is conserved across flushes, and the
+// current-hour log bucket aggregates without double counting.
+func TestFlushPersistsPendingExactlyOnceAndConservesTotals(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("conservation", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(120)
+	inst.bytesOut.Store(80)
+	app.pm.proxies[site.ID] = inst
+
+	// Before any flush the live total already includes the pending bytes.
+	snap, err := app.pm.TrafficSnapshot()
+	if err != nil {
+		t.Fatalf("TrafficSnapshot: %v", err)
+	}
+	live := findLiveSite(t, snap, site.ID)
+	if live.TrafficUsed != 200 || live.PersistedTraffic != 0 || live.BytesIn != 120 || live.BytesOut != 80 {
+		t.Fatalf("pre-flush live state = %+v, want used=200 persisted=0 in=120 out=80", live)
+	}
+
+	app.pm.FlushTraffic()
+
+	// Pending moved to the baseline exactly once.
+	if got := inst.persistedTraffic.Load(); got != 200 {
+		t.Fatalf("persistedTraffic after flush = %d, want 200", got)
+	}
+	if got := inst.bytesIn.Load(); got != 0 {
+		t.Fatalf("bytesIn after flush = %d, want 0", got)
+	}
+	if got := inst.bytesOut.Load(); got != 0 {
+		t.Fatalf("bytesOut after flush = %d, want 0", got)
+	}
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 200 {
+		t.Fatalf("traffic_used = %d, want 200", reloaded.TrafficUsed)
+	}
+	logs, err := app.db.GetTrafficLogs(site.ID, 1)
+	if err != nil {
+		t.Fatalf("GetTrafficLogs: %v", err)
+	}
+	if len(logs) != 1 || logs[0].BytesIn != 120 || logs[0].BytesOut != 80 {
+		t.Fatalf("logs after flush = %+v, want one row with 120/80", logs)
+	}
+
+	// A second flush with fresh pending accumulates; nothing is double counted.
+	inst.bytesIn.Store(30)
+	inst.bytesOut.Store(10)
+	app.pm.FlushTraffic()
+	if got := inst.persistedTraffic.Load(); got != 240 {
+		t.Fatalf("persistedTraffic after second flush = %d, want 240", got)
+	}
+	logs, err = app.db.GetTrafficLogs(site.ID, 1)
+	if err != nil {
+		t.Fatalf("GetTrafficLogs: %v", err)
+	}
+	if len(logs) != 1 || logs[0].BytesIn != 150 || logs[0].BytesOut != 90 {
+		t.Fatalf("logs after second flush = %+v, want one aggregated row 150/90", logs)
+	}
+	snap, err = app.pm.TrafficSnapshot()
+	if err != nil {
+		t.Fatalf("TrafficSnapshot: %v", err)
+	}
+	live = findLiveSite(t, snap, site.ID)
+	if live.TrafficUsed != 240 || snap.TotalTraffic != 240 {
+		t.Fatalf("post-flush total = site:%d snapshot:%d, want 240/240", live.TrafficUsed, snap.TotalTraffic)
+	}
+}
+
+// A failed flush restores the pending counters verbatim and a later retry
+// persists exactly those bytes, so no traffic is lost or double counted.
+func TestFlushFailureRestoresPendingAndRetryPersistsExactlyOnce(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("retry", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(120)
+	inst.bytesOut.Store(80)
+	app.pm.proxies[site.ID] = inst
+
+	setDBReadonly(t, app, true)
+	if err := app.pm.flushProxyTraffic(inst); err == nil {
+		t.Fatal("flush succeeded against a read-only database")
+	}
+	// Full refill: pending intact, baseline and DB untouched.
+	if got := inst.bytesIn.Load(); got != 120 {
+		t.Fatalf("bytesIn after failed flush = %d, want 120 restored", got)
+	}
+	if got := inst.bytesOut.Load(); got != 80 {
+		t.Fatalf("bytesOut after failed flush = %d, want 80 restored", got)
+	}
+	if got := inst.persistedTraffic.Load(); got != 0 {
+		t.Fatalf("persistedTraffic after failed flush = %d, want 0", got)
+	}
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 0 {
+		t.Fatalf("traffic_used after failed flush = %d, want 0", reloaded.TrafficUsed)
+	}
+
+	// Retry after the DB recovers persists the exact same bytes, once.
+	setDBReadonly(t, app, false)
+	if err := app.pm.flushProxyTraffic(inst); err != nil {
+		t.Fatalf("flush retry: %v", err)
+	}
+	if got := inst.persistedTraffic.Load(); got != 200 {
+		t.Fatalf("persistedTraffic after retry = %d, want 200", got)
+	}
+	reloaded, err = app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 200 {
+		t.Fatalf("traffic_used after retry = %d, want 200", reloaded.TrafficUsed)
+	}
+	logs, err := app.db.GetTrafficLogs(site.ID, 1)
+	if err != nil {
+		t.Fatalf("GetTrafficLogs: %v", err)
+	}
+	if len(logs) != 1 || logs[0].BytesIn != 120 || logs[0].BytesOut != 80 {
+		t.Fatalf("logs after retry = %+v, want one row 120/80", logs)
+	}
+}
+
+// The single-site history snapshot reads DB logs, persisted baseline and
+// pending under one lock: pending bytes land in the current-hour bucket of the
+// returned copy (synthetic ID=0 bucket when absent, no-op when pending is 0).
+func TestSiteTrafficHistoryMergesPendingIntoCurrentHourBucket(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("merge", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	pastHour := time.Now().Add(-2 * time.Hour).Truncate(time.Hour).Format("2006-01-02 15:04:05")
+	if _, err := app.db.db.Exec("INSERT INTO traffic_logs (site_id, bytes_in, bytes_out, recorded_at) VALUES (?,?,?,?)", site.ID, 100, 50, pastHour); err != nil {
+		t.Fatalf("insert past log: %v", err)
+	}
+	if _, err := app.db.db.Exec("UPDATE sites SET traffic_used=150 WHERE id=?", site.ID); err != nil {
+		t.Fatalf("bump traffic_used: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.persistedTraffic.Store(150)
+	inst.bytesIn.Store(30)
+	inst.bytesOut.Store(20)
+	app.pm.proxies[site.ID] = inst
+
+	history, err := app.pm.SiteTrafficHistory(*site, 24)
+	if err != nil {
+		t.Fatalf("SiteTrafficHistory: %v", err)
+	}
+	if len(history.Logs) != 2 {
+		t.Fatalf("logs = %+v, want past row plus synthetic current-hour bucket", history.Logs)
+	}
+	if history.Logs[0].ID == 0 || history.Logs[0].BytesIn != 100 || history.Logs[0].BytesOut != 50 {
+		t.Fatalf("past bucket mutated = %+v, want 100/50 untouched", history.Logs[0])
+	}
+	current := history.Logs[1]
+	hourBefore := time.Now()
+	if _, err := time.Parse(time.RFC3339, current.RecordedAt); err != nil {
+		t.Fatalf("synthetic recorded_at %q is not RFC3339: %v", current.RecordedAt, err)
+	}
+	hourAfter := time.Now()
+	if current.ID != 0 || current.BytesIn != 30 || current.BytesOut != 20 || !(sameTrafficHour(current.RecordedAt, hourBefore) || sameTrafficHour(current.RecordedAt, hourAfter)) {
+		t.Fatalf("synthetic current bucket = %+v, want ID=0 30/20 at the current hour", current)
+	}
+	if !history.Snapshot.Running || history.Snapshot.PersistedTraffic != 150 || history.Snapshot.BytesIn != 30 || history.Snapshot.BytesOut != 20 || history.Snapshot.TrafficUsed != 200 {
+		t.Fatalf("snapshot = %+v, want running persisted=150 in=30 out=20 used=200", history.Snapshot)
+	}
+
+	// pending = 0 is a no-op: no synthetic bucket is appended.
+	inst.bytesIn.Store(0)
+	inst.bytesOut.Store(0)
+	history, err = app.pm.SiteTrafficHistory(*site, 24)
+	if err != nil {
+		t.Fatalf("SiteTrafficHistory: %v", err)
+	}
+	if len(history.Logs) != 1 {
+		t.Fatalf("logs with zero pending = %+v, want only the past row", history.Logs)
+	}
+
+	// When the current hour already has a bucket, pending merges into it.
+	// Use the synchronous addTraffic so the bucket is committed before the
+	// immediate read below (AddTraffic only logs errors and races the read).
+	// The bucket is identified by its bytes and real ID, never by a recorded_at
+	// string layout: the SQLite driver re-serializes DATETIME columns as
+	// RFC3339, so the persisted value must be matched by time semantics.
+	if err := app.db.addTraffic(site.ID, 10, 5); err != nil {
+		t.Fatalf("addTraffic: %v", err)
+	}
+	inst.bytesIn.Store(7)
+	inst.bytesOut.Store(3)
+	history, err = app.pm.SiteTrafficHistory(*site, 24)
+	if err != nil {
+		t.Fatalf("SiteTrafficHistory: %v", err)
+	}
+	if len(history.Logs) != 2 {
+		t.Fatalf("logs after merge = %+v, want past row plus one current-hour bucket, no synthetic duplicate", history.Logs)
+	}
+	var merged *TrafficLog
+	for i := range history.Logs {
+		l := &history.Logs[i]
+		if l.ID == 0 {
+			t.Fatalf("synthetic ID=0 bucket present although the real row exists: %+v", l)
+		}
+		if l.BytesIn == 17 && l.BytesOut == 8 {
+			if merged != nil {
+				t.Fatalf("two buckets carry 17/8: %+v and %+v", *merged, *l)
+			}
+			merged = l
+		}
+	}
+	if merged == nil {
+		t.Fatalf("no 17/8 bucket in %+v; pending must merge into the real addTraffic row", history.Logs)
+	}
+}
+
+// The merge identifies the current hour by time semantics, across every
+// format persisted rows carry: RFC3339 / RFC3339Nano (what the modernc
+// SQLite driver re-serializes DATETIME columns as) and the legacy
+// "2006-01-02 15:04:05" SQL layout. Rows from other hours and values that
+// parse as neither never absorb pending bytes; zero pending is a no-op.
+func TestMergePendingIntoLogsHourRecognition(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordedAt string
+		pendingIn  int64
+		pendingOut int64
+		wantMerge  bool // pending lands in the existing bucket
+		wantAppend bool // synthetic ID=0 bucket is appended
+	}{
+		{"RFC3339 current hour", "", 8, 4, true, false},
+		{"RFC3339Nano current hour", "", 8, 4, true, false},
+		{"RFC3339Nano current hour with fraction", "", 8, 4, true, false},
+		{"legacy SQL layout current hour", "", 8, 4, true, false},
+		{"RFC3339 other hour", "", 8, 4, false, true},
+		{"legacy SQL layout other hour", "", 8, 4, false, true},
+		{"unparseable value", "not-a-timestamp", 8, 4, false, true},
+		{"empty value", "", 8, 4, false, true},
+		{"zero pending no-op", "", 0, 0, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			nowLocal := now.In(time.Local)
+			// wallHour is the current local wall hour stamped as UTC, the exact
+			// shape the SQLite driver returns for a stored local-hour row.
+			wallHour := func(h int) time.Time {
+				return time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), h, 0, 0, 0, time.UTC)
+			}
+			recordedAt := tt.recordedAt
+			switch tt.name {
+			case "RFC3339 current hour":
+				recordedAt = wallHour(nowLocal.Hour()).Format(time.RFC3339)
+			case "RFC3339Nano current hour":
+				recordedAt = wallHour(nowLocal.Hour()).Format(time.RFC3339Nano)
+			case "RFC3339Nano current hour with fraction":
+				recordedAt = wallHour(nowLocal.Hour()).Add(250 * time.Millisecond).Format(time.RFC3339Nano)
+			case "legacy SQL layout current hour":
+				recordedAt = nowLocal.Format("2006-01-02 15:04:05")
+			case "RFC3339 other hour":
+				recordedAt = wallHour(nowLocal.Hour() - 1).Format(time.RFC3339)
+			case "legacy SQL layout other hour":
+				recordedAt = nowLocal.Add(-time.Hour).Format("2006-01-02 15:04:05")
+			}
+
+			in := []TrafficLog{{ID: 7, SiteID: 3, BytesIn: 10, BytesOut: 5, RecordedAt: recordedAt}}
+			out := mergePendingIntoLogs(in, 3, tt.pendingIn, tt.pendingOut)
+
+			if tt.wantMerge {
+				if len(out) != 1 {
+					t.Fatalf("len(out) = %d, want the existing bucket merged; got %+v", len(out), out)
+				}
+				if out[0].ID != 7 || out[0].BytesIn != 18 || out[0].BytesOut != 9 {
+					t.Fatalf("merged bucket = %+v, want ID=7 18/9", out[0])
+				}
+				return
+			}
+			if tt.wantAppend {
+				if len(out) != 2 {
+					t.Fatalf("len(out) = %d, want original plus synthetic bucket; got %+v", len(out), out)
+				}
+				if out[0].ID != 7 || out[0].BytesIn != 10 || out[0].BytesOut != 5 {
+					t.Fatalf("existing bucket mutated = %+v, want 10/5 untouched", out[0])
+				}
+				syn := out[1]
+				if syn.ID != 0 || syn.SiteID != 3 || syn.BytesIn != 8 || syn.BytesOut != 4 {
+					t.Fatalf("synthetic bucket = %+v, want ID=0 site=3 8/4", syn)
+				}
+				if _, err := time.Parse(time.RFC3339, syn.RecordedAt); err != nil {
+					t.Fatalf("synthetic recorded_at %q is not RFC3339: %v", syn.RecordedAt, err)
+				}
+				if !sameTrafficHour(syn.RecordedAt, time.Now()) {
+					t.Fatalf("synthetic recorded_at %q is not the current hour", syn.RecordedAt)
+				}
+				return
+			}
+			if len(out) != 1 || out[0] != in[0] {
+				t.Fatalf("zero pending must be a no-op, got %+v", out)
+			}
+		})
+	}
+}
+
+// mergePendingIntoLogs is only ever allowed to touch the copy it is given
+// (GetTrafficLogs always returns a fresh slice): mutating the returned slice
+// must never leak into the caller's own data.
+func TestMergePendingIntoLogsOnlyMutatesPrivateCopy(t *testing.T) {
+	now := time.Now()
+	nowLocal := now.In(time.Local)
+	wallHour := time.Date(nowLocal.Year(), nowLocal.Month(), nowLocal.Day(), nowLocal.Hour(), 0, 0, 0, time.UTC)
+	src := []TrafficLog{
+		{ID: 1, SiteID: 3, BytesIn: 10, BytesOut: 5, RecordedAt: wallHour.Format(time.RFC3339)},
+		{ID: 2, SiteID: 3, BytesIn: 1, BytesOut: 1, RecordedAt: wallHour.Add(-3 * time.Hour).Format(time.RFC3339)},
+	}
+	work := append([]TrafficLog(nil), src...)
+	out := mergePendingIntoLogs(work, 3, 8, 4)
+	// Pending lands in the current-hour element of the returned copy.
+	if len(out) != 2 || out[0].BytesIn != 18 || out[0].BytesOut != 9 {
+		t.Fatalf("merged result = %+v, want current-hour bucket 18/9", out)
+	}
+	// Caller-side mutation of the result must not touch the caller's original.
+	out[0].BytesIn = 999
+	out[0].BytesOut = 999
+	if src[0].BytesIn != 10 || src[0].BytesOut != 5 || src[1].BytesIn != 1 {
+		t.Fatalf("source slice mutated through the result: %+v", src)
+	}
+}
+
+// In a non-UTC deployment the DB stores local wall-clock hours and the driver
+// stamps them as UTC on read, so matching must compare wall-clock components
+// and the synthetic bucket must carry the current local wall hour as Z. This
+// pins that behavior with the process zone fixed to UTC+8: an RFC3339 row
+// whose hour reads 08:00Z matches a now of 08:30+08, a different wall hour
+// does not, and the synthetic bucket is exactly the local 08:00Z row the next
+// addTraffic will persist.
+func TestMergePendingIntoLogsFixedZoneUTC8(t *testing.T) {
+	savedLocal := time.Local
+	time.Local = time.FixedZone("UTC+8", 8*3600)
+	defer func() { time.Local = savedLocal }()
+
+	now := time.Now().In(time.Local)
+	wallHour := func(h int) time.Time {
+		return time.Date(now.Year(), now.Month(), now.Day(), h, 0, 0, 0, time.UTC)
+	}
+	// RFC3339 08:00Z matches a now of 08:30+08: the stored local hour 08 read
+	// back as Z is the same wall clock, even though the instants differ.
+	if !sameTrafficHour(wallHour(now.Hour()).Format(time.RFC3339), now) {
+		t.Fatalf("RFC3339 %q must match local wall hour %s", wallHour(now.Hour()).Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+	// The legacy local wall-clock row matches by the same wall-clock rule.
+	if !sameTrafficHour(now.Format("2006-01-02 15:04:05"), now) {
+		t.Fatalf("legacy %q must match local wall hour %s", now.Format("2006-01-02 15:04:05"), now.Format(time.RFC3339))
+	}
+	// A different wall hour never matches, regardless of instant proximity.
+	if sameTrafficHour(wallHour(now.Hour()-1).Format(time.RFC3339), now) {
+		t.Fatalf("RFC3339 %q must not match local wall hour %s", wallHour(now.Hour()-1).Format(time.RFC3339), now.Format(time.RFC3339))
+	}
+
+	// A real current-hour RFC3339 row absorbs pending bytes.
+	in := []TrafficLog{{ID: 5, SiteID: 2, BytesIn: 1, BytesOut: 1, RecordedAt: wallHour(now.Hour()).Format(time.RFC3339)}}
+	out := mergePendingIntoLogs(in, 2, 9, 3)
+	if len(out) != 1 || out[0].ID != 5 || out[0].BytesIn != 10 || out[0].BytesOut != 4 {
+		t.Fatalf("merged bucket = %+v, want ID=5 10/4", out)
+	}
+
+	// The synthetic bucket is the current local wall hour stamped as UTC,
+	// byte-identical to the row the next addTraffic will persist and read back.
+	in = []TrafficLog{{ID: 5, SiteID: 2, BytesIn: 1, BytesOut: 1, RecordedAt: wallHour(now.Hour() - 1).Format(time.RFC3339)}}
+	out = mergePendingIntoLogs(in, 2, 9, 3)
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want original plus synthetic bucket; got %+v", len(out), out)
+	}
+	want := wallHour(now.Hour()).Format(time.RFC3339)
+	if out[1].RecordedAt != want {
+		t.Fatalf("synthetic recorded_at = %q, want %q (local wall hour as Z)", out[1].RecordedAt, want)
+	}
+}
+
+// The global snapshot is one authoritative payload: every DB site overlaid
+// with persistedTraffic + pending for running sites, with unified totals.
+func TestTrafficSnapshotUnifiedPayloadAndTotals(t *testing.T) {
+	app := newTestApp(t)
+	siteA, err := app.db.CreateSite("running-a", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 1024, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	siteB, err := app.db.CreateSite("idle-b", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	app.db.AddTraffic(siteB.ID, 40, 0)
+
+	inst := &ProxyInstance{Site: *siteA, server: &http.Server{}}
+	inst.persistedTraffic.Store(100)
+	inst.bytesIn.Store(30)
+	inst.bytesOut.Store(20)
+	app.pm.proxies[siteA.ID] = inst
+
+	snap, err := app.pm.TrafficSnapshot()
+	if err != nil {
+		t.Fatalf("TrafficSnapshot: %v", err)
+	}
+	if snap.TotalSites != 2 || snap.OnlineSites != 2 || snap.RunningSites != 1 {
+		t.Fatalf("counts = total:%d online:%d running:%d, want 2/2/1", snap.TotalSites, snap.OnlineSites, snap.RunningSites)
+	}
+	if snap.TotalTraffic != 190 {
+		t.Fatalf("total_traffic = %d, want 190 (100+30+20 persisted+pending + 40 DB)", snap.TotalTraffic)
+	}
+	a := findLiveSite(t, snap, siteA.ID)
+	if !a.Running || a.TrafficQuota != 1024 || a.PersistedTraffic != 100 || a.BytesIn != 30 || a.BytesOut != 20 || a.TrafficUsed != 150 {
+		t.Fatalf("running site entry = %+v, want running quota=1024 persisted=100 in=30 out=20 used=150", a)
+	}
+	b := findLiveSite(t, snap, siteB.ID)
+	if b.Running || b.PersistedTraffic != 40 || b.BytesIn != 0 || b.BytesOut != 0 || b.TrafficUsed != 40 {
+		t.Fatalf("idle site entry = %+v, want not running persisted=40 used=40", b)
+	}
+}
+
+// The legacy endpoint keeps the plain TrafficLog[] shape (with live-merged
+// current hour) and returns [] for unknown sites; the /snapshot endpoint
+// returns the {snapshot, logs} envelope and 404 for unknown sites.
+func TestHandleTrafficLegacyArrayAndSnapshotEnvelope(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("shape", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(40)
+	inst.bytesOut.Store(10)
+	app.pm.proxies[site.ID] = inst
+
+	// Legacy: plain array, live-merged current hour.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/traffic/"+jsonNumber64(site.ID)+"?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("legacy status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var logs []TrafficLog
+	if err := json.Unmarshal(rr.Body.Bytes(), &logs); err != nil {
+		t.Fatalf("legacy body is not a TrafficLog array: %v body=%s", err, rr.Body.String())
+	}
+	if len(logs) != 1 || logs[0].ID != 0 || logs[0].BytesIn != 40 || logs[0].BytesOut != 10 {
+		t.Fatalf("legacy logs = %+v, want synthetic current-hour bucket 40/10", logs)
+	}
+
+	// Envelope: {snapshot, logs} with the same live state.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/traffic/"+jsonNumber64(site.ID)+"/snapshot?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("snapshot status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	body := decodeBody(t, rr)
+	snap := mustMapValue(t, body, "snapshot")
+	if mustNumberValue(t, snap, "traffic_used") != 50 || mustNumberValue(t, snap, "persisted_traffic") != 0 || mustNumberValue(t, snap, "bytes_in") != 40 || mustNumberValue(t, snap, "bytes_out") != 10 {
+		t.Fatalf("envelope snapshot = %v, want used=50 persisted=0 in=40 out=10", snap)
+	}
+	if !mustBoolValue(t, snap, "running") {
+		t.Fatal("envelope snapshot must report the site as running")
+	}
+	envLogs, ok := body["logs"].([]interface{})
+	if !ok || len(envLogs) != 1 {
+		t.Fatalf("envelope logs = %v, want one merged bucket", body["logs"])
+	}
+
+	// Legacy unknown site: empty array, not an error.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/traffic/999999?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("legacy missing-site status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	logs = nil
+	if err := json.Unmarshal(rr.Body.Bytes(), &logs); err != nil || len(logs) != 0 {
+		t.Fatalf("legacy missing-site body = %q, want []", rr.Body.String())
+	}
+
+	// Envelope unknown site: 404.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/traffic/999999/snapshot?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("snapshot missing-site status = %d, want 404; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// StopSite fails closed when the flush cannot persist: the instance stays
+// registered, its pending bytes stay intact, and a later retry succeeds.
+func TestStopSiteFailClosedOnFlushError(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("stopclosed", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(50)
+	inst.bytesOut.Store(25)
+	app.pm.proxies[site.ID] = inst
+
+	setDBReadonly(t, app, true)
+	if err := app.pm.StopSite(site.ID); err == nil {
+		t.Fatal("StopSite succeeded against a read-only database")
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("StopSite dropped the instance despite the failed flush")
+	}
+	if got := inst.bytesIn.Load(); got != 50 {
+		t.Fatalf("bytesIn after failed stop = %d, want 50", got)
+	}
+	if got := inst.bytesOut.Load(); got != 25 {
+		t.Fatalf("bytesOut after failed stop = %d, want 25", got)
+	}
+	if got := inst.persistedTraffic.Load(); got != 0 {
+		t.Fatalf("persistedTraffic after failed stop = %d, want 0", got)
+	}
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 0 {
+		t.Fatalf("traffic_used after failed stop = %d, want 0", reloaded.TrafficUsed)
+	}
+
+	// Same stop succeeds once the DB recovers and persists exactly once.
+	setDBReadonly(t, app, false)
+	if err := app.pm.StopSite(site.ID); err != nil {
+		t.Fatalf("StopSite retry: %v", err)
+	}
+	if app.pm.IsRunning(site.ID) {
+		t.Fatal("instance still registered after successful stop")
+	}
+	reloaded, err = app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 75 {
+		t.Fatalf("traffic_used after stop retry = %d, want 75", reloaded.TrafficUsed)
+	}
+}
+
+// DELETE only deletes the DB row when the stop (and its flush) succeeded; a
+// failed flush aborts with the instance and the row intact.
+func TestDeleteSiteAbortsWhenFlushFails(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("delclosed", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(10)
+	inst.bytesOut.Store(5)
+	app.pm.proxies[site.ID] = inst
+
+	setDBReadonly(t, app, true)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sites/"+jsonNumber64(site.ID), nil)
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("DELETE status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	if _, err := app.db.GetSite(site.ID); err != nil {
+		t.Fatal("site row was deleted despite the failed flush")
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("instance was stopped despite the failed flush")
+	}
+	if got := inst.bytesIn.Load(); got != 10 {
+		t.Fatalf("bytesIn after failed delete = %d, want 10", got)
+	}
+	setDBReadonly(t, app, false)
+}
+
+// Replacing a running instance fails closed when the flush cannot persist: the
+// old instance and its pending bytes stay registered and the new instance's
+// freshly bound listener is released.
+func TestStartSiteReplaceFailClosedAndReleasesNewListener(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("replaceclosed", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(site.ListenPort)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("site did not register a proxy instance")
+	}
+	inst.bytesIn.Store(60)
+	inst.bytesOut.Store(40)
+
+	moved := *site
+	moved.ListenPort = freePort(t)
+	releasePort(moved.ListenPort)
+	setDBReadonly(t, app, true)
+	if err := app.pm.StartSite(moved); err == nil {
+		t.Fatal("replace succeeded against a read-only database")
+	}
+	setDBReadonly(t, app, false)
+
+	// The old instance is still the registered one, with pending intact.
+	app.pm.mu.RLock()
+	still := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if still != inst {
+		t.Fatal("old instance was replaced despite the failed flush")
+	}
+	if got := inst.bytesIn.Load(); got != 60 {
+		t.Fatalf("bytesIn after failed replace = %d, want 60", got)
+	}
+	if got := inst.bytesOut.Load(); got != 40 {
+		t.Fatalf("bytesOut after failed replace = %d, want 40", got)
+	}
+	if got := inst.persistedTraffic.Load(); got != 0 {
+		t.Fatalf("persistedTraffic after failed replace = %d, want 0", got)
+	}
+
+	// The new listener was released: the new port binds again immediately.
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", moved.ListenPort))
+	if err != nil {
+		t.Fatalf("new listener was not released after failed replace: %v", err)
+	}
+	ln.Close()
+}
+
+// Concurrent flush/snapshot/history must never expose a torn per-instance
+// view (traffic_used != persisted + pending), and every byte written ends up
+// persisted exactly once. Run with -race.
+func TestConcurrentFlushSnapshotAndHistoryStayConsistent(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("race", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	app.pm.proxies[site.ID] = inst
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: accumulates 300 * 10 = 3000 pending bytes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 300; i++ {
+			inst.bytesIn.Add(7)
+			inst.bytesOut.Add(3)
+			time.Sleep(time.Microsecond)
+		}
+		close(stop)
+	}()
+
+	// Flusher: keeps draining pending into the DB until the writer stops.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				app.pm.FlushTraffic()
+				time.Sleep(100 * time.Microsecond)
+			}
+		}
+	}()
+
+	// Snapshotter: every observed per-site view must satisfy the invariant.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			snap, err := app.pm.TrafficSnapshot()
+			if err != nil {
+				t.Errorf("TrafficSnapshot: %v", err)
+				return
+			}
+			for _, st := range snap.LiveSites {
+				if st.ID == site.ID && st.TrafficUsed != st.PersistedTraffic+st.BytesIn+st.BytesOut {
+					t.Errorf("torn snapshot view: used=%d persisted=%d in=%d out=%d", st.TrafficUsed, st.PersistedTraffic, st.BytesIn, st.BytesOut)
+					return
+				}
+			}
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	// Historian: same invariant on the single-site envelope.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h, err := app.pm.SiteTrafficHistory(*site, 24)
+			if err != nil {
+				t.Errorf("SiteTrafficHistory: %v", err)
+				return
+			}
+			if h.Snapshot.TrafficUsed != h.Snapshot.PersistedTraffic+h.Snapshot.BytesIn+h.Snapshot.BytesOut {
+				t.Errorf("torn history view: used=%d persisted=%d in=%d out=%d", h.Snapshot.TrafficUsed, h.Snapshot.PersistedTraffic, h.Snapshot.BytesIn, h.Snapshot.BytesOut)
+				return
+			}
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Conservation: the final flush persists every written byte exactly once.
+	app.pm.FlushTraffic()
+	if got := inst.persistedTraffic.Load(); got != 3000 {
+		t.Fatalf("persistedTraffic after concurrent run = %d, want 3000", got)
+	}
+	if got := inst.bytesIn.Load() + inst.bytesOut.Load(); got != 0 {
+		t.Fatalf("pending after concurrent run = %d, want 0", got)
+	}
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 3000 {
+		t.Fatalf("traffic_used after concurrent run = %d, want 3000", reloaded.TrafficUsed)
+	}
+}
+
+// The read-only traffic paths (legacy, envelope, dashboard, overview, SSE)
+// must never write the database: they all succeed while the DB rejects writes.
+func TestTrafficReadsDoNotWriteDatabase(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("readonly", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(11)
+	inst.bytesOut.Store(9)
+	app.pm.proxies[site.ID] = inst
+
+	setDBReadonly(t, app, true)
+	defer setDBReadonly(t, app, false)
+
+	// Legacy array endpoint.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/traffic/"+jsonNumber64(site.ID)+"?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("legacy status = %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Envelope endpoint; the live pending shows up in the read-only view.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/traffic/"+jsonNumber64(site.ID)+"/snapshot?hours=24", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("envelope status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	body := decodeBody(t, rr)
+	snap := mustMapValue(t, body, "snapshot")
+	if mustNumberValue(t, snap, "bytes_in") != 11 || mustNumberValue(t, snap, "traffic_used") != 20 {
+		t.Fatalf("read-only envelope snapshot = %v, want in=11 used=20", snap)
+	}
+
+	// Dashboard and overview share the unified snapshot payload.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/dashboard", nil)
+	app.handleDashboard(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("dashboard status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	body = decodeBody(t, rr)
+	if mustNumberValue(t, body, "total_traffic") != 20 || mustNumberValue(t, body, "running_sites") != 1 {
+		t.Fatalf("dashboard payload = %v, want total_traffic=20 running_sites=1", body)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/traffic/overview", nil)
+	app.handleTraffic(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("overview status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	body = decodeBody(t, rr)
+	if mustNumberValue(t, body, "total_traffic") != 20 {
+		t.Fatalf("overview payload = %v, want total_traffic=20", body)
+	}
+
+	// SSE event frame.
+	rr = httptest.NewRecorder()
+	if err := app.sendSSEEvent(rr, rr); err != nil {
+		t.Fatalf("sendSSEEvent against a read-only DB: %v", err)
+	}
+	if !strings.HasPrefix(rr.Body.String(), "data: ") || !strings.Contains(rr.Body.String(), "\"total_traffic\":20") {
+		t.Fatalf("SSE frame = %q, want data: frame with total_traffic 20", rr.Body.String())
+	}
+
+	// And the DB really is untouched: no logs, no usage.
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 0 {
+		t.Fatalf("traffic_used = %d, want 0 (reads must not write)", reloaded.TrafficUsed)
+	}
+	logs, err := app.db.GetTrafficLogs(site.ID, 24)
+	if err != nil {
+		t.Fatalf("GetTrafficLogs: %v", err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("traffic_logs = %+v, want empty (reads must not write)", logs)
+	}
+}
+
+// Toggle-off stops (and flushes) before flipping the flag; a failed flush
+// aborts with the flag still on and the instance still running.
+func TestToggleOffAbortsWhenFlushFails(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("togglestop", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *site, server: &http.Server{}}
+	inst.bytesIn.Store(20)
+	app.pm.proxies[site.ID] = inst
+
+	setDBReadonly(t, app, true)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/"+jsonNumber64(site.ID)+"/toggle", nil)
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("toggle status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	setDBReadonly(t, app, false)
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if !reloaded.Enabled {
+		t.Fatal("toggle-off flipped the flag despite the failed flush")
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("toggle-off stopped the instance despite the failed flush")
+	}
+	if got := inst.bytesIn.Load(); got != 20 {
+		t.Fatalf("bytesIn after failed toggle = %d, want 20", got)
+	}
+}
+
+// The PUT pre-stop runs before the DB update; a failed flush aborts with the
+// old config still in the DB and the old instance still running.
+func TestSiteUpdateAbortsWhenPreStopFlushFails(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("prestop", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(site.ListenPort)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("site did not register a proxy instance")
+	}
+	inst.bytesIn.Store(33)
+
+	// Same listen_port -> the update path pre-stops; the flush fails -> abort.
+	body := strings.NewReader(`{"name":"renamed","listen_port":` + jsonNumber(site.ListenPort) + `,"target_url":"http://127.0.0.1:8096","ua_mode":"infuse"}`)
+	setDBReadonly(t, app, true)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(site.ID), body)
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("PUT status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	setDBReadonly(t, app, false)
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.Name != "prestop" {
+		t.Fatalf("name = %q, want the old config preserved", reloaded.Name)
+	}
+	if !reloaded.Enabled {
+		t.Fatal("PUT disabled the site despite the failed flush")
+	}
+	if reloaded.TrafficUsed != 0 {
+		t.Fatalf("traffic_used = %d, want 0", reloaded.TrafficUsed)
+	}
+	app.pm.mu.RLock()
+	still := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if still != inst {
+		t.Fatal("pre-stop replaced the instance despite the failed flush")
+	}
+	if got := inst.bytesIn.Load(); got != 33 {
+		t.Fatalf("bytesIn after failed PUT = %d, want 33", got)
+	}
+}
+
+// GET /api/sites overlays the authoritative live traffic (persisted + pending)
+// for running sites while preserving the exact Site JSON shape plus the
+// running flag; the read never writes the database, so pending bytes appear
+// before any flush.
+func TestHandleSitesGETOverlaysLiveTrafficWithoutDBWrite(t *testing.T) {
+	app := newTestApp(t)
+	running, err := app.db.CreateSite("live", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	stopped, err := app.db.CreateSite("stopped", freePort(t), "http://127.0.0.1:8097", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+
+	inst := &ProxyInstance{Site: *running, server: &http.Server{}}
+	inst.persistedTraffic.Store(100)
+	inst.bytesIn.Store(11)
+	inst.bytesOut.Store(9)
+	app.pm.proxies[running.ID] = inst
+
+	// The GET must succeed while the DB rejects every write, proving the live
+	// overlay is a pure read.
+	setDBReadonly(t, app, true)
+	defer setDBReadonly(t, app, false)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sites", nil)
+	app.handleSites(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /api/sites status = %d; body=%s", rr.Code, rr.Body.String())
+	}
+
+	// The response rows keep exactly the Site JSON fields plus "running": the
+	// overlay may only change traffic_used, never add per-component fields.
+	var raw []map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode /api/sites: %v", err)
+	}
+	expectedKeys := map[string]bool{
+		"id": true, "name": true, "listen_port": true, "target_url": true,
+		"playback_target_url": true, "playback_mode": true, "stream_hosts": true,
+		"ua_mode": true, "custom_user_agent": true, "custom_client": true,
+		"custom_version": true, "enabled": true, "traffic_quota": true,
+		"traffic_used": true, "speed_limit": true, "created_at": true,
+		"updated_at": true, "running": true,
+	}
+	if len(raw) != 2 {
+		t.Fatalf("GET /api/sites returned %d rows, want 2: %s", len(raw), rr.Body.String())
+	}
+	for i, row := range raw {
+		if len(row) != len(expectedKeys) {
+			t.Fatalf("row %d has %d fields, want %d: %v", i, len(row), len(expectedKeys), row)
+		}
+		for key := range row {
+			if !expectedKeys[key] {
+				t.Fatalf("row %d has unexpected field %q", i, key)
+			}
+		}
+	}
+
+	var rows []struct {
+		ID          int64 `json:"id"`
+		Running     bool  `json:"running"`
+		Enabled     bool  `json:"enabled"`
+		TrafficUsed int64 `json:"traffic_used"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode /api/sites rows: %v", err)
+	}
+	var liveRow, stoppedRow *struct {
+		ID          int64 `json:"id"`
+		Running     bool  `json:"running"`
+		Enabled     bool  `json:"enabled"`
+		TrafficUsed int64 `json:"traffic_used"`
+	}
+	for i := range rows {
+		switch rows[i].ID {
+		case running.ID:
+			liveRow = &rows[i]
+		case stopped.ID:
+			stoppedRow = &rows[i]
+		}
+	}
+	if liveRow == nil || stoppedRow == nil {
+		t.Fatalf("expected both sites in the response: %+v", rows)
+	}
+	if liveRow.TrafficUsed != 120 {
+		t.Fatalf("live traffic_used = %d, want 120 (100 persisted + 11 + 9 pending)", liveRow.TrafficUsed)
+	}
+	if !liveRow.Running {
+		t.Fatal("running site must be flagged running")
+	}
+	if !liveRow.Enabled {
+		t.Fatal("non-traffic fields must keep their DB values")
+	}
+	if stoppedRow.TrafficUsed != 0 || stoppedRow.Running {
+		t.Fatalf("stopped site row = traffic_used %d running %v, want 0/false", stoppedRow.TrafficUsed, stoppedRow.Running)
+	}
+
+	// The read left the DB untouched: no flush, no logs.
+	reloaded, err := app.db.GetSite(running.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.TrafficUsed != 0 {
+		t.Fatalf("DB traffic_used = %d, want 0 (the read must not flush)", reloaded.TrafficUsed)
+	}
+	logs, err := app.db.GetTrafficLogs(running.ID, 24)
+	if err != nil {
+		t.Fatalf("GetTrafficLogs: %v", err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("traffic_logs = %+v, want empty (the read must not write)", logs)
+	}
+}
+
+// A PUT whose record update fails after a successful pre-stop must restart the
+// old instance: the enabled row is never left without a running proxy. The
+// failure is injected with a trigger that aborts name updates only, so the
+// pre-stop flush (which updates traffic_used, not name) still succeeds - the
+// granularity query_only cannot express.
+func TestSiteUpdateRestartsPreStoppedInstanceWhenRecordUpdateFails(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	site, err := app.db.CreateSite("rename-me", port, "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(port)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("site did not register a proxy instance")
+	}
+	inst.bytesIn.Store(33)
+
+	execTestSQL(t, app, "CREATE TRIGGER block_rename BEFORE UPDATE OF name ON sites BEGIN SELECT RAISE(ABORT, 'rename blocked'); END;")
+	defer execTestSQL(t, app, "DROP TRIGGER block_rename")
+
+	// Same listen_port -> the update path pre-stops; the flush succeeds but the
+	// record update (which sets name) is aborted.
+	body := strings.NewReader(`{"name":"renamed","listen_port":` + jsonNumber(site.ListenPort) + `,"target_url":"http://127.0.0.1:8096","ua_mode":"infuse"}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(site.ID), body)
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("PUT status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "rename blocked") {
+		t.Fatalf("PUT error must report the record update failure: %s", rr.Body.String())
+	}
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if reloaded.Name != "rename-me" {
+		t.Fatalf("name = %q, want the old config preserved", reloaded.Name)
+	}
+	if !reloaded.Enabled {
+		t.Fatal("PUT disabled the site despite the failed record update")
+	}
+	if reloaded.TrafficUsed != 33 {
+		t.Fatalf("traffic_used = %d, want 33 (the pre-stop flush persisted pending bytes)", reloaded.TrafficUsed)
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("the pre-stopped instance was not restarted after the failed record update")
+	}
+	app.pm.mu.RLock()
+	restarted := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if restarted == nil || restarted == inst {
+		t.Fatal("expected a fresh instance for the restored site")
+	}
+	if got := restarted.persistedTraffic.Load(); got != 33 {
+		t.Fatalf("restarted persistedTraffic = %d, want 33", got)
+	}
+	if got := restarted.bytesIn.Load(); got != 0 {
+		t.Fatalf("restarted bytesIn = %d, want 0", got)
+	}
+}
+
+// DELETE restarts the stopped enabled site when the row deletion fails: the
+// instance is never left stopped while the enabled row survives. The failure
+// is injected with a trigger that aborts row deletion after the stop flush.
+func TestDeleteSiteRestartsInstanceWhenDeleteFails(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	site, err := app.db.CreateSite("del-restore", port, "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(port)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("site did not register a proxy instance")
+	}
+	inst.bytesIn.Store(10)
+	inst.bytesOut.Store(5)
+
+	execTestSQL(t, app, "CREATE TRIGGER block_delete BEFORE DELETE ON sites BEGIN SELECT RAISE(ABORT, 'delete blocked'); END;")
+	defer execTestSQL(t, app, "DROP TRIGGER block_delete")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sites/"+jsonNumber64(site.ID), nil)
+	app.handleSiteByID(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("DELETE status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "delete blocked") {
+		t.Fatalf("DELETE error must report the delete failure: %s", rr.Body.String())
+	}
+
+	reloaded, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite: %v", err)
+	}
+	if !reloaded.Enabled {
+		t.Fatal("site row was mutated despite the failed delete")
+	}
+	if reloaded.TrafficUsed != 15 {
+		t.Fatalf("traffic_used = %d, want 15 (the stop flush persisted pending bytes)", reloaded.TrafficUsed)
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("the stopped instance was not restarted after the failed delete")
+	}
+	app.pm.mu.RLock()
+	restarted := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if restarted == nil || restarted == inst {
+		t.Fatal("expected a fresh instance for the surviving row")
+	}
+	if got := restarted.persistedTraffic.Load(); got != 15 {
+		t.Fatalf("restarted persistedTraffic = %d, want 15", got)
+	}
+	if in, out := restarted.bytesIn.Load(), restarted.bytesOut.Load(); in != 0 || out != 0 {
+		t.Fatalf("restarted pending counters = in:%d out:%d, want 0/0", in, out)
 	}
 }
 

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -1,0 +1,401 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const STATIC_JS = path.join(__dirname, '..', 'web', 'static', 'js');
+
+function readScript(relativePath) {
+  return fs.readFileSync(path.join(STATIC_JS, relativePath), 'utf8');
+}
+
+function loadInto(sandbox, ...relativePaths) {
+  for (const relativePath of relativePaths) {
+    vm.runInContext(readScript(relativePath), sandbox, { filename: relativePath });
+  }
+}
+
+function okJson(body) {
+  return { status: 200, ok: true, statusText: 'OK', json: async () => body };
+}
+
+function makeCanvasContext() {
+  return {
+    scale() {}, clearRect() {}, beginPath() {}, moveTo() {}, lineTo() {},
+    quadraticCurveTo() {}, stroke() {}, fill() {}, save() {}, restore() {},
+    closePath() {}, fillText() {},
+    createLinearGradient() { return { addColorStop() {} }; },
+  };
+}
+
+function makeElement(id, opts) {
+  opts = opts || {};
+  return {
+    id,
+    value: opts.value !== undefined ? opts.value : '',
+    innerHTML: '',
+    textContent: '',
+    style: {},
+    hidden: false,
+    required: false,
+    disabled: false,
+    onchange: null,
+    className: '',
+    dataset: {},
+    classList: { add() {}, remove() {}, toggle() {} },
+    setAttribute() {},
+    addEventListener() {},
+    focus() {},
+    getContext() { return makeCanvasContext(); },
+    parentElement: { clientWidth: 800 },
+    isConnected: true,
+    scrollTop: 0,
+    width: undefined,
+    height: undefined,
+  };
+}
+
+function makeDocument(elementsById) {
+  const elements = new Map(Object.entries(elementsById || {}));
+  return {
+    getElementById(id) { return elements.get(id) || null; },
+    querySelectorAll() { return []; },
+    addEventListener() {},
+    body: { classList: { add() {}, remove() {} } },
+    activeElement: null,
+  };
+}
+
+// Loads api.js + dashboard.js (for formatBytes) + traffic.js into one sandbox,
+// the way index.html evaluates them as classic <script> tags sharing a global.
+function makeTrafficHarness(options) {
+  options = options || {};
+  const elements = {
+    'page-traffic': makeElement('page-traffic'),
+    'traffic-site-select': makeElement('traffic-site-select', { value: '1' }),
+    'traffic-hours-select': makeElement('traffic-hours-select', { value: '24' }),
+    'traffic-totals': makeElement('traffic-totals'),
+    trafficChart: makeElement('trafficChart'),
+  };
+
+  const intervals = [];
+  const cleared = [];
+  const calls = [];
+  let nextTimerId = 1;
+  let resizeListeners = 0;
+
+  const sandbox = {
+    window: {
+      addEventListener(name) { if (name === 'resize') resizeListeners++; },
+      devicePixelRatio: 1,
+    },
+    document: makeDocument(elements),
+    Toast: { error() {}, success() {}, info() {} },
+    console,
+    fetch: async (url, opts) => {
+      calls.push(String(url));
+      if (options.fetch) return options.fetch(url, opts);
+      return okJson({});
+    },
+    setInterval(cb, ms) { const id = nextTimerId++; intervals.push({ id, ms, cb }); return id; },
+    clearInterval(id) { cleared.push(id); },
+    setTimeout() { return 0; },
+    clearTimeout() {},
+    confirm: () => true,
+    Router: { current: 'traffic' },
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js', 'pages/traffic.js');
+  return { sandbox, elements, intervals, cleared, calls, resizeListeners };
+}
+
+test('getTrafficSnapshot calls the additive snapshot endpoint; getTraffic is kept', async () => {
+  const calls = [];
+  const sandbox = {
+    window: {},
+    fetch: async (url) => { calls.push(String(url)); return okJson({ snapshot: { traffic_used: 7 }, logs: [] }); },
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js');
+
+  const data = await vm.runInContext('API.getTrafficSnapshot(7, 24)', sandbox);
+  assert.equal(calls[0], '/api/traffic/7/snapshot?hours=24');
+  assert.equal(data.snapshot.traffic_used, 7);
+  assert.deepEqual(data.logs, []);
+
+  await vm.runInContext('API.getTraffic(7, 24)', sandbox);
+  assert.equal(calls[1], '/api/traffic/7?hours=24', 'legacy getTraffic must remain available unchanged');
+
+  await vm.runInContext('API.getTrafficSnapshot(3)', sandbox);
+  assert.equal(calls[2], '/api/traffic/3/snapshot?hours=24', 'hours must default to 24');
+});
+
+test('traffic page paints totals from the snapshot and the chart from merged logs in one request', async () => {
+  const recordedAt = new Date(Date.now() - 3600000).toISOString();
+  const h = makeTrafficHarness({
+    fetch: async (url) => {
+      if (String(url) === '/api/traffic/1/snapshot?hours=24') {
+        return okJson({
+          snapshot: {
+            id: 1, name: 'Alpha', running: true, traffic_used: 1000000, traffic_quota: 5000000,
+            persisted_traffic: 0, bytes_in: 1000000, bytes_out: 0, requests: 3,
+          },
+          logs: [{ id: 9, site_id: 1, bytes_in: 400000, bytes_out: 600000, recorded_at: recordedAt }],
+        });
+      }
+      return okJson({});
+    },
+  });
+
+  await vm.runInContext('loadTrafficChart()', h.sandbox);
+
+  assert.deepEqual(
+    h.calls,
+    ['/api/traffic/1/snapshot?hours=24'],
+    'the chart must load from a single snapshot request, not a second listSites call',
+  );
+  const totals = h.elements['traffic-totals'].innerHTML;
+  assert.ok(totals.includes(h.sandbox.formatBytes(400000)), 'inbound total must come from the returned logs');
+  assert.ok(totals.includes(h.sandbox.formatBytes(600000)), 'outbound total must come from the returned logs');
+  assert.ok(totals.includes(h.sandbox.formatBytes(1000000)), 'cumulative total must come from snapshot.traffic_used');
+  assert.ok(
+    totals.includes('额度') && totals.includes(h.sandbox.formatBytes(5000000)),
+    'quota line must come from snapshot.traffic_quota',
+  );
+  assert.equal(h.elements.trafficChart.width, 800, 'chart must be drawn from the merged logs');
+});
+
+test('no quota line is rendered when the site has no quota', async () => {
+  const h = makeTrafficHarness({
+    fetch: async (url) => {
+      if (String(url) === '/api/traffic/1/snapshot?hours=24') {
+        return okJson({ snapshot: { traffic_used: 42, traffic_quota: 0 }, logs: [] });
+      }
+      return okJson({});
+    },
+  });
+
+  await vm.runInContext('loadTrafficChart()', h.sandbox);
+
+  const totals = h.elements['traffic-totals'].innerHTML;
+  assert.ok(totals.includes(h.sandbox.formatBytes(42)), 'cumulative total must still render');
+  assert.ok(!totals.includes('额度'), 'a zero quota must not render a quota line');
+});
+
+test('traffic refresh timer ticks every 15s and only while the traffic route is active', () => {
+  const h = makeTrafficHarness();
+  vm.runInContext('startTrafficRefresh()', h.sandbox);
+  assert.equal(h.intervals.length, 1);
+  assert.equal(h.intervals[0].ms, 15000);
+
+  const tick = h.intervals[0].cb;
+  h.sandbox.Router.current = 'dashboard';
+  tick();
+  assert.equal(h.calls.length, 0, 'timer must not fetch while another route is active');
+
+  h.sandbox.Router.current = 'traffic';
+  tick();
+  assert.equal(h.calls.length, 1);
+  assert.equal(h.calls[0], '/api/traffic/1/snapshot?hours=24');
+
+  vm.runInContext('stopTrafficRefresh()', h.sandbox);
+  assert.deepEqual(h.cleared, [h.intervals[0].id], 'stopTrafficRefresh must clear the interval');
+});
+
+test('renderTraffic restarts the timer and never re-registers the resize listener', async () => {
+  const h = makeTrafficHarness({
+    fetch: async (url) => {
+      if (String(url) === '/api/sites') return okJson([{ id: 1, name: 'Alpha' }]);
+      if (String(url) === '/api/traffic/1/snapshot?hours=24') return okJson({ snapshot: { traffic_used: 0, traffic_quota: 0 }, logs: [] });
+      return okJson({});
+    },
+  });
+  assert.equal(h.resizeListeners, 1, 'resize must be registered once when the script loads');
+
+  await vm.runInContext('renderTraffic()', h.sandbox);
+  assert.equal(h.intervals.length, 1);
+  assert.equal(h.intervals[0].ms, 15000);
+
+  await vm.runInContext('renderTraffic()', h.sandbox);
+  assert.equal(h.intervals.length, 2);
+  assert.deepEqual(h.cleared, [h.intervals[0].id], 'a re-render must stop the previous timer before starting a new one');
+  assert.equal(h.resizeListeners, 1, 're-rendering must not add another resize listener');
+});
+
+test('leaving the traffic route stops the refresh timer; staying keeps it', () => {
+  const cleared = [];
+  let nextTimerId = 1;
+  const sandbox = {
+    window: { addEventListener() {} },
+    document: {
+      getElementById() { return null; },
+      querySelectorAll() { return []; },
+    },
+    location: { hash: '#traffic' },
+    console,
+    setInterval() { return nextTimerId++; },
+    clearInterval(id) { cleared.push(id); },
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'pages/traffic.js', 'router.js');
+
+  vm.runInContext('Router.resolve()', sandbox);
+  assert.equal(vm.runInContext('Router.current', sandbox), 'traffic');
+  vm.runInContext('startTrafficRefresh()', sandbox);
+  const timerId = nextTimerId - 1;
+
+  sandbox.location.hash = '#traffic';
+  vm.runInContext('Router.resolve()', sandbox);
+  assert.deepEqual(cleared, [], 'staying on traffic must keep the timer alive');
+
+  sandbox.location.hash = '#sites';
+  vm.runInContext('Router.resolve()', sandbox);
+  assert.deepEqual(cleared, [timerId], 'leaving traffic must stop the refresh timer');
+});
+
+test('logout tears down the traffic refresh timer', async () => {
+  const elementIds = [
+    'page-login', 'app-shell', 'login-footer', 'btn-login', 'setup-token-group',
+    'setup-token-input', 'inp-setup-token', 'modal-overlay', 'modal-close',
+    'loginForm', 'avatar-btn', 'inp-username', 'inp-password',
+  ];
+  const elements = {};
+  const listeners = {};
+  for (const id of elementIds) {
+    const el = makeElement(id);
+    el.addEventListener = (event, cb) => {
+      (listeners[id] = listeners[id] || {})[event] = cb;
+    };
+    elements[id] = el;
+  }
+
+  const calls = [];
+  const cleared = [];
+  let nextTimerId = 1;
+  const sandbox = {
+    window: { addEventListener() {} },
+    document: makeDocument(elements),
+    Toast: { error() {}, success() {}, info() {} },
+    console,
+    confirm: () => true,
+    // app.js assigns window.closeModal but reads the bare global at load time
+    // (modal-close click handler), which this sandbox must provide up front.
+    closeModal() {},
+    fetch: async (url) => { calls.push(String(url)); return okJson({}); },
+    setInterval() { return nextTimerId++; },
+    clearInterval(id) { cleared.push(id); },
+    setTimeout() { return 0; },
+    clearTimeout() {},
+    location: { hash: '#dashboard' },
+  };
+  vm.createContext(sandbox);
+  // app.js runs checkAuth() at load; the stub reports an unauthenticated session.
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js', 'pages/traffic.js', 'app.js');
+
+  vm.runInContext('startTrafficRefresh()', sandbox);
+  const timerId = nextTimerId - 1;
+
+  await listeners['avatar-btn'].click();
+
+  assert.deepEqual(cleared, [timerId], 'logout must stop the traffic refresh timer');
+  assert.ok(calls.includes('/api/auth/logout'), 'logout must POST the session away');
+  assert.equal(vm.runInContext('API.authenticated', sandbox), false);
+});
+
+test('a late snapshot response cannot paint over a different route', async () => {
+  const h = makeTrafficHarness();
+  let resolveFetch;
+  const gate = new Promise(resolve => { resolveFetch = resolve; });
+  h.sandbox.fetch = async () => gate;
+
+  const pending = vm.runInContext('loadTrafficChart()', h.sandbox);
+  h.sandbox.Router.current = 'sites';
+  resolveFetch(okJson({ snapshot: { traffic_used: 999999 }, logs: [] }));
+  await pending;
+
+  assert.equal(h.elements['traffic-totals'].innerHTML, '', 'a response arriving after leaving must not paint totals');
+  assert.equal(h.elements.trafficChart.width, undefined, 'a response arriving after leaving must not draw the chart');
+});
+
+test('a late snapshot response cannot paint over a different site selection', async () => {
+  const h = makeTrafficHarness();
+  let resolveFetch;
+  const gate = new Promise(resolve => { resolveFetch = resolve; });
+  h.sandbox.fetch = async () => gate;
+
+  const pending = vm.runInContext('loadTrafficChart()', h.sandbox);
+  h.elements['traffic-site-select'].value = '2';
+  resolveFetch(okJson({ snapshot: { traffic_used: 999999 }, logs: [] }));
+  await pending;
+
+  assert.equal(h.elements['traffic-totals'].innerHTML, '', 'a response for the old selection must not paint');
+  assert.equal(h.elements.trafficChart.width, undefined);
+});
+
+test('site list responses arriving after leaving the route are dropped', async () => {
+  const h = makeTrafficHarness();
+  let resolveFetch;
+  const gate = new Promise(resolve => { resolveFetch = resolve; });
+  h.sandbox.fetch = async () => gate;
+
+  const pending = vm.runInContext('loadTrafficSites()', h.sandbox);
+  h.sandbox.Router.current = 'sites';
+  h.sandbox.fetch = async () => { h.calls.push('fetched'); return gate; };
+  resolveFetch(okJson([{ id: 1, name: 'Alpha' }]));
+  await pending;
+
+  assert.equal(h.elements['traffic-site-select'].innerHTML, '', 'sites must not populate after leaving the page');
+  assert.deepEqual(h.calls, [], 'no chart request may follow a dropped site list');
+});
+
+test('site list populates the select and auto-loads the chart for the first site', async () => {
+  const h = makeTrafficHarness({
+    fetch: async (url) => {
+      if (String(url) === '/api/sites') return okJson([{ id: 1, name: 'Alpha' }]);
+      return okJson({ snapshot: { traffic_used: 0, traffic_quota: 0 }, logs: [] });
+    },
+  });
+
+  await vm.runInContext('loadTrafficSites()', h.sandbox);
+
+  assert.ok(h.elements['traffic-site-select'].innerHTML.includes('Alpha'), 'select must be populated with the site name');
+  assert.deepEqual(h.calls, ['/api/sites', '/api/traffic/1/snapshot?hours=24'], 'populating must trigger one chart load');
+});
+
+test('dashboard table paints live traffic_used and the running badge from one /api/sites request', async () => {
+  const elements = {
+    'dash-table': makeElement('dash-table'),
+  };
+  const calls = [];
+  const sandbox = {
+    window: {},
+    document: makeDocument(elements),
+    console,
+    Toast: { error() {}, success() {}, info() {} },
+    fetch: async (url) => {
+      calls.push(String(url));
+      return okJson([
+        { id: 1, name: 'Alpha', target_url: 'http://a.example', ua_mode: 'infuse', listen_port: 8001, running: true, traffic_used: 1048576 },
+        { id: 2, name: 'Beta', target_url: 'http://b.example', ua_mode: 'web', listen_port: 8002, running: false, traffic_used: 0 },
+      ]);
+    },
+    Router: { current: 'dashboard' },
+    setInterval() { return 1; },
+    clearInterval() {},
+    setTimeout() { return 0; },
+    clearTimeout() {},
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js');
+
+  await vm.runInContext('loadDashboardTable()', sandbox);
+
+  assert.deepEqual(calls, ['/api/sites'], 'the dashboard table must load from exactly one /api/sites request');
+  const html = elements['dash-table'].innerHTML;
+  assert.ok(html.includes('Alpha') && html.includes('Beta'), 'every site must be rendered');
+  assert.ok(html.includes(sandbox.formatBytes(1048576)), 'the authoritative traffic_used must be formatted into the row');
+  assert.ok(html.includes('运行中') && html.includes('已停止'), 'the running flag must drive the status badge');
+});

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -66,6 +66,8 @@ const API = {
 
   // Traffic
   getTraffic(siteId, hours) { return this.request('GET', '/api/traffic/' + siteId + '?hours=' + (hours || 24)); },
+  // Live-merged traffic page payload: { snapshot: SiteTraffic, logs: TrafficLog[] }.
+  getTrafficSnapshot(siteId, hours) { return this.request('GET', '/api/traffic/' + siteId + '/snapshot?hours=' + (hours || 24)); },
 
   // UA Profiles
   getProfiles() { return this.request('GET', '/api/ua-profiles'); },

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -121,6 +121,7 @@
   function teardownAppRuntime() {
     stopDashboardRefresh();
     if (typeof stopDashSSE === 'function') stopDashSSE();
+    if (typeof stopTrafficRefresh === 'function') stopTrafficRefresh();
   }
 
   document.getElementById('loginForm').addEventListener('submit', async function(e) {

--- a/web/static/js/pages/traffic.js
+++ b/web/static/js/pages/traffic.js
@@ -31,12 +31,18 @@ function renderTraffic() {
 
   document.getElementById('traffic-site-select').onchange = loadTrafficChart;
   document.getElementById('traffic-hours-select').onchange = loadTrafficChart;
+
+  startTrafficRefresh();
 }
 
 async function loadTrafficSites() {
   try {
     const sites = await API.listSites();
+    // The page may have been left (or re-rendered) while the request was in
+    // flight; only touch the live DOM when traffic is still the active route.
+    if (Router.current !== 'traffic') return;
     const sel = document.getElementById('traffic-site-select');
+    if (!sel) return;
     if (!sites || sites.length === 0) {
       sel.innerHTML = '<option value="">暂无站点</option>';
       return;
@@ -54,9 +60,14 @@ async function loadTrafficChart() {
   if (!siteId) return;
 
   try {
-    const logs = await API.getTraffic(siteId, hours);
-    const sites = await API.listSites();
-    const site = sites.find(s => s.id === parseInt(siteId));
+    // Single {snapshot, logs} request: snapshot carries the live total
+    // (persisted + pending) for the totals cards, logs already include the
+    // current hour's pending bytes merged in, so the chart is live too.
+    const data = await API.getTrafficSnapshot(siteId, hours);
+    if (!data || !trafficChartStillCurrent(siteId, hours)) return;
+
+    const snapshot = data.snapshot || {};
+    const logs = data.logs || [];
 
     // Update totals
     const totalIn = logs.reduce((a, l) => a + (l.bytes_in || 0), 0);
@@ -73,8 +84,8 @@ async function loadTrafficChart() {
       </div>
       <div class="total-card fade-up stagger-5">
         <div class="total-label">累计使用</div>
-        <div class="total-value">${formatBytes(site ? site.traffic_used : 0)}</div>
-        ${site && site.traffic_quota > 0 ? `<div class="total-delta" style="color:var(--white-38)">额度 ${formatBytes(site.traffic_quota)}</div>` : ''}
+        <div class="total-value">${formatBytes(snapshot.traffic_used || 0)}</div>
+        ${snapshot.traffic_quota > 0 ? `<div class="total-delta" style="color:var(--white-38)">额度 ${formatBytes(snapshot.traffic_quota)}</div>` : ''}
       </div>
     `;
 
@@ -82,6 +93,30 @@ async function loadTrafficChart() {
   } catch (e) {
     console.error('Traffic load error:', e);
   }
+}
+
+// A chart request may finish after the user navigated away or switched site/
+// hours; those late responses must not paint over the new page or selection.
+function trafficChartStillCurrent(siteId, hours) {
+  if (Router.current !== 'traffic') return false;
+  const sel = document.getElementById('traffic-site-select');
+  const hoursSel = document.getElementById('traffic-hours-select');
+  return !!sel && !!hoursSel && sel.value === siteId && parseInt(hoursSel.value) === hours;
+}
+
+let trafficRefreshTimer = null;
+
+function startTrafficRefresh() {
+  stopTrafficRefresh();
+  trafficRefreshTimer = setInterval(() => {
+    if (Router.current === 'traffic') loadTrafficChart();
+  }, 15000);
+}
+
+function stopTrafficRefresh() {
+  if (!trafficRefreshTimer) return;
+  clearInterval(trafficRefreshTimer);
+  trafficRefreshTimer = null;
 }
 
 function drawTrafficChart(logs, hours) {

--- a/web/static/js/router.js
+++ b/web/static/js/router.js
@@ -18,6 +18,9 @@ const Router = {
     if (previous === 'dashboard' && hash !== 'dashboard' && typeof stopDashSSE === 'function') {
       stopDashSSE();
     }
+    if (previous === 'traffic' && hash !== 'traffic' && typeof stopTrafficRefresh === 'function') {
+      stopTrafficRefresh();
+    }
 
     this.current = hash;
 


### PR DESCRIPTION
## Summary

Makes live traffic views consistent: a single atomic snapshot endpoint, a per-instance mutex around traffic state transitions, and a fail-closed flush lifecycle. Title is the same as the commit.

## Changes

- **New snapshot endpoint** — `GET /api/traffic/{site_id}/snapshot?hours=N` returns `{ snapshot: SiteTraffic, logs: TrafficLog[] }` in one atomically captured view: the live total (persisted + pending bytes) and the current-hour bucket merged with pending bytes, so the totals cards and the chart describe the same instant.
- **Legacy API compatibility** — `GET /api/traffic/{site_id}` is retained unchanged; the new endpoint is additive, and the merged-log logic preserves the legacy SQL row layout and wall-clock hour semantics (including rows written with a UTC `Z` suffix, matched against the local wall clock via `sameTrafficHour`).
- **Per-instance `trafficMu`** — each site instance owns a `sync.Mutex` serializing flush, single-site history snapshots, and the live overlay inside global snapshots. Lock order is `pm.mu` → `trafficMu`; no nested re-entry. The DB read and the live counters happen under `trafficMu`, so logs and live counters describe the same instant.
- **Fail-closed lifecycle** — a failed flush leaves the instance running with its pending bytes intact; the periodic ticker retries, and on failure the pending counters are restored in full. The trafficMu is held across the swap → DB → persisted-baseline order so a crash between steps cannot lose or double-count bytes.
- **Frontend live timer** — `pages/traffic.js` polls the snapshot endpoint on an interval, guards late responses (`trafficChartStillCurrent`) so they never paint over a newer route/site/hours selection, and `stopTrafficRefresh()` (wired into `router.js` and `app.js`) stops the timer when leaving the traffic page. `api.js` gains `getTrafficSnapshot`.

## Verification evidence

- Real-instance smoke (parent-verified): snapshot/legacy/dashboard/sites views are immediately consistent; toggle flush/restart paths exercised; hour-bucket and non-UTC fixes verified.
- `go test -race` — all green (main_test.go +1232 lines covering snapshot atomicity, wall-clock hour matching, legacy merge, flush failure/restore, lock ordering).
- Node frontend tests — 21/21, including the new `tests/traffic_page.test.js` (401 lines).
- `go mod`, vet (incl. Windows/Darwin targets), `govulncheck`/`gosec`, cross-platform builds, and installer CI — all passed.

## Acknowledgments

The live-traffic approach builds on the real-time traffic idea from [PR #4](https://github.com/snnabb/Meridian/pull/4); no code from that PR was merged here.

## Scope

No merge, tag, or Release is created by this PR; release steps are gated on CI results and follow-up review.
