### PR TITLE
feat: add UA passthrough mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Meridian 把这些事情打包成一个单二进制程序，带管理界面，�
 |------|------|
 | **多站点反代** | 每个站点独立监听端口，独立配置上游地址 |
 | **双上游分流** | 网页/API 和播放/转码流量可分别指向不同上游 |
-| **UA 伪装** | 3 种预设（Infuse / Web / 客户端）或每站自定义身份；HTTP、WebSocket 与受限播放重定向统一改写 |
+| **UA 伪装** | 预设（Infuse / Web / 客户端）、自定义固定身份或透传保留客户端身份；HTTP、WebSocket 与受限播放重定向统一改写或透传 |
 | **流量管控** | 按站点统计流量、设置限速、设置配额 |
 | **WebSocket 代理** | 完整支持 Emby 的 WebSocket 通信 |
 | **SSE 实时推送** | 仪表盘数据通过 Server-Sent Events 实时更新 |
@@ -272,7 +272,12 @@ Meridian/
 
 ### UA 身份模式
 
-每个站点可选 Infuse、Web、客户端三个预设，或选择“自定义”并填写 `User-Agent`、Emby `Client`、`Version`。自定义值会在普通 HTTP、WebSocket 以及受配置白名单约束的播放重定向请求中保持一致；`Device` 与 `DeviceId` 会原样保留。为避免请求头注入和 Emby 授权头格式损坏，自定义值只接受受限长度的可打印 ASCII 字符，`Client` 和 `Version` 不接受引号或反斜杠。
+每个站点可选 Infuse、Web、客户端三个预设，或选择“自定义”固定身份，或选择“透传”保留客户端身份。
+
+- **自定义（固定身份）**：填写 `User-Agent`、Emby `Client`、`Version`，Meridian 会在普通 HTTP、WebSocket 以及受配置白名单约束的播放重定向请求中统一改写成这套固定值，所有请求保持一致；`Device` 与 `DeviceId` 会原样保留。为避免请求头注入和 Emby 授权头格式损坏，自定义值只接受受限长度的可打印 ASCII 字符，`Client` 和 `Version` 不接受引号或反斜杠。
+- **透传（每请求真实身份）**：Meridian 不生成也不改写任何 UA 身份，每个请求原样保留客户端自带的 `User-Agent` 与 Emby `Client`、`Version`、`Device`、`DeviceId` 后转发，适合多用户共用一个反代站点、需要按客户端区分身份的部署。
+
+两种模式的凭据安全边界一致：跨 authority 转发时 `Cookie`、`Authorization` 等凭据仍会被剥离，`X-Forwarded-*` 与 hop-by-hop 请求头清洗保持不变，透传不会绕过任何凭据清洗。
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -53,10 +53,23 @@ var uaProfiles = map[string]UAProfile{
 
 const (
 	customUAMode          = "custom"
+	passthroughUAMode     = "passthrough"
 	maxCustomUserAgentLen = 1024
 	maxCustomClientLen    = 128
 	maxCustomVersionLen   = 64
 )
+
+// UAHeaderPolicy is the explicit discriminator for how a site's inbound
+// identity headers are handled on the way upstream. Rewrite=true applies
+// Profile (the configured User-Agent plus Emby Client/Version identity);
+// Rewrite=false is passthrough, preserving the client's identity headers byte
+// for byte. Passthrough is never encoded as an empty UAProfile sentinel: the
+// policy itself carries the mode, and every header-preparation path branches
+// on this discriminator.
+type UAHeaderPolicy struct {
+	Rewrite bool
+	Profile UAProfile
+}
 
 func getUAProfile(mode string) UAProfile {
 	if p, ok := uaProfiles[strings.ToLower(mode)]; ok {
@@ -85,6 +98,11 @@ func validateCustomUAValue(field, value string, maxLen int, allowQuotes bool) er
 
 func normalizeUAConfig(mode, userAgent, client, version string) (string, string, string, string, error) {
 	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == passthroughUAMode {
+		// Passthrough carries no identity of its own: the client's headers are
+		// preserved verbatim, so any stored custom triplet is cleared.
+		return mode, "", "", "", nil
+	}
 	if mode != customUAMode {
 		if _, ok := uaProfiles[mode]; !ok {
 			return "", "", "", "", fmt.Errorf("unknown ua_mode")
@@ -107,15 +125,22 @@ func normalizeUAConfig(mode, userAgent, client, version string) (string, string,
 	return mode, userAgent, client, version, nil
 }
 
-func resolveSiteUAProfile(site Site) (UAProfile, error) {
+// resolveUAHeaderPolicy resolves a site's stored UA configuration into the
+// explicit header-handling policy used everywhere identity headers are
+// prepared: the HTTP proxy path, WebSocket upgrade, redirect follow, and
+// diagnostics.
+func resolveUAHeaderPolicy(site Site) (UAHeaderPolicy, error) {
 	mode, userAgent, client, version, err := normalizeUAConfig(site.UAMode, site.CustomUserAgent, site.CustomClient, site.CustomVersion)
 	if err != nil {
-		return UAProfile{}, err
+		return UAHeaderPolicy{}, err
+	}
+	if mode == passthroughUAMode {
+		return UAHeaderPolicy{}, nil
 	}
 	if mode == customUAMode {
-		return UAProfile{Name: "Custom", UserAgent: userAgent, Client: client, Version: version}, nil
+		return UAHeaderPolicy{Rewrite: true, Profile: UAProfile{Name: "Custom", UserAgent: userAgent, Client: client, Version: version}}, nil
 	}
-	return uaProfiles[mode], nil
+	return UAHeaderPolicy{Rewrite: true, Profile: uaProfiles[mode]}, nil
 }
 
 func mergeSiteUAConfig(old Site, requestedMode, requestedUserAgent, requestedClient, requestedVersion *string) (string, string, string, string, error) {
@@ -847,7 +872,7 @@ func (d *DB) GetTrafficLogs(siteID int64, hours int) ([]TrafficLog, error) {
 type redirectFollowTransport struct {
 	base          http.RoundTripper
 	playbackHosts map[string]bool
-	profile       UAProfile
+	policy        UAHeaderPolicy
 }
 
 func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -887,12 +912,13 @@ func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, 
 		if !sameRedirectAuthority(req.URL, locURL) {
 			// A redirect to a different scheme/host/port is a new security
 			// domain: the browser's cookies and the client's Emby access token
-			// must not follow the hop to a playback or CDN host. The UA profile
+			// must not follow the hop to a playback or CDN host. The UA policy
 			// is reapplied below, so identity rewriting stays consistent while
-			// secrets stay behind.
+			// secrets stay behind; passthrough keeps whatever non-secret
+			// identity the client sent.
 			stripSensitiveRedirectHeaders(newReq.Header)
 		}
-		applyUAProfileHeaders(newReq.Header, t.profile)
+		applyUAHeaderPolicy(newReq.Header, t.policy)
 		resp, err = t.base.RoundTrip(newReq)
 		if err != nil {
 			return nil, err
@@ -904,6 +930,8 @@ func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, 
 
 type embyAuthAttribute struct {
 	name       string
+	attrStart  int
+	attrEnd    int
 	valueStart int
 	valueEnd   int
 }
@@ -959,6 +987,8 @@ func parseEmbyAuthorizationAttributes(value string, offset int) ([]embyAuthAttri
 		}
 		attributes = append(attributes, embyAuthAttribute{
 			name:       name,
+			attrStart:  nameStart,
+			attrEnd:    offset + 1,
 			valueStart: valueStart,
 			valueEnd:   offset,
 		})
@@ -1077,6 +1107,7 @@ func rewriteEmbyAuthorizationHeaders(header http.Header, headerName string, prof
 // value carries (or may carry) an access token that could not be stripped, and
 // the caller must drop the entire header instead of forwarding it. Values
 // without any recognizable Token attribute are returned unchanged with true.
+// A value whose only attribute is the token is reduced to its bare scheme.
 func stripEmbyAuthorizationToken(value string) (string, bool) {
 	offset := 0
 	for offset < len(value) && isEmbyAuthWhitespace(value[offset]) {
@@ -1095,6 +1126,7 @@ func stripEmbyAuthorizationToken(value string) (string, bool) {
 		// Unknown scheme: it cannot be proven token-free, so fail closed.
 		return value, false
 	}
+	schemeEnd := offset
 	if offset < len(value) && !isEmbyAuthWhitespace(value[offset]) {
 		return value, false
 	}
@@ -1124,7 +1156,19 @@ func stripEmbyAuthorizationToken(value string) (string, bool) {
 		return value, true
 	}
 	attribute := attributes[tokenIndex]
-	return value[:attribute.valueStart] + value[attribute.valueEnd:], true
+	switch {
+	case tokenIndex == 0 && len(attributes) == 1:
+		// The only attribute is the token: leave the bare scheme.
+		return value[:schemeEnd] + value[attribute.attrEnd:], true
+	case tokenIndex == 0:
+		// The token is the first attribute: drop it together with the
+		// delimiter that followed it.
+		return value[:attribute.attrStart] + value[attributes[1].attrStart:], true
+	default:
+		// The token sits after other attributes: drop the delimiter before
+		// it together with the attribute itself.
+		return value[:attributes[tokenIndex-1].attrEnd] + value[attribute.attrEnd:], true
+	}
 }
 
 // stripSensitiveRedirectHeaders removes browser credentials and access tokens
@@ -1544,6 +1588,16 @@ func applyUAProfileHeaders(header http.Header, profile UAProfile) {
 	rewriteEmbyAuthorizationHeaders(header, "Authorization", profile)
 }
 
+// applyUAHeaderPolicy applies a resolved UAHeaderPolicy to outbound headers.
+// Rewrite mode sets the configured User-Agent and rewrites Emby Client/Version
+// identity; passthrough leaves every inbound identity header untouched.
+func applyUAHeaderPolicy(header http.Header, policy UAHeaderPolicy) {
+	if !policy.Rewrite {
+		return
+	}
+	applyUAProfileHeaders(header, policy.Profile)
+}
+
 func removeClientForwardingHeaders(header http.Header) {
 	for name := range header {
 		lowerName := strings.ToLower(name)
@@ -1572,13 +1626,23 @@ func setTrustedForwardingHeaders(header http.Header, inbound *http.Request) {
 	header.Set("X-Forwarded-Proto", forwardedProto)
 }
 
-func prepareUpstreamHeaders(header http.Header, inbound *http.Request, profile UAProfile) {
+func prepareUpstreamHeaders(header http.Header, inbound *http.Request, policy UAHeaderPolicy) {
 	setTrustedForwardingHeaders(header, inbound)
-	applyUAProfileHeaders(header, profile)
+	applyUAHeaderPolicy(header, policy)
 }
 
-func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, profile UAProfile) http.Header {
+func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, policy UAHeaderPolicy) http.Header {
 	header := inbound.Header.Clone()
+	// RFC 9110 hop-by-hop: every header named by the inbound Connection header
+	// is consumed by the first recipient and must not be forwarded. Delete them
+	// all before rebuilding the upgrade headers below.
+	for _, value := range inbound.Header.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			if token = strings.TrimSpace(token); token != "" {
+				header.Del(token)
+			}
+		}
+	}
 	for _, name := range []string{
 		// Content-Length must go with the other hop-by-hop headers: the upgrade
 		// path never reads r.Body, so letting a length through would tell the
@@ -1598,7 +1662,7 @@ func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, pro
 	header.Set("Connection", "Upgrade")
 	header.Set("Upgrade", "websocket")
 	header.Set("Host", target.Host)
-	prepareUpstreamHeaders(header, inbound, profile)
+	prepareUpstreamHeaders(header, inbound, policy)
 	return header
 }
 
@@ -1609,7 +1673,7 @@ func writeWebSocketGatewayError(conn net.Conn) {
 	_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
 }
 
-func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, profile UAProfile, inst *ProxyInstance, speedLimitBytes int64) {
+func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, policy UAHeaderPolicy, inst *ProxyInstance, speedLimitBytes int64) {
 	// Nothing on this path reads r.Body, so a body would be left sitting in the
 	// hijacked buffer and relayed verbatim to the upstream.
 	if r.ContentLength != 0 || len(r.TransferEncoding) > 0 {
@@ -1669,7 +1733,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, pr
 		log.Printf("[WS] write request line: %v", err)
 		return
 	}
-	upstreamHeader := prepareWebSocketUpstreamHeaders(r, target, profile)
+	upstreamHeader := prepareWebSocketUpstreamHeaders(r, target, policy)
 	if err := upstreamHeader.Write(upstreamConn); err != nil {
 		log.Printf("[WS] write request headers: %v", err)
 		return
@@ -1782,7 +1846,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		}
 	}
 
-	profile, err := resolveSiteUAProfile(site)
+	policy, err := resolveUAHeaderPolicy(site)
 	if err != nil {
 		return fmt.Errorf("invalid UA profile: %w", err)
 	}
@@ -1806,7 +1870,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			}
 			applyUpstreamURL(proxyReq.Out.URL, upstream)
 			proxyReq.Out.Host = upstream.Host
-			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, profile)
+			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, policy)
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			log.Printf("[%s] proxy error: %v", site.Name, err)
@@ -1820,7 +1884,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		proxy.Transport = &redirectFollowTransport{
 			base:          proxyTransport,
 			playbackHosts: playbackHostsSet,
-			profile:       profile,
+			policy:        policy,
 		}
 	}
 
@@ -1845,7 +1909,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			if isRedirectMode {
 				wsTarget = target
 			}
-			handleWebSocket(w, r, wsTarget, profile, inst, speedLimitBytes)
+			handleWebSocket(w, r, wsTarget, policy, inst, speedLimitBytes)
 			return
 		}
 
@@ -2276,6 +2340,9 @@ type DiagTLS struct {
 }
 
 type DiagHeaders struct {
+	// Passthrough is the explicit marker for ua_mode passthrough: the client's
+	// identity headers are preserved, so no configured identity is shown.
+	Passthrough  bool   `json:"passthrough"`
 	UAApplied    bool   `json:"ua_applied"`
 	CurrentUA    string `json:"current_ua"`
 	ClientField  string `json:"client_field"`
@@ -2656,7 +2723,7 @@ func displayTargetURL(raw string) string {
 }
 
 func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
-	profile, profileErr := resolveSiteUAProfile(*site)
+	policy, profileErr := resolveUAHeaderPolicy(*site)
 	primary, primaryKey := diagnoseUpstreamTarget(site.TargetURL, "metadata_api")
 	primary.Configured = true
 	primary.ShowHealth = true
@@ -2700,12 +2767,19 @@ func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
 		result.Headers = DiagHeaders{
 			ProfileError: "invalid stored UA configuration",
 		}
+	} else if !policy.Rewrite {
+		// Passthrough has no configured identity to show, and the real request
+		// headers must never be rendered in diagnostics output.
+		result.Headers = DiagHeaders{
+			Passthrough: true,
+			UAApplied:   false,
+		}
 	} else {
 		result.Headers = DiagHeaders{
 			UAApplied:    true,
-			CurrentUA:    profile.UserAgent,
-			ClientField:  profile.Client,
-			VersionField: profile.Version,
+			CurrentUA:    policy.Profile.UserAgent,
+			ClientField:  policy.Profile.Client,
+			VersionField: policy.Profile.Version,
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -177,6 +177,188 @@ func TestMergeSiteUAConfigUsesCompleteSnapshots(t *testing.T) {
 	}
 }
 
+func TestNormalizeUAPassthroughMode(t *testing.T) {
+	mode, userAgent, client, version, err := normalizeUAConfig(" PASSTHROUGH ", "stale", "stale", "stale")
+	if err != nil {
+		t.Fatalf("normalize passthrough config: %v", err)
+	}
+	if mode != passthroughUAMode || userAgent != "" || client != "" || version != "" {
+		t.Fatalf("passthrough config = %#v %#v %#v %#v, want mode only with a cleared custom triplet", mode, userAgent, client, version)
+	}
+
+	if _, _, _, _, err := normalizeUAConfig("bogus-mode", "", "", ""); err == nil {
+		t.Fatal("unknown ua_mode unexpectedly accepted")
+	}
+}
+
+func TestMergeSiteUAConfigPassthrough(t *testing.T) {
+	old := Site{
+		UAMode:          customUAMode,
+		CustomUserAgent: "Old UA",
+		CustomClient:    "Old Client",
+		CustomVersion:   "1.0",
+	}
+
+	// Switching custom -> passthrough clears the stored custom triplet.
+	mode, userAgent, client, version, err := mergeSiteUAConfig(old, stringPointer(passthroughUAMode), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("switch to passthrough: %v", err)
+	}
+	if mode != passthroughUAMode || userAgent != "" || client != "" || version != "" {
+		t.Fatalf("passthrough switch = %#v %#v %#v %#v", mode, userAgent, client, version)
+	}
+
+	// Passthrough with an explicitly empty custom triplet is legal.
+	if _, _, _, _, err := mergeSiteUAConfig(old, stringPointer(passthroughUAMode), stringPointer(""), stringPointer(""), stringPointer("")); err != nil {
+		t.Fatalf("passthrough with empty custom fields: %v", err)
+	}
+
+	// Passthrough with a non-empty custom triplet is rejected like any other
+	// non-custom mode: the custom-switch rules do not regress.
+	if _, _, _, _, err := mergeSiteUAConfig(old, stringPointer(passthroughUAMode), stringPointer("New UA"), stringPointer("New Client"), stringPointer("2.0")); err == nil {
+		t.Fatal("passthrough with non-empty custom fields unexpectedly accepted")
+	}
+
+	// PUT omitting ua_mode preserves the stored passthrough mode and clears
+	// any stale triplet left in the row.
+	passthroughOld := Site{UAMode: passthroughUAMode, CustomUserAgent: "stale", CustomClient: "stale", CustomVersion: "stale"}
+	mode, userAgent, client, version, err = mergeSiteUAConfig(passthroughOld, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("preserve passthrough: %v", err)
+	}
+	if mode != passthroughUAMode || userAgent != "" || client != "" || version != "" {
+		t.Fatalf("preserved passthrough = %#v %#v %#v %#v", mode, userAgent, client, version)
+	}
+
+	// Passthrough -> custom with a full triplet is legal.
+	mode, userAgent, client, version, err = mergeSiteUAConfig(passthroughOld, stringPointer(customUAMode), stringPointer("New UA"), stringPointer("New Client"), stringPointer("2.0"))
+	if err != nil {
+		t.Fatalf("switch passthrough to custom: %v", err)
+	}
+	if mode != customUAMode || userAgent != "New UA" || client != "New Client" || version != "2.0" {
+		t.Fatalf("custom switch = %#v %#v %#v %#v", mode, userAgent, client, version)
+	}
+
+	// Passthrough -> preset.
+	if mode, _, _, _, err := mergeSiteUAConfig(passthroughOld, stringPointer("web"), nil, nil, nil); err != nil || mode != "web" {
+		t.Fatalf("passthrough to preset: mode=%q err=%v", mode, err)
+	}
+}
+
+func TestResolveUAHeaderPolicyDiscriminatesModes(t *testing.T) {
+	custom, err := resolveUAHeaderPolicy(Site{UAMode: customUAMode, CustomUserAgent: "Custom UA/1.0", CustomClient: "Custom Client", CustomVersion: "1.0.0"})
+	if err != nil {
+		t.Fatalf("resolve custom: %v", err)
+	}
+	if !custom.Rewrite || custom.Profile.UserAgent != "Custom UA/1.0" || custom.Profile.Client != "Custom Client" || custom.Profile.Version != "1.0.0" {
+		t.Fatalf("custom policy = %#v", custom)
+	}
+
+	preset, err := resolveUAHeaderPolicy(Site{UAMode: "web"})
+	if err != nil {
+		t.Fatalf("resolve preset: %v", err)
+	}
+	if !preset.Rewrite || preset.Profile != uaProfiles["web"] {
+		t.Fatalf("preset policy = %#v", preset)
+	}
+
+	// Passthrough is its own policy state, never an empty-UAProfile sentinel;
+	// stale custom fields in the row are cleared by normalization.
+	pass, err := resolveUAHeaderPolicy(Site{UAMode: passthroughUAMode, CustomUserAgent: "stale", CustomClient: "stale", CustomVersion: "stale"})
+	if err != nil {
+		t.Fatalf("resolve passthrough: %v", err)
+	}
+	if pass.Rewrite {
+		t.Fatalf("passthrough policy must not rewrite: %#v", pass)
+	}
+
+	if _, err := resolveUAHeaderPolicy(Site{UAMode: "bogus"}); err == nil {
+		t.Fatal("unknown mode unexpectedly resolved")
+	}
+}
+
+func TestApplyUAHeaderPolicyPassthroughPreservesIdentityHeaders(t *testing.T) {
+	authorization := `MediaBrowser Client="Client", Device="TV", DeviceId="d1", Version="1", Token="secret"`
+	header := http.Header{
+		"User-Agent":           []string{"ClientUA/9.9"},
+		"X-Emby-Authorization": []string{authorization},
+		"Authorization":        []string{"Bearer opaque"},
+	}
+	applyUAHeaderPolicy(header, UAHeaderPolicy{})
+	if got := header.Get("User-Agent"); got != "ClientUA/9.9" {
+		t.Fatalf("User-Agent = %q, want the client value preserved", got)
+	}
+	if got := header.Get("X-Emby-Authorization"); got != authorization {
+		t.Fatalf("X-Emby-Authorization = %q, want byte-identical passthrough", got)
+	}
+	if got := header.Get("Authorization"); got != "Bearer opaque" {
+		t.Fatalf("Authorization = %q, want byte-identical passthrough", got)
+	}
+
+	rewritten := http.Header{
+		"User-Agent":           []string{"ClientUA/9.9"},
+		"X-Emby-Authorization": []string{authorization},
+	}
+	applyUAHeaderPolicy(rewritten, UAHeaderPolicy{Rewrite: true, Profile: uaProfiles["client"]})
+	if got := rewritten.Get("User-Agent"); got != uaProfiles["client"].UserAgent {
+		t.Fatalf("rewrite User-Agent = %q, want %q", got, uaProfiles["client"].UserAgent)
+	}
+	if got := rewritten.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Emby Theater"`) || !strings.Contains(got, `Version="4.7.0"`) {
+		t.Fatalf("rewrite authorization = %q", got)
+	}
+}
+
+func TestHTTPPassthroughPreservesClientIdentityAndRebuildsForwarding(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "http://meridian.example:50001/System/Info", nil)
+	request.RemoteAddr = "198.51.100.26:12345"
+	request.Header.Set("User-Agent", "ClientUA/9.9")
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Client="Client", Device="TV", Version="1"`)
+	request.Header.Set("X-Forwarded-For", "203.0.113.8")
+
+	header := request.Header.Clone()
+	prepareUpstreamHeaders(header, request, UAHeaderPolicy{})
+
+	if got := header.Get("User-Agent"); got != "ClientUA/9.9" {
+		t.Fatalf("User-Agent = %q, want the client value preserved", got)
+	}
+	if got := header.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Client"`) || !strings.Contains(got, `Device="TV"`) {
+		t.Fatalf("X-Emby-Authorization = %q, want client identity preserved", got)
+	}
+	// X-Forwarded-* rebuilding is unchanged in passthrough mode.
+	if got := header.Get("X-Forwarded-For"); got != "198.51.100.26" {
+		t.Fatalf("X-Forwarded-For = %q, want rebuilt from the peer address", got)
+	}
+	if got := header.Get("X-Forwarded-Host"); got != "meridian.example:50001" {
+		t.Fatalf("X-Forwarded-Host = %q", got)
+	}
+	if got := header.Get("X-Forwarded-Proto"); got != "http" {
+		t.Fatalf("X-Forwarded-Proto = %q", got)
+	}
+}
+
+func TestPrepareWebSocketUpstreamHeadersRemovesConnectionNominatedHopByHop(t *testing.T) {
+	target, err := normalizeTargetURL("https://upstream.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://meridian.example/socket", nil)
+	req.Header.Set("Connection", "Upgrade, X-Hop-By-Hop, keep-alive")
+	req.Header.Set("X-Hop-By-Hop", "secret")
+	req.Header.Set("Keep-Alive", "timeout=5")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	header := prepareWebSocketUpstreamHeaders(req, target, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
+	if got := header.Get("X-Hop-By-Hop"); got != "" {
+		t.Fatalf("Connection-nominated X-Hop-By-Hop forwarded: %q", got)
+	}
+	if got := header.Get("Keep-Alive"); got != "" {
+		t.Fatalf("Connection-nominated Keep-Alive forwarded: %q", got)
+	}
+	if got := header.Get("Connection"); got != "Upgrade" {
+		t.Fatalf("Connection = %q, want the rebuilt Upgrade value", got)
+	}
+}
+
 func createLegacySiteDatabase(t *testing.T, dbPath string, withHourlyIndex bool) {
 	t.Helper()
 	legacy, err := sql.Open("sqlite", dbPath)
@@ -457,7 +639,7 @@ func TestRedirectModeTreatsExplicit443AsDefaultHTTPSPort(t *testing.T) {
 	transport := &redirectFollowTransport{
 		base:          base,
 		playbackHosts: map[string]bool{redirectHostKey(configured): true},
-		profile:       getUAProfile("infuse"),
+		policy:        UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
 	}
 	req := httptest.NewRequest(http.MethodGet, "http://api.example.com/Videos/1/stream", nil)
 	resp, err := transport.RoundTrip(req)
@@ -486,7 +668,7 @@ func TestRedirectModeTreatsExplicit443AsDefaultHTTPSPort(t *testing.T) {
 		transport := &redirectFollowTransport{
 			base:          base,
 			playbackHosts: map[string]bool{redirectHostKey(configured): true},
-			profile:       getUAProfile("infuse"),
+			policy:        UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
 		}
 		req := httptest.NewRequest(http.MethodGet, "http://api.example.com/Videos/1/stream", nil)
 		resp, err := transport.RoundTrip(req)
@@ -521,7 +703,7 @@ func TestRedirectModeTreatsExplicit443AsDefaultHTTPSPort(t *testing.T) {
 		transport := &redirectFollowTransport{
 			base:          base,
 			playbackHosts: map[string]bool{redirectHostKey(configured): true},
-			profile:       getUAProfile("infuse"),
+			policy:        UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
 		}
 		req := httptest.NewRequest(http.MethodGet, "http://api.example.com/custom/play/path", nil)
 		resp, err := transport.RoundTrip(req)
@@ -556,7 +738,7 @@ func TestRedirectModeTreatsExplicit443AsDefaultHTTPSPort(t *testing.T) {
 		transport := &redirectFollowTransport{
 			base:          base,
 			playbackHosts: map[string]bool{redirectHostKey(configured): true},
-			profile:       getUAProfile("infuse"),
+			policy:        UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
 		}
 		req := httptest.NewRequest(http.MethodGet, "https://api.example.com/custom/play/path", nil)
 		resp, err := transport.RoundTrip(req)
@@ -586,7 +768,7 @@ func TestRedirectModeTreatsExplicit443AsDefaultHTTPSPort(t *testing.T) {
 		transport := &redirectFollowTransport{
 			base:          base,
 			playbackHosts: map[string]bool{redirectHostKey(configured): true},
-			profile:       getUAProfile("infuse"),
+			policy:        UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
 		}
 		req := httptest.NewRequest(http.MethodPost, "http://api.example.com/Users/AuthenticateByName", strings.NewReader(`{"Username":"test"}`))
 		resp, err := transport.RoundTrip(req)
@@ -605,7 +787,7 @@ func TestReverseProxyRebuildsForwardingHeadersAfterHopHeaderRemoval(t *testing.T
 	if err != nil {
 		t.Fatalf("normalize target: %v", err)
 	}
-	profile := getUAProfile("infuse")
+	policy := UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")}
 	var captured *http.Request
 	proxy := &httputil.ReverseProxy{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -621,7 +803,7 @@ func TestReverseProxyRebuildsForwardingHeadersAfterHopHeaderRemoval(t *testing.T
 		Rewrite: func(proxyReq *httputil.ProxyRequest) {
 			applyUpstreamURL(proxyReq.Out.URL, target)
 			proxyReq.Out.Host = target.Host
-			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, profile)
+			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, policy)
 		},
 	}
 
@@ -650,8 +832,8 @@ func TestReverseProxyRebuildsForwardingHeadersAfterHopHeaderRemoval(t *testing.T
 	if captured.Host != target.Host {
 		t.Fatalf("outbound Host = %q, want %q", captured.Host, target.Host)
 	}
-	if got := captured.Header.Get("User-Agent"); got != profile.UserAgent {
-		t.Fatalf("outbound User-Agent = %q, want profile value %q", got, profile.UserAgent)
+	if got := captured.Header.Get("User-Agent"); got != policy.Profile.UserAgent {
+		t.Fatalf("outbound User-Agent = %q, want profile value %q", got, policy.Profile.UserAgent)
 	}
 	for name, want := range map[string]string{
 		"X-Forwarded-For":   "198.51.100.24",
@@ -675,7 +857,7 @@ func TestPrepareWebSocketUpstreamHeadersRebuildsForwardingHeaders(t *testing.T) 
 	if err != nil {
 		t.Fatalf("normalize target: %v", err)
 	}
-	profile := getUAProfile("infuse")
+	policy := UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")}
 	req := httptest.NewRequest(http.MethodGet, "http://meridian.example:50001/socket", nil)
 	req.RemoteAddr = "198.51.100.25:54321"
 	req.Header.Set("Connection", "Upgrade, User-Agent")
@@ -687,7 +869,7 @@ func TestPrepareWebSocketUpstreamHeadersRebuildsForwardingHeaders(t *testing.T) 
 	req.Header.Set("X-Real-IP", "203.0.113.11")
 	req.Header.Set("Proxy-Connection", "keep-alive")
 
-	header := prepareWebSocketUpstreamHeaders(req, target, profile)
+	header := prepareWebSocketUpstreamHeaders(req, target, policy)
 	if got := req.Header.Get("Forwarded"); got == "" {
 		t.Fatal("preparing WebSocket headers mutated the inbound request")
 	}
@@ -695,7 +877,7 @@ func TestPrepareWebSocketUpstreamHeadersRebuildsForwardingHeaders(t *testing.T) 
 		"Connection":        "Upgrade",
 		"Upgrade":           "websocket",
 		"Host":              target.Host,
-		"User-Agent":        profile.UserAgent,
+		"User-Agent":        policy.Profile.UserAgent,
 		"X-Forwarded-For":   "198.51.100.25",
 		"X-Real-IP":         "198.51.100.25",
 		"X-Forwarded-Host":  "meridian.example:50001",
@@ -1878,20 +2060,20 @@ func TestApplyCustomUAProfileHeadersSafelyRewritesOnlyValidEmbyValues(t *testing
 }
 
 func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T) {
-	profile := UAProfile{
+	policy := UAHeaderPolicy{Rewrite: true, Profile: UAProfile{
 		Name:      "Custom",
 		UserAgent: "Meridian Test/1.0",
 		Client:    "Meridian Test",
 		Version:   "1.0.0",
-	}
+	}}
 	authorization := "MediaBrowser Device=\"TV\", DeviceId=\"device-1\", Client=\"old\", Version=\"old\""
 	assertIdentity := func(t *testing.T, header http.Header) {
 		t.Helper()
-		if got := header.Get("User-Agent"); got != profile.UserAgent {
-			t.Fatalf("User-Agent = %q, want %q", got, profile.UserAgent)
+		if got := header.Get("User-Agent"); got != policy.Profile.UserAgent {
+			t.Fatalf("User-Agent = %q, want %q", got, policy.Profile.UserAgent)
 		}
 		got := header.Get("X-Emby-Authorization")
-		for _, want := range []string{"Device=\"TV\"", "DeviceId=\"device-1\"", "Client=\"" + profile.Client + "\"", "Version=\"" + profile.Version + "\""} {
+		for _, want := range []string{"Device=\"TV\"", "DeviceId=\"device-1\"", "Client=\"" + policy.Profile.Client + "\"", "Version=\"" + policy.Profile.Version + "\""} {
 			if !strings.Contains(got, want) {
 				t.Fatalf("authorization = %q, missing %q", got, want)
 			}
@@ -1902,7 +2084,7 @@ func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T
 		request := httptest.NewRequest(http.MethodGet, "http://meridian.example/System/Info", nil)
 		request.Header.Set("X-Emby-Authorization", authorization)
 		header := request.Header.Clone()
-		prepareUpstreamHeaders(header, request, profile)
+		prepareUpstreamHeaders(header, request, policy)
 		assertIdentity(t, header)
 	})
 
@@ -1915,7 +2097,7 @@ func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T
 		request.Header.Set("Connection", "Upgrade")
 		request.Header.Set("Upgrade", "websocket")
 		request.Header.Set("X-Emby-Authorization", authorization)
-		header := prepareWebSocketUpstreamHeaders(request, target, profile)
+		header := prepareWebSocketUpstreamHeaders(request, target, policy)
 		assertIdentity(t, header)
 	})
 
@@ -1928,7 +2110,7 @@ func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T
 		var followedHeaders http.Header
 		transport := &redirectFollowTransport{
 			playbackHosts: map[string]bool{redirectHostKey(target): true},
-			profile:       profile,
+			policy:        policy,
 			base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 				calls++
 				if calls == 1 {
@@ -1950,7 +2132,7 @@ func TestCustomUAProfileIsConsistentAcrossHTTPWebSocketAndRedirects(t *testing.T
 		}
 		request := httptest.NewRequest(http.MethodGet, "https://api.example.com/Videos/1/stream", nil)
 		request.Header.Set("X-Emby-Authorization", authorization)
-		applyUAProfileHeaders(request.Header, profile)
+		applyUAHeaderPolicy(request.Header, policy)
 		response, err := transport.RoundTrip(request)
 		if err != nil {
 			t.Fatalf("follow redirect: %v", err)
@@ -1973,7 +2155,7 @@ func TestRedirectFollowStripsSensitiveHeadersCrossOrigin(t *testing.T) {
 	calls := 0
 	transport := &redirectFollowTransport{
 		playbackHosts: map[string]bool{redirectHostKey(target): true},
-		profile:       profile,
+		policy:        UAHeaderPolicy{Rewrite: true, Profile: profile},
 		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
@@ -2025,10 +2207,11 @@ func TestRedirectFollowStripsSensitiveHeadersCrossOrigin(t *testing.T) {
 	if strings.Contains(emby, "emby-access-token") {
 		t.Fatalf("Emby access token forwarded across origin: %q", emby)
 	}
-	for _, want := range []string{`Client="Meridian Test"`, `Version="1.0.0"`, `Device="TV"`, `DeviceId="device-1"`} {
-		if !strings.Contains(emby, want) {
-			t.Fatalf("authorization = %q, missing %q", emby, want)
-		}
+	if strings.Contains(strings.ToLower(emby), "token=") {
+		t.Fatalf("Token attribute survives cross-origin hop: %q", emby)
+	}
+	if emby != `MediaBrowser Device="TV", DeviceId="device-1", Client="Meridian Test", Version="1.0.0"` {
+		t.Fatalf("identity fields altered: %q", emby)
 	}
 	if got := followedHeaders.Get("User-Agent"); got != profile.UserAgent {
 		t.Fatalf("User-Agent = %q, want %q", got, profile.UserAgent)
@@ -2045,7 +2228,7 @@ func TestRedirectFollowKeepsHeadersSameOrigin(t *testing.T) {
 	calls := 0
 	transport := &redirectFollowTransport{
 		playbackHosts: map[string]bool{redirectHostKey(target): true},
-		profile:       profile,
+		policy:        UAHeaderPolicy{Rewrite: true, Profile: profile},
 		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
@@ -2101,19 +2284,61 @@ func TestStripEmbyAuthorizationToken(t *testing.T) {
 		{
 			name:     "removes token and keeps identity",
 			value:    `MediaBrowser Client="App", Device="TV", DeviceId="d1", Token="secret", Version="1"`,
-			want:     `MediaBrowser Client="App", Device="TV", DeviceId="d1", Token="", Version="1"`,
+			want:     `MediaBrowser Client="App", Device="TV", DeviceId="d1", Version="1"`,
 			wantSafe: true,
 		},
 		{
 			name:     "emby scheme is stripped like mediabrowser",
 			value:    `Emby Device="TV", Token="secret"`,
-			want:     `Emby Device="TV", Token=""`,
+			want:     `Emby Device="TV"`,
+			wantSafe: true,
+		},
+		{
+			name:     "token as only attribute leaves bare scheme",
+			value:    `MediaBrowser Token="secret"`,
+			want:     `MediaBrowser`,
+			wantSafe: true,
+		},
+		{
+			name:     "token as first attribute drops delimiter",
+			value:    `MediaBrowser Token="secret", Client="App"`,
+			want:     `MediaBrowser Client="App"`,
+			wantSafe: true,
+		},
+		{
+			name:     "token as last attribute drops preceding delimiter",
+			value:    `MediaBrowser Client="App", Device="TV", Token="secret"`,
+			want:     `MediaBrowser Client="App", Device="TV"`,
 			wantSafe: true,
 		},
 		{
 			name:     "leading whitespace is preserved",
 			value:    `  MediaBrowser Token="secret"`,
-			want:     `  MediaBrowser Token=""`,
+			want:     `  MediaBrowser`,
+			wantSafe: true,
+		},
+		{
+			name:     "token name matching is case-insensitive",
+			value:    `MediaBrowser Client="App", tOkEn="secret", Version="1"`,
+			want:     `MediaBrowser Client="App", Version="1"`,
+			wantSafe: true,
+		},
+		{
+			name:     "irregular whitespace around token is absorbed",
+			value:    `MediaBrowser Token="secret"  ,  Client="App"`,
+			want:     `MediaBrowser Client="App"`,
+			wantSafe: true,
+		},
+		{
+			name:     "whitespace before token attribute is preserved",
+			value:    "MediaBrowser\tToken=\"secret\", Client=\"App\"",
+			want:     "MediaBrowser\tClient=\"App\"",
+			wantSafe: true,
+		},
+		{
+			name:     "token value with comma is still removed",
+			value:    `MediaBrowser Client="App", Token="a,b", Version="1"`,
+			want:     `MediaBrowser Client="App", Version="1"`,
 			wantSafe: true,
 		},
 		{
@@ -2141,9 +2366,21 @@ func TestStripEmbyAuthorizationToken(t *testing.T) {
 			wantSafe: false,
 		},
 		{
+			name:     "duplicate token with mixed case fails closed",
+			value:    `MediaBrowser Token="a", token="b", Client="App"`,
+			want:     `MediaBrowser Token="a", token="b", Client="App"`,
+			wantSafe: false,
+		},
+		{
 			name:     "unterminated attribute fails closed",
 			value:    `MediaBrowser Client="unterminated`,
 			want:     `MediaBrowser Client="unterminated`,
+			wantSafe: false,
+		},
+		{
+			name:     "unquoted token value fails closed",
+			value:    `MediaBrowser Client="App", Token=secret`,
+			want:     `MediaBrowser Client="App", Token=secret`,
 			wantSafe: false,
 		},
 		{
@@ -2161,6 +2398,9 @@ func TestStripEmbyAuthorizationToken(t *testing.T) {
 			}
 			if safe != tt.wantSafe {
 				t.Fatalf("safe = %v, want %v", safe, tt.wantSafe)
+			}
+			if safe && strings.Contains(strings.ToLower(got), "token=") {
+				t.Fatalf("stripped value still carries a Token attribute: %q", got)
 			}
 		})
 	}
@@ -2192,8 +2432,11 @@ func TestStripSensitiveRedirectHeadersRemovesDedicatedTokenHeaders(t *testing.T)
 	if strings.Contains(emby, "emby-access-token") {
 		t.Fatalf("Emby access token forwarded: %q", emby)
 	}
-	if !strings.Contains(emby, `Device="TV"`) {
-		t.Fatalf("identity fields lost: %q", emby)
+	if strings.Contains(strings.ToLower(emby), "token=") {
+		t.Fatalf("Token attribute survives stripping: %q", emby)
+	}
+	if emby != `MediaBrowser Device="TV", Client="old"` {
+		t.Fatalf("identity fields altered: %q", emby)
 	}
 	if got := header.Get("X-Forwarded-For"); got != "10.0.0.1" {
 		t.Fatalf("non-sensitive header dropped: %q", got)
@@ -2223,7 +2466,7 @@ func TestRedirectFollowDropsUnsafeEmbyAuthorizationCrossOrigin(t *testing.T) {
 	calls := 0
 	transport := &redirectFollowTransport{
 		playbackHosts: map[string]bool{redirectHostKey(target): true},
-		profile:       profile,
+		policy:        UAHeaderPolicy{Rewrite: true, Profile: profile},
 		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 			calls++
 			if calls == 1 {
@@ -2257,6 +2500,198 @@ func TestRedirectFollowDropsUnsafeEmbyAuthorizationCrossOrigin(t *testing.T) {
 	}
 	if got := followedHeaders.Values("X-Emby-Authorization"); len(got) != 0 {
 		t.Fatalf("unsafe X-Emby-Authorization forwarded across origin: %q", got)
+	}
+}
+
+func TestRedirectFollowPassthroughCrossOriginPreservesIdentityStripsSecrets(t *testing.T) {
+	target, err := normalizeTargetURL("https://media.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	var followedHeaders http.Header
+	calls := 0
+	transport := &redirectFollowTransport{
+		playbackHosts: map[string]bool{redirectHostKey(target): true},
+		policy:        UAHeaderPolicy{},
+		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    request,
+				}, nil
+			}
+			followedHeaders = request.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    request,
+			}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "https://api.example.com/Videos/1/stream", nil)
+	request.Header.Set("User-Agent", "ClientUA/9.9")
+	request.Header.Set("Cookie", "session=secret-cookie")
+	request.Header.Set("Authorization", "Bearer opaque-bearer")
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Client="Client", Device="TV", DeviceId="d1", Token="emby-access-token", Version="1"`)
+	request.Header.Set("X-Emby-Token", "emby-access-token")
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatalf("follow redirect: %v", err)
+	}
+	response.Body.Close()
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := followedHeaders.Get("Cookie"); got != "" {
+		t.Fatalf("Cookie forwarded across origin: %q", got)
+	}
+	if got := followedHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization forwarded across origin: %q", got)
+	}
+	if got := followedHeaders.Get("X-Emby-Token"); got != "" {
+		t.Fatalf("X-Emby-Token forwarded across origin: %q", got)
+	}
+	emby := followedHeaders.Get("X-Emby-Authorization")
+	if strings.Contains(emby, "emby-access-token") {
+		t.Fatalf("Emby access token forwarded across origin: %q", emby)
+	}
+	if strings.Contains(strings.ToLower(emby), "token=") {
+		t.Fatalf("Token attribute survives cross-origin hop: %q", emby)
+	}
+	if emby != `MediaBrowser Client="Client", Device="TV", DeviceId="d1", Version="1"` {
+		t.Fatalf("identity fields altered: %q", emby)
+	}
+	// Passthrough keeps the client's own non-secret identity and UA.
+	if got := followedHeaders.Get("User-Agent"); got != "ClientUA/9.9" {
+		t.Fatalf("User-Agent = %q, want the client value preserved", got)
+	}
+}
+
+func TestRedirectFollowPassthroughSameOriginKeepsAuth(t *testing.T) {
+	target, err := normalizeTargetURL("https://media.example.com")
+	if err != nil {
+		t.Fatalf("normalize target: %v", err)
+	}
+	var followedHeaders http.Header
+	calls := 0
+	transport := &redirectFollowTransport{
+		playbackHosts: map[string]bool{redirectHostKey(target): true},
+		policy:        UAHeaderPolicy{},
+		base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    request,
+				}, nil
+			}
+			followedHeaders = request.Header.Clone()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("ok")),
+				Request:    request,
+			}, nil
+		}),
+	}
+	request := httptest.NewRequest(http.MethodGet, "https://media.example.com/Videos/1/stream", nil)
+	request.Header.Set("User-Agent", "ClientUA/9.9")
+	request.Header.Set("Cookie", "session=secret-cookie")
+	request.Header.Set("Authorization", "Bearer opaque-bearer")
+	request.Header.Set("X-Emby-Authorization", `MediaBrowser Client="Client", Device="TV", Token="emby-access-token", Version="1"`)
+	response, err := transport.RoundTrip(request)
+	if err != nil {
+		t.Fatalf("follow redirect: %v", err)
+	}
+	response.Body.Close()
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := followedHeaders.Get("Cookie"); got != "session=secret-cookie" {
+		t.Fatalf("Cookie dropped on same-origin redirect: %q", got)
+	}
+	if got := followedHeaders.Get("Authorization"); got != "Bearer opaque-bearer" {
+		t.Fatalf("Authorization dropped on same-origin redirect: %q", got)
+	}
+	if got := followedHeaders.Get("User-Agent"); got != "ClientUA/9.9" {
+		t.Fatalf("User-Agent = %q, want the client value preserved", got)
+	}
+	emby := followedHeaders.Get("X-Emby-Authorization")
+	if !strings.Contains(emby, "emby-access-token") {
+		t.Fatalf("Emby token lost on same-origin redirect: %q", emby)
+	}
+	if !strings.Contains(emby, `Client="Client"`) {
+		t.Fatalf("Emby identity lost on same-origin redirect: %q", emby)
+	}
+}
+
+func TestRedirectFollowDropsUnsafeEmbyAuthorizationCrossOriginInPassthrough(t *testing.T) {
+	// Duplicate or malformed Token attributes cannot be stripped safely, so the
+	// whole X-Emby-Authorization header must be dropped on a cross-authority hop
+	// even in passthrough mode. The non-secret User-Agent still survives.
+	for _, tc := range []struct {
+		name  string
+		value string
+	}{
+		{"duplicate token", `MediaBrowser Token="first", Token="second", Device="TV", Client="Client"`},
+		{"malformed token", `MediaBrowser Client="Client", Device="TV", Token="unterminated`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target, err := normalizeTargetURL("https://media.example.com")
+			if err != nil {
+				t.Fatalf("normalize target: %v", err)
+			}
+			var followedHeaders http.Header
+			calls := 0
+			transport := &redirectFollowTransport{
+				playbackHosts: map[string]bool{redirectHostKey(target): true},
+				policy:        UAHeaderPolicy{},
+				base: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+					calls++
+					if calls == 1 {
+						return &http.Response{
+							StatusCode: http.StatusFound,
+							Header:     http.Header{"Location": []string{"https://media.example.com/Videos/1/stream"}},
+							Body:       io.NopCloser(strings.NewReader("")),
+							Request:    request,
+						}, nil
+					}
+					followedHeaders = request.Header.Clone()
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader("ok")),
+						Request:    request,
+					}, nil
+				}),
+			}
+			request := httptest.NewRequest(http.MethodGet, "https://api.example.com/Videos/1/stream", nil)
+			request.Header.Set("User-Agent", "ClientUA/9.9")
+			request.Header.Set("X-Emby-Authorization", tc.value)
+			response, err := transport.RoundTrip(request)
+			if err != nil {
+				t.Fatalf("follow redirect: %v", err)
+			}
+			response.Body.Close()
+
+			if calls != 2 {
+				t.Fatalf("calls = %d, want 2", calls)
+			}
+			if got := followedHeaders.Values("X-Emby-Authorization"); len(got) != 0 {
+				t.Fatalf("unsafe X-Emby-Authorization forwarded across origin: %q", got)
+			}
+			if got := followedHeaders.Get("User-Agent"); got != "ClientUA/9.9" {
+				t.Fatalf("User-Agent = %q, want the client value preserved", got)
+			}
+		})
 	}
 }
 
@@ -4066,6 +4501,175 @@ func TestHandleSiteDiagUsesResolvedCustomUAProfile(t *testing.T) {
 	}
 	if got := mustStringValue(t, headers, "version_field"); got != "1.0.0" {
 		t.Fatalf("version_field = %q", got)
+	}
+}
+
+func TestHandleSitesCreateAndUpdatePassthroughMode(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	releasePort(port)
+	createPayload, err := json.Marshal(map[string]interface{}{
+		"name":              "passthrough-site",
+		"listen_port":       port,
+		"target_url":        "http://127.0.0.1:8096",
+		"ua_mode":           "passthrough",
+		"custom_user_agent": "Stale UA",
+		"custom_client":     "Stale Client",
+		"custom_version":    "9.9",
+	})
+	if err != nil {
+		t.Fatalf("marshal create payload: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	app.handleSites(rr, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(createPayload)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var created Site
+	if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created site: %v", err)
+	}
+	t.Cleanup(func() { app.pm.StopSite(created.ID) })
+	if created.UAMode != passthroughUAMode || created.CustomUserAgent != "" || created.CustomClient != "" || created.CustomVersion != "" {
+		t.Fatalf("created passthrough site = %#v, want cleared custom triplet", created)
+	}
+
+	// PUT switching passthrough -> custom stores the triplet.
+	customPayload, err := json.Marshal(map[string]interface{}{
+		"name":              created.Name,
+		"listen_port":       created.ListenPort,
+		"target_url":        created.TargetURL,
+		"ua_mode":           "custom",
+		"custom_user_agent": "New UA",
+		"custom_client":     "New Client",
+		"custom_version":    "2.0",
+	})
+	if err != nil {
+		t.Fatalf("marshal custom payload: %v", err)
+	}
+	rr = httptest.NewRecorder()
+	app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(created.ID), bytes.NewReader(customPayload)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("custom update status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	reloaded, err := app.db.GetSite(created.ID)
+	if err != nil {
+		t.Fatalf("load custom site: %v", err)
+	}
+	if reloaded.UAMode != customUAMode || reloaded.CustomUserAgent != "New UA" || reloaded.CustomClient != "New Client" || reloaded.CustomVersion != "2.0" {
+		t.Fatalf("custom update = %#v", reloaded)
+	}
+
+	// PUT switching custom -> passthrough clears the triplet again.
+	passPayload, err := json.Marshal(map[string]interface{}{
+		"name":        reloaded.Name,
+		"listen_port": reloaded.ListenPort,
+		"target_url":  reloaded.TargetURL,
+		"ua_mode":     "passthrough",
+	})
+	if err != nil {
+		t.Fatalf("marshal passthrough payload: %v", err)
+	}
+	rr = httptest.NewRecorder()
+	app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, "/api/sites/"+jsonNumber64(created.ID), bytes.NewReader(passPayload)))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("passthrough update status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	reloaded, err = app.db.GetSite(created.ID)
+	if err != nil {
+		t.Fatalf("load passthrough site: %v", err)
+	}
+	if reloaded.UAMode != passthroughUAMode || reloaded.CustomUserAgent != "" || reloaded.CustomClient != "" || reloaded.CustomVersion != "" {
+		t.Fatalf("passthrough update = %#v, want cleared custom triplet", reloaded)
+	}
+}
+
+func TestHandleSitesRejectsUnknownUAMode(t *testing.T) {
+	app := newTestApp(t)
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":        "bogus-mode",
+		"listen_port": freePort(t),
+		"target_url":  "http://127.0.0.1:8096",
+		"ua_mode":     "bogus",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	app.handleSites(rr, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(payload)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	if sites, err := app.db.ListSites(); err != nil || len(sites) != 0 {
+		t.Fatalf("unknown-mode site was persisted: sites=%#v err=%v", sites, err)
+	}
+}
+
+func TestHandleSiteDiagMarksPassthroughWithoutExposingIdentity(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/System/Info/Public" {
+			w.Write([]byte("{\"Version\":\"4.9.0\"}"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("diag-passthrough", freePort(t), upstream.URL, "", "direct", "[]", passthroughUAMode, 0, 0)
+	if err != nil {
+		t.Fatalf("create passthrough site: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	app.handleSiteByID(rr, httptest.NewRequest(http.MethodGet, "/api/sites/"+jsonNumber64(site.ID)+"/diag", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("diag status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	headers := mustMapValue(t, decodeBody(t, rr), "headers")
+	if got := mustBoolValue(t, headers, "passthrough"); !got {
+		t.Fatalf("passthrough = %v, want true", got)
+	}
+	if got := mustBoolValue(t, headers, "ua_applied"); got {
+		t.Fatalf("ua_applied = %v, want false", got)
+	}
+	// Diagnostics must not render identity values for passthrough: there is no
+	// configured profile, and the real request headers are never shown.
+	if got := mustStringValue(t, headers, "current_ua"); got != "" {
+		t.Fatalf("current_ua = %q, want empty", got)
+	}
+	if got := mustStringValue(t, headers, "client_field"); got != "" {
+		t.Fatalf("client_field = %q, want empty", got)
+	}
+	if got := mustStringValue(t, headers, "version_field"); got != "" {
+		t.Fatalf("version_field = %q, want empty", got)
+	}
+}
+
+func TestHandleUAProfilesReturnsThreePresetsWithoutPassthrough(t *testing.T) {
+	app := newTestApp(t)
+	rr := httptest.NewRecorder()
+	app.handleUAProfiles(rr, httptest.NewRequest(http.MethodGet, "/api/ua-profiles", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var profiles []UAProfile
+	if err := json.Unmarshal(rr.Body.Bytes(), &profiles); err != nil {
+		t.Fatalf("decode profiles: %v body=%s", err, rr.Body.String())
+	}
+	if len(profiles) != 3 {
+		t.Fatalf("profiles = %#v, want exactly the three presets", profiles)
+	}
+	names := make(map[string]bool, len(profiles))
+	for _, p := range profiles {
+		names[p.Name] = true
+		if p.Name == "" || p.UserAgent == "" || p.Client == "" || p.Version == "" {
+			t.Fatalf("preset with empty identity fields: %#v", p)
+		}
+	}
+	for _, want := range []string{"Infuse", "Web", "Client"} {
+		if !names[want] {
+			t.Fatalf("presets missing %q: %#v", want, profiles)
+		}
 	}
 }
 

--- a/tests/sites_ua_mode.test.js
+++ b/tests/sites_ua_mode.test.js
@@ -6,14 +6,25 @@ const path = require('node:path');
 const test = require('node:test');
 const vm = require('node:vm');
 
+const STATIC_JS = path.join(__dirname, '..', 'web', 'static', 'js');
+
 function loadSiteHelpers() {
-  const source = fs.readFileSync(
-    path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'sites.js'),
-    'utf8',
-  );
+  const source = fs.readFileSync(path.join(STATIC_JS, 'pages', 'sites.js'), 'utf8');
   const sandbox = { window: {} };
   vm.createContext(sandbox);
   vm.runInContext(source, sandbox, { filename: 'sites.js' });
+  return sandbox;
+}
+
+// Loads page scripts into one shared sandbox, mirroring how index.html evaluates
+// them as classic <script> tags sharing a single global.
+function loadPageScripts(...relativePaths) {
+  const sandbox = { window: {} };
+  vm.createContext(sandbox);
+  for (const relativePath of relativePaths) {
+    const filename = path.join(STATIC_JS, relativePath);
+    vm.runInContext(fs.readFileSync(filename, 'utf8'), sandbox, { filename: relativePath });
+  }
   return sandbox;
 }
 
@@ -58,4 +69,75 @@ test('custom UA payload trims custom values and preset payload clears them', () 
   assert.equal(preset.custom_user_agent, '');
   assert.equal(preset.custom_client, '');
   assert.equal(preset.custom_version, '');
+});
+
+test('passthrough form state hides, unrequires and clears the custom triplet', () => {
+  const { customUAFormState } = loadSiteHelpers();
+  const state = customUAFormState('passthrough', {
+    custom_user_agent: 'stale',
+    custom_client: 'stale',
+    custom_version: 'stale',
+  });
+
+  assert.equal(state.visible, false);
+  assert.equal(state.required, false);
+  assert.equal(state.customUserAgent, '');
+  assert.equal(state.customClient, '');
+  assert.equal(state.customVersion, '');
+});
+
+test('passthrough payload clears the custom triplet', () => {
+  const { buildCustomUAPayload } = loadSiteHelpers();
+  const payload = buildCustomUAPayload('passthrough', 'stale UA', 'stale Client', '1.0');
+  assert.equal(payload.custom_user_agent, '');
+  assert.equal(payload.custom_client, '');
+  assert.equal(payload.custom_version, '');
+});
+
+test('passthrough mode label maps to 透传 with an existing pill class', () => {
+  const sandbox = loadPageScripts('pages/dashboard.js', 'pages/sites.js');
+  const { uaNameMap, uaClassMap } = vm.runInContext('({ uaNameMap, uaClassMap })', sandbox);
+
+  assert.equal(uaNameMap.passthrough, '透传');
+  assert.ok(
+    ['pill-blue', 'pill-green', 'pill-orange', 'pill-purple'].includes(uaClassMap.passthrough),
+    'passthrough must reuse an existing pill class, not introduce a new one',
+  );
+});
+
+test('diagnostics renders passthrough status instead of UA value rows', () => {
+  const { renderHeadersCard } = loadPageScripts('api.js', 'pages/diag.js');
+  const html = renderHeadersCard({
+    passthrough: true,
+    ua_applied: false,
+    current_ua: 'Sneaky-UA',
+    client_field: 'Sneaky-Client',
+    version_field: '9.9.9',
+  }, 'stagger-5');
+
+  assert.ok(html.includes('UA 透传'), 'passthrough row must be rendered');
+  assert.ok(html.includes('保留客户端原值'), 'passthrough row must state the client value is kept');
+  assert.ok(!html.includes('UA 改写'), 'UA 改写 row must not render for passthrough');
+  assert.ok(!html.includes('当前 UA'), 'empty 当前 UA row must not render for passthrough');
+  assert.ok(!html.includes('Client 字段'), 'Client 字段 row must not render for passthrough');
+  assert.ok(!html.includes('Version 字段'), 'Version 字段 row must not render for passthrough');
+  assert.ok(!html.includes('Sneaky-UA'), 'real request UA must never be rendered');
+  assert.ok(!html.includes('Sneaky-Client'), 'real request client must never be rendered');
+  assert.ok(!html.includes('9.9.9'), 'real request version must never be rendered');
+});
+
+test('diagnostics keeps configured UA rows for non-passthrough modes', () => {
+  const { renderHeadersCard } = loadPageScripts('api.js', 'pages/diag.js');
+  const html = renderHeadersCard({
+    ua_applied: true,
+    current_ua: 'Infuse/7.8.1',
+    client_field: 'Infuse',
+    version_field: '7.8.1',
+  }, 'stagger-5');
+
+  assert.ok(html.includes('UA 改写'), 'UA 改写 row must still render');
+  assert.ok(html.includes('已启用'), 'enabled rewrite status must still render');
+  assert.ok(html.includes('Infuse/7.8.1'), 'configured UA must still render');
+  assert.ok(html.includes('Client 字段'), 'Client 字段 row must still render');
+  assert.ok(html.includes('Version 字段'), 'Version 字段 row must still render');
 });

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -205,8 +205,8 @@ async function loadDashboardData() {
   loadDashboardTable();
 }
 
-const uaClassMap = { infuse: 'pill-blue', web: 'pill-green', client: 'pill-orange', custom: 'pill-purple' };
-const uaNameMap = { infuse: 'Infuse', web: 'Web', client: '客户端', custom: '自定义' };
+const uaClassMap = { infuse: 'pill-blue', web: 'pill-green', client: 'pill-orange', custom: 'pill-purple', passthrough: 'pill-blue' };
+const uaNameMap = { infuse: 'Infuse', web: 'Web', client: '客户端', custom: '自定义', passthrough: '透传' };
 
 function formatBytes(bytes) {
   if (!bytes || bytes === 0) return '0 B';

--- a/web/static/js/pages/diag.js
+++ b/web/static/js/pages/diag.js
@@ -171,6 +171,21 @@ function renderHeadersCard(headers, staggerClass) {
   const profileError = headers.profile_error
     ? '<div class="diag-row"><span class="diag-key">身份配置</span><span class="diag-val bad diag-wrap">' + esc(headers.profile_error) + '</span></div>'
     : '';
+
+  let rows;
+  if (headers.passthrough) {
+    rows = `
+      <div class="diag-row"><span class="diag-key">UA 透传</span><span class="diag-val good diag-wrap">保留客户端原值</span></div>
+    `;
+  } else {
+    rows = `
+      <div class="diag-row"><span class="diag-key">UA 改写</span><span class="diag-val ${headers.ua_applied ? 'good' : 'bad'}">${headers.ua_applied ? '已启用' : '未启用'}</span></div>
+      <div class="diag-row"><span class="diag-key">当前 UA</span><span class="diag-val diag-wrap">${diagText(headers.current_ua)}</span></div>
+      <div class="diag-row"><span class="diag-key">Client 字段</span><span class="diag-val">${diagText(headers.client_field)}</span></div>
+      <div class="diag-row"><span class="diag-key">Version 字段</span><span class="diag-val">${diagText(headers.version_field)}</span></div>
+    `;
+  }
+
   return `
     <div class="diag-card fade-up ${staggerClass}">
       <div class="diag-head">
@@ -183,10 +198,7 @@ function renderHeadersCard(headers, staggerClass) {
         </div>
       </div>
       <div class="diag-rows">
-        <div class="diag-row"><span class="diag-key">UA 改写</span><span class="diag-val ${headers.ua_applied ? 'good' : 'bad'}">${headers.ua_applied ? '已启用' : '未启用'}</span></div>
-        <div class="diag-row"><span class="diag-key">当前 UA</span><span class="diag-val diag-wrap">${diagText(headers.current_ua)}</span></div>
-        <div class="diag-row"><span class="diag-key">Client 字段</span><span class="diag-val">${diagText(headers.client_field)}</span></div>
-        <div class="diag-row"><span class="diag-key">Version 字段</span><span class="diag-val">${diagText(headers.version_field)}</span></div>
+        ${rows}
         ${profileError}
       </div>
     </div>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -212,6 +212,7 @@ function showSiteModal(site) {
         <option value="web" ${isEdit && site.ua_mode === 'web' ? 'selected' : ''}>Web</option>
         <option value="client" ${isEdit && site.ua_mode === 'client' ? 'selected' : ''}>客户端</option>
         <option value="custom">自定义</option>
+        <option value="passthrough" ${isEdit && site.ua_mode === 'passthrough' ? 'selected' : ''}>透传（保留客户端身份）</option>
       </select>
     </div>
     <div class="form-group" id="m-custom-ua-group" hidden>

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
@@ -89,14 +90,32 @@ func (u *fakeWSUpstream) waitFor(t *testing.T, marker string) {
 	t.Fatalf("upstream never received %q; got %q", marker, u.received())
 }
 
-func newWSProxyServer(t *testing.T, upstreamAddr string, inst *ProxyInstance, speedLimitBytes int64) *httptest.Server {
+// waitForRequest blocks until a complete HTTP request header block has arrived
+// and parses it with http.ReadRequest. Header names are case-insensitive on the
+// wire and net/http writes its canonical spelling (e.g. "Sec-Websocket-Key"), so
+// callers must look headers up by name rather than match literal header text.
+func (u *fakeWSUpstream) waitForRequest(t *testing.T) *http.Request {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(u.received())))
+		if err == nil {
+			return req
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("upstream never received a complete request; got %q", u.received())
+	return nil
+}
+
+func newWSProxyServer(t *testing.T, upstreamAddr string, inst *ProxyInstance, speedLimitBytes int64, policy UAHeaderPolicy) *httptest.Server {
 	t.Helper()
 	target, err := normalizeTargetURL("http://" + upstreamAddr)
 	if err != nil {
 		t.Fatalf("normalizeTargetURL: %v", err)
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleWebSocket(w, r, target, getUAProfile("infuse"), inst, speedLimitBytes)
+		handleWebSocket(w, r, target, policy, inst, speedLimitBytes)
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -122,7 +141,7 @@ func TestHandleWebSocketRefusesTunnelWhenUpstreamDoesNotSwitchProtocols(t *testi
 	// requests that skipped every forwarding-header sanitizer.
 	upstream := startFakeWSUpstream(t, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
 	inst := &ProxyInstance{server: &http.Server{}}
-	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0)
+	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
 
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	if err != nil {
@@ -173,7 +192,7 @@ func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
 		"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"+
 		serverPayload)
 	inst := &ProxyInstance{server: &http.Server{}}
-	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0)
+	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
 
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	if err != nil {
@@ -220,7 +239,7 @@ func TestHandleWebSocketRejectsUpgradeCarryingBody(t *testing.T) {
 	// Nothing on the upgrade path reads r.Body, so a body would be left in the
 	// hijacked buffer and relayed to the upstream verbatim.
 	inst := &ProxyInstance{server: &http.Server{}}
-	srv := newWSProxyServer(t, "127.0.0.1:9", inst, 0)
+	srv := newWSProxyServer(t, "127.0.0.1:9", inst, 0, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
 
 	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
 	if err != nil {
@@ -248,6 +267,92 @@ func TestHandleWebSocketRejectsUpgradeCarryingBody(t *testing.T) {
 	}
 	if !strings.Contains(string(buf[:n]), "400 Bad Request") {
 		t.Fatalf("client response = %q, want 400 Bad Request", string(buf[:n]))
+	}
+}
+
+func TestHandleWebSocketPassthroughPreservesClientIdentity(t *testing.T) {
+	const clientUA = "ClientUA/9.9"
+	const clientAuth = `MediaBrowser Client="Client", Device="TV", Version="1"`
+
+	for _, tc := range []struct {
+		name     string
+		policy   UAHeaderPolicy
+		wantUA   string
+		wantAuth string
+		absent   []string
+	}{
+		{
+			name:     "passthrough keeps client identity",
+			policy:   UAHeaderPolicy{},
+			wantUA:   clientUA,
+			wantAuth: clientAuth,
+			absent:   []string{"Infuse/7.8.1", `Client="Infuse"`},
+		},
+		{
+			name:     "rewrite applies configured identity",
+			policy:   UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")},
+			wantUA:   "Infuse/7.8.1",
+			wantAuth: `MediaBrowser Client="Infuse", Device="TV", Version="7.8.1"`,
+			absent:   []string{clientUA, `Client="Client"`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := startFakeWSUpstream(t, "HTTP/1.1 101 Switching Protocols\r\n"+
+				"Upgrade: websocket\r\n"+
+				"Connection: Upgrade\r\n"+
+				"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n")
+			inst := &ProxyInstance{server: &http.Server{}}
+			srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0, tc.policy)
+
+			conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+			if err != nil {
+				t.Fatalf("dial proxy: %v", err)
+			}
+			handshake := "GET /embywebsocket HTTP/1.1\r\n" +
+				"Host: proxy.test\r\n" +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n" +
+				"User-Agent: " + clientUA + "\r\n" +
+				"X-Emby-Authorization: " + clientAuth + "\r\n\r\n"
+			if _, err := io.WriteString(conn, handshake); err != nil {
+				conn.Close()
+				t.Fatalf("write handshake: %v", err)
+			}
+			// Drain until the relayed 101 arrives, then close our side.
+			if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				conn.Close()
+				t.Fatalf("set client deadline: %v", err)
+			}
+			buf := make([]byte, 1024)
+			seen := ""
+			for !strings.Contains(seen, "101 Switching Protocols") {
+				n, err := conn.Read(buf)
+				if err != nil {
+					break
+				}
+				seen += string(buf[:n])
+			}
+			conn.Close()
+
+			req := upstream.waitForRequest(t)
+			received := upstream.received()
+			if got := req.Header.Get("Sec-WebSocket-Key"); got != "dGhlIHNhbXBsZSBub25jZQ==" {
+				t.Fatalf("upstream handshake Sec-WebSocket-Key = %q, want the client key; got: %q", got, received)
+			}
+			if got := req.Header.Get("User-Agent"); got != tc.wantUA {
+				t.Fatalf("upstream handshake User-Agent = %q, want %q; got: %q", got, tc.wantUA, received)
+			}
+			if got := req.Header.Get("X-Emby-Authorization"); got != tc.wantAuth {
+				t.Fatalf("upstream handshake X-Emby-Authorization = %q, want %q; got: %q", got, tc.wantAuth, received)
+			}
+			for _, marker := range tc.absent {
+				if strings.Contains(received, marker) {
+					t.Fatalf("upstream handshake carried %q: %q", marker, received)
+				}
+			}
+		})
 	}
 }
 
@@ -297,7 +402,7 @@ func TestPrepareWebSocketUpstreamHeadersDropsContentLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeTargetURL: %v", err)
 	}
-	header := prepareWebSocketUpstreamHeaders(req, target, getUAProfile("infuse"))
+	header := prepareWebSocketUpstreamHeaders(req, target, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
 	if got := header.Get("Content-Length"); got != "" {
 		t.Fatalf("Content-Length = %q, want it dropped before the upstream handshake", got)
 	}


### PR DESCRIPTION
## Summary

Adds a **UA passthrough mode** as a third site UA policy alongside the existing custom/infuse/web modes. In passthrough, the proxy preserves the client's identity headers byte for byte instead of rewriting them.

## Changes

- **custom vs passthrough** — `custom` rewrites the inbound `User-Agent` (and associated identity headers) to a configured value; `passthrough` leaves every inbound identity header untouched. Passthrough is never encoded as an empty-UAProfile sentinel, so it round-trips through site configuration and the dashboard cleanly.
- **HTTP / WebSocket / redirect safety** — the passthrough path is handled consistently in the HTTP proxy path, the WebSocket upgrade path, and redirect following. For WebSocket upgrades, upstream headers are rebuilt from the inbound request (hop-by-hop `Connection` tokens are stripped before forwarding), so secrets stay behind while the client identity passes through.
- **Full Token attribute stripping fix** — the token-scrubbing logic now handles every attribute layout: a value whose only attribute is the token reduces to its bare scheme; a leading token is dropped together with its following delimiter; a token after other attributes is dropped with its preceding delimiter. Previously only some layouts were scrubbed.
- **Frontend** — sites page exposes the new mode; dashboard pills and diagnostics show "透传" (passthrough) vs rewrite state (`headers.passthrough`).
- **No migration** — no schema change, no config migration; the new mode is a pure additive enum value.

## Verification evidence

- Rebased on `origin/master` `1500a02`; `go test -race` all green (main_test.go +670, websocket_test.go +117).
- Node frontend tests 26/26, including `tests/sites_ua_mode.test.js` (+90).
- `go mod`, vet (incl. Windows/Darwin targets), `govulncheck`/`gosec`, cross-platform builds, installer CI — all passed.
- Real-instance smoke (parent-verified): HTTP, WebSocket, fixed-mode, and cross-authority scenarios — full Token attribute stripping verified end to end.

Closes #29

## Scope

No merge, tag, or Release is created by this PR; release steps are gated on CI results and follow-up review.
