### PR TITLE
fix: publish multi-arch GHCR images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
@@ -148,6 +154,7 @@ jobs:
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ env.RELEASE_TAG }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=v1.6.0
+ARG VERSION=v1.6.1
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION}" -o meridian .
 
 # Runtime stage

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ go build -trimpath -buildvcs=false -o meridian .      # 编译
 - 多平台构建（linux/amd64、linux/arm64、windows/amd64、darwin/amd64、darwin/arm64）
 - 创建 GitHub Release 并上传二进制
 - 生成并上传 `SHA256SUMS`
-- 构建并推送 Docker 镜像到 `ghcr.io`
+- 构建并推送 linux/amd64、linux/arm64 多架构 Docker 镜像到 `ghcr.io`
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -3857,7 +3857,7 @@ func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
 var startTime = time.Now()
 
 // appVersion is overridable at build time via -ldflags "-X main.appVersion=vX.Y.Z".
-var appVersion = "v1.6.0"
+var appVersion = "v1.6.1"
 
 func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, error) {
 	if len(args) == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -961,7 +961,7 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read embedded index HTML: %v", err)
 	}
-	for _, asset := range []string{"/css/style.css?v=1.6.0", "/js/pages/sites.js?v=1.6.0", "/js/app.js?v=1.6.0"} {
+	for _, asset := range []string{"/css/style.css?v=1.6.1", "/js/pages/sites.js?v=1.6.1", "/js/app.js?v=1.6.1"} {
 		if !strings.Contains(string(indexHTML), asset) {
 			t.Errorf("index must cache-bust updated asset %q", asset)
 		}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.6.0">
-<link rel="stylesheet" href="/css/style.css?v=1.6.0">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.6.1">
+<link rel="stylesheet" href="/css/style.css?v=1.6.1">
 </head>
 <body>
 
@@ -101,13 +101,13 @@
 
 </div>
 
-<script src="/js/api.js?v=1.6.0"></script>
-<script src="/js/toast.js?v=1.6.0"></script>
-<script src="/js/router.js?v=1.6.0"></script>
-<script src="/js/pages/dashboard.js?v=1.6.0"></script>
-<script src="/js/pages/sites.js?v=1.6.0"></script>
-<script src="/js/pages/traffic.js?v=1.6.0"></script>
-<script src="/js/pages/diag.js?v=1.6.0"></script>
-<script src="/js/app.js?v=1.6.0"></script>
+<script src="/js/api.js?v=1.6.1"></script>
+<script src="/js/toast.js?v=1.6.1"></script>
+<script src="/js/router.js?v=1.6.1"></script>
+<script src="/js/pages/dashboard.js?v=1.6.1"></script>
+<script src="/js/pages/sites.js?v=1.6.1"></script>
+<script src="/js/pages/traffic.js?v=1.6.1"></script>
+<script src="/js/pages/diag.js?v=1.6.1"></script>
+<script src="/js/app.js?v=1.6.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes the GHCR release workflow to publish **multi-arch** images (`linux/amd64` + `linux/arm64`) instead of single-arch, and bumps version stamps to **v1.6.1**. 6 files, +21/−14.

## Root cause (v1.6.0 single-arch image)

The v1.6.0 release workflow built and pushed the Docker image with no explicit platform configuration and no QEMU emulation setup on the `docker` job. On the default runner (linux/amd64), `docker buildx` therefore produced and pushed only `linux/amd64`, leaving GHCR without an `linux/arm64` variant even though the release assets included `meridian-linux-arm64`.

## Changes

- **QEMU + Buildx setup** — the `docker` job now runs `docker/setup-qemu-action` (pinned `96fe6ef…` # v4.2.0, `platforms: arm64`) and `docker/setup-buildx-action` (pinned `bb05f3f…` # v4.2.0) before building.
- **Explicit platforms** — the docker build/push step now declares `platforms: linux/amd64,linux/arm64`, so both architectures are built and pushed to `ghcr.io` as a manifest list.
- **Pins** — both actions are pinned to full commit SHAs with `# v4.2.0` comments, matching the repository's action-pinning convention.
- **README** — documents the multi-arch (`linux/amd64`, `linux/arm64`) image contract.
- **v1.6.1 stamps** — `Dockerfile` `ARG VERSION`, `main.go` `appVersion`, `main_test.go` cache-bust assertions, and `web/static/index.html` asset queries all bumped v1.6.0 → v1.6.1.

## Verification evidence (parent-verified)

- Full regression suite green: `go test -race`, Node frontend tests, vet (incl. Windows/Darwin targets), `govulncheck`/`gosec`, cross-platform builds, installer CI.
- `actionlint` clean on the workflow changes.
- Local dual-arch OCI build verified (`linux/amd64` + `linux/arm64` images), and both architectures passed runtime checks (QEMU-arm64 container ran successfully).

## Scope

No merge, tag, or Release is created by this PR; the v1.6.1 tag + release workflow run is a separate, parent-approved step after this PR merges.
