### PR TITLE
release: v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=v1.5.6
+ARG VERSION=v1.6.0
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION}" -o meridian .
 
 # Runtime stage

--- a/main.go
+++ b/main.go
@@ -3857,7 +3857,7 @@ func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
 var startTime = time.Now()
 
 // appVersion is overridable at build time via -ldflags "-X main.appVersion=vX.Y.Z".
-var appVersion = "v1.5.6"
+var appVersion = "v1.6.0"
 
 func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, error) {
 	if len(args) == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -961,7 +961,7 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read embedded index HTML: %v", err)
 	}
-	for _, asset := range []string{"/css/style.css?v=1.5.6", "/js/pages/sites.js?v=1.5.6", "/js/app.js?v=1.5.6"} {
+	for _, asset := range []string{"/css/style.css?v=1.6.0", "/js/pages/sites.js?v=1.6.0", "/js/app.js?v=1.6.0"} {
 		if !strings.Contains(string(indexHTML), asset) {
 			t.Errorf("index must cache-bust updated asset %q", asset)
 		}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.5.6">
-<link rel="stylesheet" href="/css/style.css?v=1.5.6">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.6.0">
+<link rel="stylesheet" href="/css/style.css?v=1.6.0">
 </head>
 <body>
 
@@ -101,13 +101,13 @@
 
 </div>
 
-<script src="/js/api.js?v=1.5.6"></script>
-<script src="/js/toast.js?v=1.5.6"></script>
-<script src="/js/router.js?v=1.5.6"></script>
-<script src="/js/pages/dashboard.js?v=1.5.6"></script>
-<script src="/js/pages/sites.js?v=1.5.6"></script>
-<script src="/js/pages/traffic.js?v=1.5.6"></script>
-<script src="/js/pages/diag.js?v=1.5.6"></script>
-<script src="/js/app.js?v=1.5.6"></script>
+<script src="/js/api.js?v=1.6.0"></script>
+<script src="/js/toast.js?v=1.6.0"></script>
+<script src="/js/router.js?v=1.6.0"></script>
+<script src="/js/pages/dashboard.js?v=1.6.0"></script>
+<script src="/js/pages/sites.js?v=1.6.0"></script>
+<script src="/js/pages/traffic.js?v=1.6.0"></script>
+<script src="/js/pages/diag.js?v=1.6.0"></script>
+<script src="/js/app.js?v=1.6.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Release branch for **v1.6.0**: version-stamp bump only (4 files, +13/−13). No functional code changes.

## Changes

- `Dockerfile`: build `ARG VERSION` v1.5.6 → v1.6.0.
- `main.go`: `appVersion` v1.5.6 → v1.6.0 (binary `--version` reports v1.6.0, verified locally).
- `main_test.go`: cache-bust asset assertions updated to `?v=1.6.0`.
- `web/static/index.html`: all asset/cache-bust version queries bumped to v1.6.0.
- Installer test fixtures are intentionally untouched (install tests keep their own version samples).

## What v1.6.0 ships (already merged to master)

- [#34](https://github.com/snnabb/Meridian/pull/34) — `fix: make live traffic snapshots consistent`: atomic `/api/traffic/{id}/snapshot` endpoint, per-instance `trafficMu`, fail-closed flush lifecycle, legacy API compatibility, frontend live timer.
- [#35](https://github.com/snnabb/Meridian/pull/35) — `feat: add UA passthrough mode`: byte-for-byte identity header passthrough across HTTP/WebSocket/redirect paths, full Token attribute stripping fix, closes #29.
- [#33](https://github.com/snnabb/Meridian/pull/33) — v1.5.6 security hardening (already released as v1.5.6; v1.6.0 continues from that baseline).

## Verification evidence

- Parent-verified full CI-equivalent green: `go test -race`, Node frontend tests, vet (incl. Windows/Darwin targets), `govulncheck`/`gosec`, cross-platform builds, installer CI.
- Local binary `--version` reports `v1.6.0`.

## Release workflow asset contract

The tag-based release workflow builds and uploads exactly: `meridian-linux-amd64`, `meridian-linux-arm64`, `meridian-darwin-amd64`, `meridian-darwin-arm64`, `meridian-windows-amd64.exe`, `SHA256SUMS`, plus the Docker image. No manual asset uploads; no test-machine steps are part of the workflow.

## Scope

No merge, tag, or Release is created by this PR; the release gate (tag + workflow) is a separate, parent-approved step after this PR merges.
