### PR TITLE
feat: add secure Host-based ingress for CDN deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
           node --test tests/*.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
-          shellcheck install.sh tests/install_test.sh
+          bash -n tests/upstream_header_key_test.sh
+          shellcheck install.sh tests/install_test.sh tests/upstream_header_key_test.sh
+          bash tests/upstream_header_key_test.sh
           bash tests/install_test.sh
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,26 @@ jobs:
           go mod verify
           go test -race ./...
           go vet ./...
+          GOOS=windows GOARCH=amd64 go vet ./...
+          GOOS=darwin GOARCH=arm64 go vet ./...
           find web/static/js -name '*.js' -print0 | xargs -0 -n1 node --check
           node --test tests/*.test.js
           bash -n install.sh
           bash -n tests/install_test.sh
-          shellcheck install.sh tests/install_test.sh
+          bash -n tests/upstream_header_key_test.sh
+          shellcheck install.sh tests/install_test.sh tests/upstream_header_key_test.sh
+          bash tests/upstream_header_key_test.sh
           bash tests/install_test.sh
 
       - name: Vulnerability scan
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
           govulncheck ./...
+
+      - name: Security lint
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+          gosec -quiet -severity medium -confidence medium ./...
 
       - name: Build
         run: go build -trimpath -buildvcs=false -o meridian .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=v1.6.1
+ARG VERSION=v1.7.0
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION}" -o meridian .
 
 # Runtime stage

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Meridian 把这些事情打包成一个单二进制程序，带管理界面，�
 
 | 功能 | 说明 |
 |------|------|
-| **多站点反代** | 每个站点独立监听端口，独立配置上游地址 |
+| **多站点反代** | 每个站点可选择 `host`、`port` 或 `both` 入口模式，并独立配置主回源与播放回源 |
+| **共享域名入口** | 可为站点配置一个精确域名，通过面板入口按 Host 分流，兼容 Nginx/CDN 的标准 443 入口 |
 | **双上游分流** | 网页/API 和播放/转码流量可分别指向不同上游 |
 | **UA 伪装** | 预设（Infuse / Web / 客户端）、自定义固定身份或透传保留客户端身份；HTTP、WebSocket 与受限播放重定向统一改写或透传 |
+| **加密上游请求头** | 为主回源添加固定自定义 Header；值加密存储、只写不回显，且不会转发到独立播放/CDN 域名 |
 | **流量管控** | 按站点统计流量、设置限速、设置配额 |
 | **WebSocket 代理** | 完整支持 Emby 的 WebSocket 通信 |
 | **SSE 实时推送** | 仪表盘数据通过 Server-Sent Events 实时更新 |
@@ -98,6 +100,7 @@ docker run -d --name meridian \
   -p 127.0.0.1:9090:9090 -p 8001-8010:8001-8010 \
 	-v meridian-data:/app/data \
 	-e JWT_SECRET=$(openssl rand -hex 32) \
+	-e UPSTREAM_HEADER_KEY=$(openssl rand -hex 32) \
 	-e SETUP_TOKEN="$MERIDIAN_SETUP_TOKEN" \
 	ghcr.io/snnabb/meridian:latest
 ```
@@ -120,11 +123,12 @@ function New-MeridianSecret {
     -join ($bytes | ForEach-Object { $_.ToString('x2') })
 }
 $env:JWT_SECRET = New-MeridianSecret
+$env:UPSTREAM_HEADER_KEY = New-MeridianSecret
 $env:SETUP_TOKEN = New-MeridianSecret
 .\meridian.exe
 ```
 
-> 密钥必须用密码学安全随机数生成。`Get-Random` 不够安全，不要用它生成 `JWT_SECRET` 或 `SETUP_TOKEN`。若以前按旧命令生成过密钥，请重新生成并轮换 `JWT_SECRET`。
+> 密钥必须用密码学安全随机数生成。`Get-Random` 不够安全，不要用它生成 `JWT_SECRET`、`UPSTREAM_HEADER_KEY` 或 `SETUP_TOKEN`。若以前按旧命令生成过密钥，请重新生成并轮换 `JWT_SECRET`；已经保存固定上游 Header 后不要直接轮换 `UPSTREAM_HEADER_KEY`，否则旧密文无法解密，必须为所有相关站点重新配置 Header 值。
 >
 > Windows 二进制下载同样依赖 GitHub Releases。没有已发布版本时，请使用源码构建。
 
@@ -134,7 +138,7 @@ $env:SETUP_TOKEN = New-MeridianSecret
 ```bash
 git clone https://github.com/snnabb/Meridian.git && cd Meridian
 go build -o meridian .
-JWT_SECRET=$(openssl rand -hex 32) SETUP_TOKEN=$(openssl rand -hex 32) ./meridian
+JWT_SECRET=$(openssl rand -hex 32) UPSTREAM_HEADER_KEY=$(openssl rand -hex 32) SETUP_TOKEN=$(openssl rand -hex 32) ./meridian
 ```
 
 未配置域名时访问 `http://你的IP:9090`；配置后访问对应的 `https://面板域名`。首次打开会要求输入管理员账号、12–72 字节的密码，以及安装完成时显示的初始化令牌。源码、Docker 和 Windows 部署必须在首次启动前显式设置 `SETUP_TOKEN`；服务本身不会自动生成或记录该值。
@@ -162,11 +166,12 @@ unset ADMIN_PASSWORD
 |------|--------|------|
 | `PORT` | `9090` | 管理面板监听端口 |
 | `DB_PATH` | `meridian.db` | SQLite 数据库路径 |
-| `PANEL_BIND_ADDR` | `0.0.0.0` | 仅控制管理面板的绑定地址；域名模式由安装器设为 `127.0.0.1`，不影响站点监听端口 |
-| `PANEL_DOMAIN` | 空 | 安装器记录的单个管理面板域名；不作为播放回源配置 |
+| `PANEL_BIND_ADDR` | `0.0.0.0` | 控制管理面板及共享 Host 入口的绑定地址；严格 `host` 模式要求回环地址，或配合非空 `TRUSTED_PROXY_CIDRS` 做入口来源白名单 |
+| `PANEL_DOMAIN` | 空 | 管理面板的唯一允许域名；设置后未知 Host 返回 `421`，不再回退到面板 |
 | `JWT_SECRET` | 进程启动时随机生成 | 至少 32 字节的 JWT 签名密钥。**生产环境必须显式设置**，否则每次重启后会话全部失效 |
+| `UPSTREAM_HEADER_KEY` | 空 | 至少 32 字节的独立加密密钥；配置固定上游请求头时必需。丢失或轮换后，已有请求头无法解密；一键安装器会自动生成 |
 | `SETUP_TOKEN` | 无 | 数据库中没有管理员时必须设置的初始化令牌；首次创建成功后仅从进程内存清除，服务不会记录其值 |
-| `TRUSTED_PROXY_CIDRS` | 空 | 允许提供 `X-Real-IP`/`X-Forwarded-For` 的反向代理 CIDR，多个值用逗号分隔；不要填写不受信任的客户端网段 |
+| `TRUSTED_PROXY_CIDRS` | 空 | 可信入口代理 CIDR，多个值用逗号分隔。Meridian 只采纳其规范化的 `X-Real-IP`/`X-Forwarded-Proto`，并在面板非回环绑定时把它同时作为严格 `host` 入口来源白名单；不要填写客户端网段或 `0.0.0.0/0` |
 
 ### Docker Compose
 
@@ -193,6 +198,7 @@ services:
       - meridian-data:/app/data
     environment:
       - JWT_SECRET=your-secret-here    # 替换为一个固定随机字符串
+      - UPSTREAM_HEADER_KEY=your-other-secret-here # 与 JWT_SECRET 不同的固定随机字符串
       - SETUP_TOKEN=your-setup-token   # 首次启动前设置并妥善保存
 
 volumes:
@@ -204,22 +210,30 @@ volumes:
 ## 技术架构
 
 ```
-┌─────────────────────────────────────────────┐
-│                 Meridian                      │
-│                                              │
-│  ┌──────────┐   ┌──────────────────────────┐ │
-│  │ 管理面板  │   │     反代引擎 (per-site)   │ │
-│  │ :9090    │   │  :8001  :8002  :800N     │ │
-│  │          │   │                          │ │
-│  │ REST API │   │  HTTP ──► target_url     │ │
-│  │ SSE 推送 │   │  WS   ──► target_url     │ │
-│  │ 静态文件  │   │  播放  ──► playback_target_url │ │
-│  └──────────┘   └──────────────────────────┘ │
-│       │                     │                │
-│  ┌──────────────────────────────────────┐    │
-│  │            SQLite (嵌入式)            │    │
-│  └──────────────────────────────────────┘    │
-└─────────────────────────────────────────────┘
+                 Nginx / CDN :443
+                         │ 保留原始 Host
+┌────────────────────────▼─────────────────────────┐
+│                    Meridian                      │
+│                                                 │
+│  ┌───────────────────────────────────────────┐  │
+│  │       共享入口 / 管理面板 :9090            │  │
+│  │  PANEL_DOMAIN ──► REST API / SSE / 静态文件 │  │
+│  │  public_host  ──► 站点反代引擎 (host/both)  │  │
+│  └───────────────────────────────────────────┘  │
+│                         │                       │
+│  :8001 / :8002 / :800N ─┤ 可选独立入口          │
+│       (port/both)        │                       │
+│                         ▼                       │
+│  ┌───────────────────────────────────────────┐  │
+│  │              每站点代理与策略              │  │
+│  │  HTTP / WebSocket ──► target_url          │  │
+│  │  播放流量         ──► playback_target_url │  │
+│  └───────────────────────────────────────────┘  │
+│                         │                       │
+│  ┌──────────────────────▼────────────────────┐  │
+│  │              SQLite（嵌入式）              │  │
+│  └───────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
 ```
 
 | 组件 | 技术选型 |
@@ -259,7 +273,7 @@ Meridian/
 | **回源地址**（`target_url`） | 网页、API、元数据 | `https://emby.example.com` |
 | **播放地址**（`playback_target_url`） | 播放、转码、直链下载 | `https://cdn.example.com` |
 
-播放地址为可选项。不设置时所有请求走同一上游。
+播放地址为可选项。不设置时所有请求走同一上游。当前可手工填写最多 128 个播放 authority：第一个是实际播放回源，其余只在 `redirect` 模式中作为允许跟随的重定向白名单；`direct` 模式不会轮询、负载均衡或自动故障转移。本阶段尚不从 Emby 响应中自动发现后端。
 
 地址没有写协议时，Meridian 会把 `域名:443`（也兼容中文全角冒号 `：443`）识别为 HTTPS；其他端口仍默认按 HTTP 处理。HTTPS 使用非 443 端口时请明确写成 `https://域名:端口`。重定向模式会把 `https://域名:443` 和省略默认端口的 `https://域名` 视为同一播放回源。
 
@@ -270,6 +284,60 @@ Meridian/
 
 **典型场景**：Emby 主服务器负责 API 和元数据，CDN 或专用媒体服务器负责大文件分发。
 
+### 共享域名入口
+
+每个站点有三种入口模式：`host`（仅共享域名，推荐）、`port`（仅独立端口）和 `both`（共享域名与独立端口同时启用）。`host` 模式只在面板监听地址上按 `public_host` 分流，不会绑定站点的保留端口；`both` 才会额外监听该高端口。当 Nginx、Cloudflare Tunnel 或其他可信入口保留原始 `Host` 时，Meridian 会把这个域名除下述保留命名空间外的路径转给对应站点。
+
+严格 `host` 模式必须满足以下一项：`PANEL_BIND_ADDR` 是回环地址（推荐，同机 Nginx），或配置非空 `TRUSTED_PROXY_CIDRS`。后一种适用于 Docker 网络/外置入口：共享站点只接受这些 peer CIDR 的请求，直接访问源站 IP 并伪造 `Host` 会返回 `403`。不要把公网客户端网段、容器默认大网段或 `0.0.0.0/0` 当作可信代理；否则等同于取消这层防绕过保护。`both` 是显式高风险兼容模式，独立端口仍需防火墙保护。
+
+设置 `PANEL_DOMAIN` 后，只有精确的面板域名能够进入管理界面，未知域名或 IP Host 返回 `421 Misdirected Request`；已配置但停用的站点返回 `503`，都不会回退并暴露管理面板。未设置 `PANEL_DOMAIN` 时继续支持直接 IP 访问，方便初始部署。
+
+`public_host` 使用精确、大小写不敏感的 DNS 名称匹配。它不接受协议、端口、路径、IP 或通配符，也不能与 `PANEL_DOMAIN` 相同。当前版本不支持路径前缀部署，因为 Emby 的绝对路径、播放 URL 和 WebSocket 端点需要完整的 base-path 协议设计，不能只做字符串裁剪。
+
+`/_meridian/d` 及其子路径保留给后续签名动态播放路由，当前版本固定返回不可缓存的 `410 Gone`，不会转发到任何上游。若现有 Emby 插件或自定义接口正在使用这个命名空间，升级前必须迁移路径；本阶段尚未实现动态后端自动识别。
+
+反向代理必须保留 Host，并把普通 HTTP 与 WebSocket 都转到同一个 Meridian 面板端口。同机 Nginx 建议同时设置 `PANEL_BIND_ADDR=127.0.0.1` 和 `TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128`；前者关闭公网直连，后者让 Meridian 只从本机代理采纳规范化的 `X-Real-IP`。若缺少后者，所有远程登录会共用 Nginx 的回环地址作为限流身份，任一来源都可能触发共享锁定。例如：
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name emby.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:9090;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        client_max_body_size 0; # 或改成符合你上传策略的明确上限
+    }
+}
+```
+
+Meridian 只接受可信代理提供的单值 `X-Real-IP`，不会从可能包含客户端伪造内容的 `X-Forwarded-For` 链选择身份。Docker、Cloudflare Tunnel 或外置 Nginx 应把 `TRUSTED_PROXY_CIDRS` 精确设为实际代理 peer 网段，不能使用 `0.0.0.0/0`。Meridian 不负责为站点域名申请证书或修改 CDN DNS；证书、Cloudflare SSL 模式、防火墙和源站只允许可信入口访问等设置仍由入口层管理。上例的长超时、关闭缓冲和上传上限是流媒体/长连接所需；如果已有全局策略，可以按等价配置调整。
+
+> 新建共享域名站点默认使用 `host`，这是避免绕过 CDN 的推荐配置；程序会拒绝在“非回环绑定且没有可信代理来源”的条件下启用它。只有确实需要兼容直接端口访问时才选择 `both`，并用防火墙限制来源；`port` 和 `both` 的独立端口都会绑定所有网络接口。
+
+### 固定上游请求头
+
+每个站点可以为主回源配置最多 16 个固定 Header。所有新值都使用 `UPSTREAM_HEADER_KEY` 通过 AES-GCM v2 加密后写入 SQLite，认证数据同时绑定 Header 名称与目标 scheme/主机/有效端口；管理 API 和浏览器只返回 Header 名称与“已配置”状态，不会回显明文或密文。同一主回源 authority 内编辑时值留空表示保留，删除整行才会移除；一旦修改协议、域名或有效端口，旧值会自动清空，必须重新输入，避免把源站秘密带到新主机。
+
+这些 Header 只会发送给 `target_url` 的精确协议、域名和有效端口。独立播放回源、WebSocket 播放目标和跨 authority 重定向都会主动删除它们，避免把源站秘密带给 CDN。`Authorization`、`Cookie`、`Host`、`User-Agent`、`X-Forwarded-*`、常见供应商客户端 IP Header、Emby 授权头和 WebSocket/hop-by-hop Header 由 Meridian 管理，不能在这里覆盖。
+
+> `UPSTREAM_HEADER_KEY` 必须与数据库一起备份并保持不变。不要与 `JWT_SECRET` 共用同一个值；丢失该密钥后，包含加密 Header 的站点会拒绝启动，而不是静默发送空值。
+
 ### UA 身份模式
 
 每个站点可选 Infuse、Web、客户端三个预设，或选择“自定义”固定身份，或选择“透传”保留客户端身份。
@@ -277,7 +345,7 @@ Meridian/
 - **自定义（固定身份）**：填写 `User-Agent`、Emby `Client`、`Version`，Meridian 会在普通 HTTP、WebSocket 以及受配置白名单约束的播放重定向请求中统一改写成这套固定值，所有请求保持一致；`Device` 与 `DeviceId` 会原样保留。为避免请求头注入和 Emby 授权头格式损坏，自定义值只接受受限长度的可打印 ASCII 字符，`Client` 和 `Version` 不接受引号或反斜杠。
 - **透传（每请求真实身份）**：Meridian 不生成也不改写任何 UA 身份，每个请求原样保留客户端自带的 `User-Agent` 与 Emby `Client`、`Version`、`Device`、`DeviceId` 后转发，适合多用户共用一个反代站点、需要按客户端区分身份的部署。
 
-两种模式的凭据安全边界一致：跨 authority 转发时 `Cookie`、`Authorization` 等凭据仍会被剥离，`X-Forwarded-*` 与 hop-by-hop 请求头清洗保持不变，透传不会绕过任何凭据清洗。
+两种模式的凭据安全边界一致：站点请求出站前始终删除 Meridian 管理会话 `meridian_session`，但保留 Emby 自己的 Cookie；跨 authority 转发时 `Cookie`、`Authorization` 等凭据仍会被剥离，`X-Forwarded-*` 与 hop-by-hop 请求头清洗保持不变，透传不会绕过任何凭据清洗。
 
 ---
 
@@ -300,6 +368,7 @@ Meridian/
 ## 运维要点
 
 - **JWT 密钥**：未设置 `JWT_SECRET` 时每次启动生成随机密钥，重启后会话全部失效
+- **上游 Header 密钥**：使用固定请求头时必须长期保留 `UPSTREAM_HEADER_KEY`；它应与 JWT 密钥分开生成和备份
 - **首次初始化**：数据库中没有管理员时必须预先配置 `SETUP_TOKEN`，创建操作在数据库中原子执行，服务不会记录令牌
 - **登录保护**：同一来源在 15 分钟内连续失败 5 次后会被暂时限制 15 分钟；限流记录会过期并在容量达到上限时按最近使用情况淘汰
 - **浏览器边界**：管理 API 使用 `HttpOnly`、`SameSite=Strict` 会话 Cookie，只允许同源的状态变更请求，并发送 CSP、防嵌入和 MIME 嗅探保护头
@@ -344,17 +413,18 @@ Meridian `v1` 明确定位为一个**单管理员、轻量、可直接落地**�
 
 ## 升级现有实例
 
-升级时建议优先保持这两样东西不变：
+升级时建议优先保持这些内容不变：
 
 - `JWT_SECRET`
+- `UPSTREAM_HEADER_KEY`
 - SQLite 数据库文件及其同目录的 `-wal` / `-shm`
 
 使用一键脚本执行 `update` 时，下列步骤会自动完成；手动部署时推荐：
 
 1. 停止正在运行的 Meridian 服务。
-2. 备份当前二进制、数据库文件和 `JWT_SECRET` 所在的环境配置。
+2. 备份当前二进制、数据库文件以及保存 `JWT_SECRET`、`UPSTREAM_HEADER_KEY` 的环境配置。
 3. 替换为新版本二进制或新镜像。
-4. 用原来的 `JWT_SECRET` 和数据库重新启动。
+4. 用原来的 `JWT_SECRET`、`UPSTREAM_HEADER_KEY` 和数据库重新启动。
 5. 登录面板后检查站点列表、端口监听和诊断页。
 
 如果升级后临时忘记保留 `JWT_SECRET`，历史 JWT 会全部失效，表现为所有登录状态需要重新建立。
@@ -368,17 +438,17 @@ Meridian `v1` 明确定位为一个**单管理员、轻量、可直接落地**�
 - `meridian.db`
 - `meridian.db-wal`
 - `meridian.db-shm`
-- 保存 `JWT_SECRET` 的 `.env`、systemd 环境文件或容器环境配置
+- 保存 `JWT_SECRET` 和 `UPSTREAM_HEADER_KEY` 的 `.env`、systemd 环境文件或容器环境配置
 
 恢复步骤：
 
 1. 停止 Meridian。
 2. 还原数据库文件到原路径。
-3. 还原原来的 `JWT_SECRET`。
+3. 还原原来的 `JWT_SECRET` 和 `UPSTREAM_HEADER_KEY`。
 4. 启动 Meridian。
 5. 验证管理员登录、站点配置和关键代理端口。
 
-如果你使用 Docker，恢复时同样要保留挂载卷里的数据库文件，并继续使用原来的 `JWT_SECRET`。
+如果你使用 Docker，恢复时同样要保留挂载卷里的数据库文件，并继续使用原来的 `JWT_SECRET` 和 `UPSTREAM_HEADER_KEY`。
 
 ---
 
@@ -396,6 +466,7 @@ Meridian `v1` 明确定位为一个**单管理员、轻量、可直接落地**�
 - 没有审计日志，操作不可追溯
 - 没有内置通知能力（无 Telegram / Webhook 集成）
 - 管理面板本身不终止 TLS，公网部署必须放在 HTTPS 反向代理之后
+- 共享入口仅支持精确 Host，不支持通配符或 URL 路径前缀
 - TLS 诊断会验证上游证书，但不负责证书签发和续期
 - UA 诊断是本地配置预览，不验证远端实际收到的请求头
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,14 +36,16 @@
 
 - 未配置域名时管理面板默认监听 `0.0.0.0`；一键脚本启用面板域名后会改为 `127.0.0.1`，只信任回环代理并由 Nginx 提供 HTTPS
 - 管理面板本身不提供 HTTPS，需要外层反代处理 TLS 终止
-- 反代站点的监听端口同样绑定在所有接口上
+- 站点支持 `host`、`port`、`both` 三种入口模式；推荐的 `host` 模式只使用共享 Host 路由，不绑定保留的高端口，并强制要求面板回环绑定或非空 `TRUSTED_PROXY_CIDRS` 来源白名单。面板非回环绑定时，伪造正确 Host 的非可信 peer 仍会被拒绝；`port` 和显式高风险的 `both` 独立端口仍绑定所有接口
+- 设置 `PANEL_DOMAIN` 后，未知 Host 返回 `421` 而不是管理面板；未设置时保留直接 IP/任意 Host 的初始部署兼容行为
 - 安装器生成的 Nginx 配置只代理管理端口，不读取或代理站点回源、播放地址或站点监听端口
 - 管理 API 默认拒绝跨站浏览器请求；所有状态变更还要求同源 `Origin` 或 `Referer`，并发送 CSP、`X-Frame-Options`、`nosniff` 等响应头
 - 管理端和站点代理端都配置了请求头超时、空闲超时及请求头大小上限
 
 ### 数据
 
-- SQLite 数据库文件包含管理员密码哈希和站点配置
+- SQLite 数据库文件包含管理员密码哈希和站点配置；固定上游 Header 的名称以明文保存，值使用独立的 `UPSTREAM_HEADER_KEY` 通过 AES-GCM 加密
+- 管理 API 对固定上游 Header 采用只写语义，不回显明文或数据库密文。`UPSTREAM_HEADER_KEY` 不得与 `JWT_SECRET` 共用，且必须随数据库一起备份
 - **仅 Linux / macOS**：进程会使用 `0077` 文件掩码并将数据库、WAL、SHM 文件收紧为 `0600`
 - **Windows**：不提供等价保证。`os.Chmod` 在 Windows 上只能切换 `FILE_ATTRIBUTE_READONLY`，无法表达"仅所有者可读"的 DACL，因此程序不会尝试收紧权限，而是在启动日志中给出警告。数据库会沿用所在目录的继承权限——请自行限制该目录的访问权限，尤其不要放在 `C:\` 下直接新建的目录中（这类目录默认允许 `BUILTIN\Users` 读取）
 - 没有审计日志，操作不可追溯
@@ -54,6 +56,10 @@
 - 与上游 Emby 服务器的通信基于配置的 URL scheme（HTTP 或 HTTPS）
 - HTTPS/WSS 上游连接和 TLS 诊断都会校验证书链、有效期与主机名，并要求 TLS 1.2 或更高版本
 - 代理会保留上游返回的 CSP 和 `X-Frame-Options` 等安全响应头
+- 固定自定义 Header 只发送给主回源的精确 scheme、主机和有效端口；新密文的 AES-GCM 认证数据同时绑定 Header 名称和该 authority。修改主回源 authority 会在 HTTP 层和数据层清空未重新输入的旧 Header，独立播放回源及跨 authority 重定向也会删除这些 Header。Authorization、Cookie、Host、转发头和 hop-by-hop Header 不能由该功能覆盖
+- Meridian 管理会话 Cookie 会在所有站点 HTTP 与 WebSocket 请求出站前单独剥离，其他上游业务 Cookie 保留；畸形 Cookie Header 按失败关闭策略整头删除
+- 上游 HTTP 响应和 WebSocket 101 中名称精确为 `meridian_session` 的 `Set-Cookie` 会被删除，合法的 Emby/业务 Cookie 原样保留；无法安全解析的单条 `Set-Cookie` 按失败关闭策略丢弃
+- 直连客户端提供的转发头会全部重建；只有 peer 命中 `TRUSTED_PROXY_CIDRS` 时才采纳单一、合法的 `X-Real-IP` 与 `http`/`https` 协议值，不会把任意 `X-Forwarded-For` 链传给上游
 - 运行日志只保留上游的 scheme、主机和端口，不记录路径、查询参数或 URL 凭据
 
 ### 部署与供应链

--- a/ingress_migration_test.go
+++ b/ingress_migration_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #28 briefly introduced public_host before ingress_mode. Preserve that
+// pre-release database shape as host-only during migration so an upgrade does
+// not silently expose the legacy high-port listener as well.
+func TestMigratePublicHostOnlyPrereleaseDatabaseToHostIngress(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prerelease-public-host.db")
+	createLegacySiteDatabase(t, dbPath, false)
+
+	legacy, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.Exec("ALTER TABLE sites ADD COLUMN public_host TEXT NOT NULL DEFAULT ''"); err != nil {
+		legacy.Close()
+		t.Fatalf("add prerelease public_host: %v", err)
+	}
+	if _, err := legacy.Exec("UPDATE sites SET public_host='Media.Example.COM' WHERE id=1"); err != nil {
+		legacy.Close()
+		t.Fatalf("set prerelease public_host: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatalf("migrate prerelease database: %v", err)
+	}
+	defer db.Close()
+	site, err := db.GetSite(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if site.PublicHost != "media.example.com" || site.IngressMode != ingressModeHost {
+		t.Fatalf("migrated ingress=(%q,%q), want normalized host-only", site.PublicHost, site.IngressMode)
+	}
+}
+
+func TestIngressCapabilitiesReflectHostOnlySafety(t *testing.T) {
+	app := newTestApp(t)
+	app.panelBindLoopback = false
+	app.trustedProxies = nil
+	app.pm.SetHostOnlyIngressSafe(false)
+
+	rr := httptest.NewRecorder()
+	app.handleIngressCapabilities(rr, httptest.NewRequest(http.MethodGet, "/api/ingress-capabilities", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	body := decodeBody(t, rr)
+	if available, ok := body["host_only_available"].(bool); !ok || available {
+		t.Fatalf("host_only_available=%#v, want false", body["host_only_available"])
+	}
+	if available, ok := body["upstream_headers_available"].(bool); !ok || !available {
+		t.Fatalf("upstream_headers_available=%#v, want true with test key", body["upstream_headers_available"])
+	}
+	if got := int(body["max_playback_addresses"].(float64)); got != maxPlaybackAddresses {
+		t.Fatalf("max_playback_addresses=%d, want %d", got, maxPlaybackAddresses)
+	}
+
+	app.panelBindLoopback = true
+	app.pm.SetHostOnlyIngressSafe(true)
+	rr = httptest.NewRecorder()
+	app.handleIngressCapabilities(rr, httptest.NewRequest(http.MethodGet, "/api/ingress-capabilities", nil))
+	body = decodeBody(t, rr)
+	if available, ok := body["host_only_available"].(bool); !ok || !available {
+		t.Fatalf("host_only_available=%#v, want true", body["host_only_available"])
+	}
+}
+
+func TestSitesAPIRoundTripsOneHundredPlaybackAddressesAsArray(t *testing.T) {
+	app := newTestApp(t)
+	addresses := make([]string, 100)
+	longPath := strings.Repeat("segment/", 100)
+	for i := range addresses {
+		addresses[i] = fmt.Sprintf("https://cdn-%03d.example.test:8443/%s%d", i, longPath, i)
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":                "one-hundred-playback-addresses",
+		"listen_port":         freePort(t),
+		"public_host":         "hundred-playback.example.test",
+		"ingress_mode":        ingressModeHost,
+		"target_url":          "https://origin.example.test",
+		"playback_target_url": addresses[0],
+		"playback_mode":       "redirect",
+		"stream_hosts":        addresses[1:],
+		"ua_mode":             "infuse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createResponse := httptest.NewRecorder()
+	app.handleSites(createResponse, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(payload)))
+	if createResponse.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createResponse.Code, createResponse.Body.String())
+	}
+	var created Site
+	if err := json.Unmarshal(createResponse.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode created site: %v", err)
+	}
+	if len(created.StreamHostList) != 99 {
+		t.Fatalf("created stream_hosts length=%d, want 99", len(created.StreamHostList))
+	}
+	if created.StreamHostList[98] != addresses[99] {
+		t.Fatalf("created final stream host=%q, want %q", created.StreamHostList[98], addresses[99])
+	}
+	t.Cleanup(func() { _ = app.pm.StopSite(created.ID) })
+
+	listResponse := httptest.NewRecorder()
+	app.handleSites(listResponse, httptest.NewRequest(http.MethodGet, "/api/sites", nil))
+	if listResponse.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listResponse.Code, listResponse.Body.String())
+	}
+	var listed []Site
+	if err := json.Unmarshal(listResponse.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode site list: %v", err)
+	}
+	if len(listed) != 1 || len(listed[0].StreamHostList) != 99 {
+		t.Fatalf("listed sites/stream_hosts=%d/%d, want 1/99", len(listed), len(listed[0].StreamHostList))
+	}
+}
+
+func TestSitesAPIRejectsMoreThanMaximumPlaybackAddresses(t *testing.T) {
+	app := newTestApp(t)
+	extra := make([]string, maxPlaybackAddresses)
+	for i := range extra {
+		extra[i] = fmt.Sprintf("https://overflow-%03d.example.test", i)
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":                "too-many-playback-addresses",
+		"listen_port":         freePort(t),
+		"public_host":         "overflow-playback.example.test",
+		"ingress_mode":        ingressModeHost,
+		"target_url":          "https://origin.example.test",
+		"playback_target_url": "https://primary-playback.example.test",
+		"playback_mode":       "redirect",
+		"stream_hosts":        extra,
+		"ua_mode":             "infuse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	app.handleSites(rr, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(payload)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+func TestResolvePlaybackConfigurationUsesFirstStreamHostAsFallback(t *testing.T) {
+	playback, hosts, err := resolvePlaybackConfiguration("", `["https://first.example.test:8443","https://second.example.test"]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if playback == nil || playback.String() != "https://first.example.test:8443" {
+		t.Fatalf("effective playback=%v, want first stream host", playback)
+	}
+	if len(hosts) != 2 || !hosts[redirectHostKey(playback)] {
+		t.Fatalf("allowed playback hosts=%v, want both configured authorities", hosts)
+	}
+}
+
+func TestDiagnosticsUsesFirstStreamHostWhenDedicatedPlaybackTargetIsEmpty(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer primary.Close()
+	playback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer playback.Close()
+
+	rawHosts, err := json.Marshal([]string{playback.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := diagnoseSite(&Site{
+		TargetURL:    primary.URL,
+		PlaybackMode: "direct",
+		StreamHosts:  string(rawHosts),
+		UAMode:       "infuse",
+	}, NewProxyManager(nil, nil))
+	got := result.Upstreams.Playback
+	if !got.Configured || got.UsingFallback || got.SameAsPrimary {
+		t.Fatalf("playback diagnostics flags configured/fallback/same=%v/%v/%v, want true/false/false", got.Configured, got.UsingFallback, got.SameAsPrimary)
+	}
+	if got.EffectiveURL != playback.URL {
+		t.Fatalf("playback effective URL=%q, want %q", got.EffectiveURL, playback.URL)
+	}
+}
+
+func TestCreateSiteReportsReservedPortConflictAsBadRequest(t *testing.T) {
+	app := newTestApp(t)
+	port := freePort(t)
+	if _, err := app.db.CreateSiteRecord(Site{
+		Name:         "first-host-only",
+		ListenPort:   port,
+		PublicHost:   "first.example.test",
+		IngressMode:  ingressModeHost,
+		TargetURL:    "http://127.0.0.1:8096",
+		PlaybackMode: "direct",
+		StreamHosts:  "[]",
+		UAMode:       "infuse",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":          "second-host-only",
+		"listen_port":   port,
+		"public_host":   "second.example.test",
+		"ingress_mode":  ingressModeHost,
+		"target_url":    "http://127.0.0.1:8096",
+		"playback_mode": "direct",
+		"ua_mode":       "infuse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	app.handleSites(rr, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(payload)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+	if body := rr.Body.String(); body == "" || bytes.Contains([]byte(body), []byte("UNIQUE constraint")) {
+		t.Fatalf("unsafe or empty conflict response: %q", body)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -238,6 +238,39 @@ restore_data_snapshot() {
     restore_data_permissions
 }
 
+restore_env_from_snapshot() {
+    # A failed full-directory restore must not leave pre-start configuration
+    # backfills (for example a newly generated encryption key) in the live
+    # environment. Restore just the exact pre-update .env atomically while the
+    # full snapshot remains pending for the exit-trap retry/manual recovery.
+    # This deliberately does not mark UPDATE_SNAPSHOT_RESTORED: database and
+    # other data files may still require the complete snapshot.
+    local snapshot_dir="$1" snapshot_env env_file
+    snapshot_env="${snapshot_dir}/data/.env"
+    env_file=$(env_file_path)
+    as_root test -f "$snapshot_env" || return 1
+    if as_root test -L "$snapshot_env"; then
+        return 1
+    fi
+    as_root test -d "$DATA_DIR" || return 1
+    if as_root test -L "$env_file"; then
+        return 1
+    fi
+    install_env_file "$snapshot_env"
+}
+
+restore_update_snapshot() {
+    local snapshot_dir="$1"
+    if restore_data_snapshot "$snapshot_dir"; then
+        UPDATE_SNAPSHOT_RESTORED=1
+        return 0
+    fi
+    if ! restore_env_from_snapshot "$snapshot_dir"; then
+        warn "完整数据快照恢复失败，且无法单独恢复更新前的 .env，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
+    fi
+    return 1
+}
+
 restore_data_permissions() {
     # Reapplies the ownership/mode contract of prepare_data_and_config after a
     # snapshot restore: the staged copy arrives as root:0700, which the
@@ -693,9 +726,7 @@ cleanup_update_transaction() {
         fi
         if [ -n "$UPDATE_SNAPSHOT_DIR" ] && [ -d "$UPDATE_SNAPSHOT_DIR" ] \
             && [ "$UPDATE_SNAPSHOT_RESTORED" != "1" ]; then
-            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
-                UPDATE_SNAPSHOT_RESTORED=1
-            else
+            if ! restore_update_snapshot "$UPDATE_SNAPSHOT_DIR"; then
                 warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
             fi
         fi
@@ -1291,9 +1322,7 @@ do_update() {
             warn "新版本健康检查失败，正在自动回滚..."
             restore_previous_binary || fail "回滚失败：缺少上一版本二进制，请手动恢复 ${LAST_BACKUP_PATH:-备份归档}"
             UPDATE_BINARY_CHANGED=0
-            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
-                UPDATE_SNAPSHOT_RESTORED=1
-            else
+            if ! restore_update_snapshot "$UPDATE_SNAPSHOT_DIR"; then
                 warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: $LAST_BACKUP_PATH"
             fi
             as_root systemctl restart "$SERVICE_NAME"
@@ -1308,9 +1337,7 @@ do_update() {
             warn "新版本二进制无法执行，正在自动回滚..."
             restore_previous_binary || true
             UPDATE_BINARY_CHANGED=0
-            if restore_data_snapshot "$UPDATE_SNAPSHOT_DIR"; then
-                UPDATE_SNAPSHOT_RESTORED=1
-            else
+            if ! restore_update_snapshot "$UPDATE_SNAPSHOT_DIR"; then
                 warn "数据快照恢复失败，原数据目录未被删除，请使用备份手动恢复: $LAST_BACKUP_PATH"
             fi
             fail "新版本无法执行，已恢复上一版本及原数据配置"

--- a/install.sh
+++ b/install.sh
@@ -447,6 +447,40 @@ ensure_setup_token() {
     install_env_file "$tmp_file"
 }
 
+ensure_upstream_header_key() {
+    local tmp_dir="$1" env_file tmp_file key_value key_count key_length new_key
+    env_file=$(env_file_path)
+    # Reject duplicate definitions rather than guessing which key systemd or a
+    # shell loader will honor. Rotating the wrong value would make every stored
+    # encrypted upstream Header unreadable.
+    # $1 is an awk field reference, not a shell variable.
+    # shellcheck disable=SC2016
+    key_count=$(as_root awk -F= '$1 == "UPSTREAM_HEADER_KEY" { count++ } END { print count + 0 }' "$env_file")
+    [ "$key_count" -le 1 ] || fail "UPSTREAM_HEADER_KEY 存在重复定义，请人工保留唯一的正确密钥后重试"
+
+    key_value=$(read_env_value UPSTREAM_HEADER_KEY)
+    if [ "$key_count" -eq 1 ] && [ -n "$key_value" ]; then
+        printf '%s' "$key_value" | grep -q '[^[:space:]]' \
+            || fail "UPSTREAM_HEADER_KEY 不能只包含空白字符"
+        if printf '%s' "$key_value" | grep -q '[[:space:]]'; then
+            fail "UPSTREAM_HEADER_KEY 不能包含空白字符；为避免 systemd 解析差异，安装器不会自动修改现有密钥"
+        fi
+        key_length=$(printf '%s' "$key_value" | LC_ALL=C wc -c | tr -d '[:space:]')
+        [ "$key_length" -ge 32 ] \
+            || fail "现有 UPSTREAM_HEADER_KEY 少于 32 字节；为避免破坏已加密数据，安装器不会自动替换"
+        return 0
+    fi
+
+    new_key=$(generate_secret)
+    tmp_file="${tmp_dir}/env-upstream-header-key"
+    # $1 is an awk field reference, not a shell variable.
+    # shellcheck disable=SC2016
+    as_root awk -F= '$1 != "UPSTREAM_HEADER_KEY" { print }' "$env_file" > "$tmp_file"
+    printf 'UPSTREAM_HEADER_KEY=%s\n' "$new_key" >> "$tmp_file"
+    chmod 0600 "$tmp_file"
+    install_env_file "$tmp_file"
+}
+
 set_panel_env() {
     local bind_addr="$1" domain="$2" proxies="$3" tmp_dir="$4" env_file tmp_file
     env_file=$(env_file_path)
@@ -530,7 +564,7 @@ ensure_service_user() {
 }
 
 prepare_data_and_config() {
-    local tmp_dir="$1" env_file secret env_tmp
+    local tmp_dir="$1" env_file secret upstream_header_key env_tmp
     validate_data_dir
     env_file=$(env_file_path)
     if is_systemd; then
@@ -542,10 +576,11 @@ prepare_data_and_config() {
 
     if ! as_root test -f "$env_file"; then
         secret=$(generate_secret)
+        upstream_header_key=$(generate_secret)
         INITIAL_SETUP_TOKEN=$(generate_secret)
         env_tmp="${tmp_dir}/meridian.env"
-        printf 'JWT_SECRET=%s\nSETUP_TOKEN=%s\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
-            "$secret" "$INITIAL_SETUP_TOKEN" "$DATA_DIR" > "$env_tmp"
+        printf 'JWT_SECRET=%s\nUPSTREAM_HEADER_KEY=%s\nSETUP_TOKEN=%s\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=0.0.0.0\nPANEL_DOMAIN=\nTRUSTED_PROXY_CIDRS=\n' \
+            "$secret" "$upstream_header_key" "$INITIAL_SETUP_TOKEN" "$DATA_DIR" > "$env_tmp"
         chmod 0600 "$env_tmp"
         install_env_file "$env_tmp"
         ok "已创建安全配置: $env_file"
@@ -554,6 +589,7 @@ prepare_data_and_config() {
         append_env_default PANEL_BIND_ADDR 0.0.0.0 "$tmp_dir"
         append_env_default PANEL_DOMAIN "" "$tmp_dir"
         append_env_default TRUSTED_PROXY_CIDRS "" "$tmp_dir"
+        ensure_upstream_header_key "$tmp_dir"
         ensure_setup_token "$tmp_dir"
         if is_systemd; then
             as_root chown root:"$SERVICE_GROUP" "$env_file"
@@ -877,7 +913,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
-        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For \$remote_addr;
         proxy_set_header X-Forwarded-Proto \$scheme;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection \$meridian_connection_upgrade;

--- a/lifecycle_regression_test.go
+++ b/lifecycle_regression_test.go
@@ -1,0 +1,537 @@
+package main
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"modernc.org/sqlite"
+)
+
+var (
+	registerLifecycleFailOnce sync.Once
+	registerLifecycleFailErr  error
+	failNextTrafficUpdate     atomic.Bool
+)
+
+// registerLifecycleFailureFunction installs a process-wide SQLite scalar
+// function whose failure is controlled outside the transaction. Unlike a
+// control row updated by a trigger, the one-shot state is therefore not rolled
+// back with the failed traffic transaction.
+func registerLifecycleFailureFunction(t *testing.T) {
+	t.Helper()
+	registerLifecycleFailOnce.Do(func() {
+		registerLifecycleFailErr = sqlite.RegisterScalarFunction(
+			"meridian_lifecycle_fail_traffic_once",
+			0,
+			func(_ *sqlite.FunctionContext, _ []driver.Value) (driver.Value, error) {
+				if failNextTrafficUpdate.Swap(false) {
+					return nil, errors.New("injected final traffic flush failure")
+				}
+				return int64(0), nil
+			},
+		)
+	})
+	if registerLifecycleFailErr != nil {
+		t.Fatalf("register SQLite failure function: %v", registerLifecycleFailErr)
+	}
+}
+
+type finalFlushFailureFixture struct {
+	app         *App
+	site        *Site
+	requestDone <-chan struct{}
+}
+
+// newFinalFlushFailureFixture keeps one proxied request active until StopSite
+// cancels the instance. The upstream then adds a small amount of tail traffic,
+// so StopSite's pre-close checkpoint is a no-op while its post-close checkpoint
+// reaches the injected SQLite failure. This deterministically exercises the
+// irreversible-close error path rather than the retryable pre-close path.
+func newFinalFlushFailureFixture(t *testing.T, name string) finalFlushFailureFixture {
+	t.Helper()
+	registerLifecycleFailureFunction(t)
+	failNextTrafficUpdate.Store(false)
+
+	app := newTestApp(t)
+	started := make(chan struct{})
+	requestDone := make(chan struct{})
+	var inst *ProxyInstance
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		inst.bytesOut.Add(23)
+	}))
+	t.Cleanup(upstream.Close)
+
+	port := freePort(t)
+	site, err := app.db.CreateSite(name, port, upstream.URL, "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(port)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	app.pm.mu.RLock()
+	inst = app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil {
+		t.Fatal("proxy instance was not installed")
+	}
+	t.Cleanup(func() {
+		failNextTrafficUpdate.Store(false)
+		_ = app.pm.StopSite(site.ID)
+	})
+
+	go func() {
+		defer close(requestDone)
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, requestErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/stream", port))
+		if requestErr == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request did not reach upstream")
+	}
+
+	if _, err := app.db.db.Exec(`
+		CREATE TRIGGER fail_one_final_lifecycle_traffic_update
+		BEFORE UPDATE OF traffic_used ON sites
+		BEGIN
+			SELECT meridian_lifecycle_fail_traffic_once();
+		END;
+	`); err != nil {
+		t.Fatalf("create final traffic trigger: %v", err)
+	}
+	failNextTrafficUpdate.Store(true)
+	return finalFlushFailureFixture{app: app, site: site, requestDone: requestDone}
+}
+
+func waitForFinalFlushFixtureRequest(t *testing.T, requestDone <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request did not finish after ingress closed")
+	}
+}
+
+func TestToggleOffAfterFinalFlushFailureDisablesSiteAndReportsCleanupPending(t *testing.T) {
+	fixture := newFinalFlushFailureFixture(t, "toggle-final-flush")
+	rr := httptest.NewRecorder()
+	fixture.app.handleSiteByID(
+		rr,
+		httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/sites/%d/toggle", fixture.site.ID), nil),
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("toggle status=%d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	waitForFinalFlushFixtureRequest(t, fixture.requestDone)
+	if failNextTrafficUpdate.Load() {
+		t.Fatal("toggle never reached the injected final traffic flush failure")
+	}
+	body := decodeBody(t, rr)
+	if enabled, ok := body["enabled"].(bool); !ok || enabled {
+		t.Fatalf("toggle enabled=%#v, want false", body["enabled"])
+	}
+	if cleanupPending, ok := body["cleanup_pending"].(bool); !ok || !cleanupPending {
+		t.Fatalf("toggle cleanup_pending=%#v, want true", body["cleanup_pending"])
+	}
+	restored, err := fixture.app.db.GetSite(fixture.site.ID)
+	if err != nil {
+		t.Fatalf("GetSite after toggle: %v", err)
+	}
+	if restored.Enabled {
+		t.Fatal("site record remained enabled after irreversible toggle shutdown")
+	}
+}
+
+func TestSamePortPutAfterFinalFlushFailureReturnsUnavailableAndDisablesOldRecord(t *testing.T) {
+	fixture := newFinalFlushFailureFixture(t, "put-final-flush")
+	payload := fmt.Sprintf(
+		`{"name":"put-should-not-commit","listen_port":%d,"target_url":%q,"ua_mode":"infuse"}`,
+		fixture.site.ListenPort,
+		fixture.site.TargetURL,
+	)
+	rr := httptest.NewRecorder()
+	fixture.app.handleSiteByID(
+		rr,
+		httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", fixture.site.ID), strings.NewReader(payload)),
+	)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("PUT status=%d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	waitForFinalFlushFixtureRequest(t, fixture.requestDone)
+	if failNextTrafficUpdate.Load() {
+		t.Fatal("PUT never reached the injected final traffic flush failure")
+	}
+	restored, err := fixture.app.db.GetSite(fixture.site.ID)
+	if err != nil {
+		t.Fatalf("GetSite after PUT: %v", err)
+	}
+	if restored.Enabled {
+		t.Fatal("old site record remained enabled after irreversible PUT shutdown")
+	}
+	if restored.Name != fixture.site.Name || restored.ListenPort != fixture.site.ListenPort || restored.TargetURL != fixture.site.TargetURL {
+		t.Fatalf("PUT changed old record despite aborted update: got name=%q port=%d target=%q", restored.Name, restored.ListenPort, restored.TargetURL)
+	}
+}
+
+func TestDeleteAfterFinalFlushFailureReturnsUnavailableAndRetainsDisabledRecord(t *testing.T) {
+	fixture := newFinalFlushFailureFixture(t, "delete-final-flush")
+	rr := httptest.NewRecorder()
+	fixture.app.handleSiteByID(
+		rr,
+		httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/sites/%d", fixture.site.ID), nil),
+	)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("DELETE status=%d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	waitForFinalFlushFixtureRequest(t, fixture.requestDone)
+	if failNextTrafficUpdate.Load() {
+		t.Fatal("DELETE never reached the injected final traffic flush failure")
+	}
+	restored, err := fixture.app.db.GetSite(fixture.site.ID)
+	if err != nil {
+		t.Fatalf("site record was deleted instead of retained: %v", err)
+	}
+	if restored.Enabled {
+		t.Fatal("retained site record remained enabled after irreversible DELETE shutdown")
+	}
+	if restored.Name != fixture.site.Name || restored.ListenPort != fixture.site.ListenPort || restored.TargetURL != fixture.site.TargetURL {
+		t.Fatalf("DELETE changed retained record: got name=%q port=%d target=%q", restored.Name, restored.ListenPort, restored.TargetURL)
+	}
+}
+
+// A different-port PUT does not pre-stop the old proxy. StartSite itself may
+// nevertheless close that proxy before a later step (here, its final traffic
+// flush) fails. Rolling the database row back must also restore a fresh runtime;
+// leaving the old closing instance in the manager makes an enabled site stay
+// offline until an operator intervenes.
+func TestDifferentPortUpdateRestartsOldSiteAfterPostShutdownReplaceFailure(t *testing.T) {
+	registerLifecycleFailureFunction(t)
+	failNextTrafficUpdate.Store(false)
+
+	app := newTestApp(t)
+	started := make(chan struct{})
+	requestDone := make(chan struct{})
+	var firstRequest sync.Once
+	var oldInst *ProxyInstance
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		isFirst := false
+		firstRequest.Do(func() {
+			isFirst = true
+			close(started)
+		})
+		if isFirst {
+			<-r.Context().Done()
+			// Produce traffic after StartSite's pre-stop flush. The replacement's
+			// final flush is therefore the first traffic_used update and the one
+			// deliberately failed by the trigger below.
+			oldInst.bytesOut.Add(17)
+			return
+		}
+		_, _ = io.WriteString(w, "restored")
+	}))
+	defer upstream.Close()
+
+	oldPort := freePort(t)
+	site, err := app.db.CreateSite("replace-rollback", oldPort, upstream.URL, "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	releasePort(oldPort)
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() { _ = app.pm.StopSite(site.ID) })
+
+	app.pm.mu.RLock()
+	oldInst = app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if oldInst == nil {
+		t.Fatal("old proxy instance was not installed")
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	go func() {
+		defer close(requestDone)
+		resp, requestErr := client.Get(fmt.Sprintf("http://127.0.0.1:%d/stream", oldPort))
+		if requestErr == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request did not reach the old upstream")
+	}
+
+	if _, err := app.db.db.Exec(`
+		CREATE TRIGGER fail_one_lifecycle_traffic_update
+		BEFORE UPDATE OF traffic_used ON sites
+		BEGIN
+			SELECT meridian_lifecycle_fail_traffic_once();
+		END;
+	`); err != nil {
+		t.Fatalf("create one-shot traffic trigger: %v", err)
+	}
+	failNextTrafficUpdate.Store(true)
+
+	newPort := freePort(t)
+	releasePort(newPort)
+	payload := fmt.Sprintf(
+		`{"name":"replace-rollback","listen_port":%d,"target_url":%q,"ua_mode":"infuse"}`,
+		newPort,
+		upstream.URL,
+	)
+	rr := httptest.NewRecorder()
+	app.handleSiteByID(
+		rr,
+		httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), strings.NewReader(payload)),
+	)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("PUT status=%d, want 500 from injected replacement failure; body=%s", rr.Code, rr.Body.String())
+	}
+	if failNextTrafficUpdate.Load() {
+		t.Fatal("replacement never reached the injected final traffic flush failure")
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("old in-flight request did not finish during replacement shutdown")
+	}
+
+	restored, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatalf("GetSite after rollback: %v", err)
+	}
+	if !restored.Enabled || restored.ListenPort != oldPort {
+		t.Fatalf("rolled-back row = enabled:%v port:%d, want enabled:true port:%d", restored.Enabled, restored.ListenPort, oldPort)
+	}
+	if !app.pm.IsRunning(site.ID) {
+		t.Fatal("enabled site remained offline after replacement failed post-shutdown")
+	}
+	app.pm.mu.RLock()
+	recoveredInst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if recoveredInst == nil || recoveredInst == oldInst {
+		t.Fatal("rollback did not install a fresh accepting proxy instance")
+	}
+	if restored.TrafficUsed < 17 {
+		t.Fatalf("tail traffic was not conserved during rollback: traffic_used=%d", restored.TrafficUsed)
+	}
+
+	verifyClient := &http.Client{Timeout: 2 * time.Second}
+	resp, err := verifyClient.Get(fmt.Sprintf("http://127.0.0.1:%d/health", oldPort))
+	if err != nil {
+		t.Fatalf("rolled-back listener is unavailable: %v", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read rolled-back proxy response: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "restored" {
+		t.Fatalf("rolled-back proxy response status=%d body=%q", resp.StatusCode, body)
+	}
+}
+
+func waitForLifecyclePortState(t *testing.T, port int, wantListening bool) {
+	t.Helper()
+	address := fmt.Sprintf("127.0.0.1:%d", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+		listening := err == nil
+		if conn != nil {
+			_ = conn.Close()
+		}
+		if listening == wantListening {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("port %s listening=%v, want %v (last dial error: %v)", address, listening, wantListening, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestEnabledSiteIngressModeTransitionMatrix(t *testing.T) {
+	tests := []struct {
+		from       string
+		to         string
+		changePort bool
+	}{
+		{from: ingressModePort, to: ingressModePort, changePort: true},
+		{from: ingressModePort, to: ingressModeHost},
+		{from: ingressModePort, to: ingressModeBoth},
+		{from: ingressModeHost, to: ingressModePort},
+		{from: ingressModeHost, to: ingressModeHost, changePort: true},
+		{from: ingressModeHost, to: ingressModeBoth, changePort: true},
+		{from: ingressModeBoth, to: ingressModePort},
+		{from: ingressModeBoth, to: ingressModeHost},
+		{from: ingressModeBoth, to: ingressModeBoth, changePort: true},
+	}
+
+	for _, tt := range tests {
+		portKind := "same-port"
+		if tt.changePort {
+			portKind = "different-port"
+		}
+		t.Run(tt.from+"-to-"+tt.to+"-"+portKind, func(t *testing.T) {
+			app := newTestApp(t)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = io.WriteString(w, "matrix-ok")
+			}))
+			defer upstream.Close()
+
+			startPort := freePort(t)
+			oldHost := ""
+			if ingressUsesHost(tt.from) {
+				oldHost = fmt.Sprintf("%s-%s-old.example.test", tt.from, tt.to)
+			}
+			if ingressUsesPort(tt.from) {
+				releasePort(startPort)
+			}
+			site, err := app.db.CreateSiteRecord(Site{
+				Name:         "ingress-" + tt.from + "-to-" + tt.to,
+				ListenPort:   startPort,
+				PublicHost:   oldHost,
+				IngressMode:  tt.from,
+				TargetURL:    upstream.URL,
+				PlaybackMode: "direct",
+				StreamHosts:  "[]",
+				UAMode:       "infuse",
+			})
+			if err != nil {
+				t.Fatalf("CreateSiteRecord: %v", err)
+			}
+			if err := app.pm.StartSite(*site); err != nil {
+				t.Fatalf("start %s ingress: %v", tt.from, err)
+			}
+			t.Cleanup(func() { _ = app.pm.StopSite(site.ID) })
+			// Host-only start deliberately kept the reservation open to prove that
+			// it did not bind the dedicated port. Release it before the PUT so the
+			// destination state, rather than the test reservation, owns the port.
+			if !ingressUsesPort(tt.from) {
+				releasePort(startPort)
+			}
+
+			destinationPort := startPort
+			if tt.changePort {
+				destinationPort = freePort(t)
+				releasePort(destinationPort)
+			}
+			newHost := ""
+			if ingressUsesHost(tt.to) {
+				newHost = fmt.Sprintf("%s-%s-new.example.test", tt.from, tt.to)
+			}
+			payload, err := json.Marshal(map[string]interface{}{
+				"name":          site.Name,
+				"listen_port":   destinationPort,
+				"public_host":   newHost,
+				"ingress_mode":  tt.to,
+				"target_url":    upstream.URL,
+				"playback_mode": "direct",
+				"ua_mode":       "infuse",
+			})
+			if err != nil {
+				t.Fatalf("marshal PUT payload: %v", err)
+			}
+			rr := httptest.NewRecorder()
+			app.handleSiteByID(
+				rr,
+				httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), strings.NewReader(string(payload))),
+			)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("PUT %s -> %s status=%d body=%s", tt.from, tt.to, rr.Code, rr.Body.String())
+			}
+
+			updated, err := app.db.GetSite(site.ID)
+			if err != nil {
+				t.Fatalf("GetSite after PUT: %v", err)
+			}
+			if !updated.Enabled || updated.IngressMode != tt.to || updated.PublicHost != newHost || updated.ListenPort != destinationPort {
+				t.Fatalf(
+					"updated row = enabled:%v mode:%q host:%q port:%d, want true/%q/%q/%d",
+					updated.Enabled,
+					updated.IngressMode,
+					updated.PublicHost,
+					updated.ListenPort,
+					tt.to,
+					newHost,
+					destinationPort,
+				)
+			}
+			if !app.pm.IsRunning(site.ID) {
+				t.Fatalf("enabled %s ingress is not operational after %s -> %s", tt.to, tt.from, tt.to)
+			}
+			_, _, runtimeRunning, portListening := app.pm.GetSiteRuntime(site.ID)
+			if !runtimeRunning || portListening != ingressUsesPort(tt.to) {
+				t.Fatalf(
+					"runtime = running:%v port_listening:%v, want true/%v",
+					runtimeRunning,
+					portListening,
+					ingressUsesPort(tt.to),
+				)
+			}
+
+			if oldHost != "" {
+				if oldID, exists := app.pm.PublicHostSiteID(oldHost); exists {
+					t.Fatalf("old public_host %q still maps to site %d", oldHost, oldID)
+				}
+			}
+			if ingressUsesHost(tt.to) {
+				mappedID, exists := app.pm.PublicHostSiteID(newHost)
+				if !exists || mappedID != site.ID {
+					t.Fatalf("new public_host %q mapping = %d/%v, want %d/true", newHost, mappedID, exists, site.ID)
+				}
+				handler, configured := app.pm.PublicHostHandler(newHost)
+				if !configured || handler == nil {
+					t.Fatalf("new public_host %q has no active handler", newHost)
+				}
+				hostResponse := httptest.NewRecorder()
+				handler.ServeHTTP(hostResponse, httptest.NewRequest(http.MethodGet, "http://"+newHost+"/matrix", nil))
+				if hostResponse.Code != http.StatusOK || hostResponse.Body.String() != "matrix-ok" {
+					t.Fatalf("host ingress status=%d body=%q", hostResponse.Code, hostResponse.Body.String())
+				}
+			}
+
+			waitForLifecyclePortState(t, destinationPort, ingressUsesPort(tt.to))
+			if ingressUsesPort(tt.to) {
+				portClient := &http.Client{Timeout: 2 * time.Second}
+				response, err := portClient.Get(fmt.Sprintf("http://127.0.0.1:%d/matrix", destinationPort))
+				if err != nil {
+					t.Fatalf("dedicated port request: %v", err)
+				}
+				body, readErr := io.ReadAll(response.Body)
+				_ = response.Body.Close()
+				if readErr != nil || response.StatusCode != http.StatusOK || string(body) != "matrix-ok" {
+					t.Fatalf("port ingress status=%d body=%q readErr=%v", response.StatusCode, body, readErr)
+				}
+			}
+			if tt.changePort && ingressUsesPort(tt.from) {
+				waitForLifecyclePortState(t, startPort, false)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5332,7 +5332,7 @@ func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
 var startTime = time.Now()
 
 // appVersion is overridable at build time via -ldflags "-X main.appVersion=vX.Y.Z".
-var appVersion = "v1.6.1"
+var appVersion = "v1.7.0"
 
 func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, error) {
 	if len(args) == 0 {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
@@ -58,6 +60,9 @@ const (
 	maxCustomClientLen    = 128
 	maxCustomVersionLen   = 64
 )
+
+var errUnsafeHostOnlyIngress = errors.New("host-only ingress requires loopback PANEL_BIND_ADDR or a non-empty TRUSTED_PROXY_CIDRS source allowlist; use port/both only with the documented risk controls")
+var errProxyManagerShuttingDown = errors.New("proxy manager is shutting down")
 
 // UAHeaderPolicy is the explicit discriminator for how a site's inbound
 // identity headers are handled on the way upstream. Rewrite=true applies
@@ -177,6 +182,303 @@ func mergeSiteUAConfig(old Site, requestedMode, requestedUserAgent, requestedCli
 		return "", "", "", "", fmt.Errorf("custom ua_mode requires User-Agent, Client, and Version")
 	}
 	return normalizeUAConfig(normalizedMode, userAgent, client, version)
+}
+
+const (
+	maxUpstreamHeaders     = 16
+	maxUpstreamHeaderName  = 64
+	maxUpstreamHeaderValue = 1024
+	maxPlaybackAddresses   = 128
+	maxTargetURLLength     = 2048
+	ingressModePort        = "port"
+	ingressModeHost        = "host"
+	ingressModeBoth        = "both"
+	dynamicRoutePrefix     = "/_meridian/d/"
+)
+
+// UpstreamHeaderView is the write-only representation returned by the API.
+// Header values are never serialized back to a browser.
+type UpstreamHeaderView struct {
+	Name       string `json:"name"`
+	Configured bool   `json:"configured"`
+}
+
+// UpstreamHeaderInput is a full-snapshot API input. On update, an omitted or
+// empty value preserves the existing encrypted value for the same header name.
+// Omitting the header row from the snapshot removes it.
+type UpstreamHeaderInput struct {
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
+}
+
+type storedUpstreamHeader struct {
+	Name       string `json:"name"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type upstreamHeaderPolicy struct {
+	authority string
+	values    http.Header
+}
+
+func isHTTPTokenByte(value byte) bool {
+	if value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' {
+		return true
+	}
+	return strings.ContainsRune("!#$%&'*+-.^_`|~", rune(value))
+}
+
+func normalizeUpstreamHeaderName(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > maxUpstreamHeaderName {
+		return "", fmt.Errorf("upstream header name must be 1-%d bytes", maxUpstreamHeaderName)
+	}
+	for i := 0; i < len(value); i++ {
+		if !isHTTPTokenByte(value[i]) {
+			return "", fmt.Errorf("upstream header name contains invalid characters")
+		}
+	}
+	name := http.CanonicalHeaderKey(value)
+	lower := strings.ToLower(name)
+	if isManagedForwardingHeaderName(lower) {
+		return "", fmt.Errorf("upstream header %s is managed by Meridian and cannot be overridden", name)
+	}
+	switch lower {
+	case "authorization", "connection", "content-length", "cookie", "host",
+		"keep-alive", "proxy-authenticate", "proxy-authorization", "proxy-connection",
+		"te", "trailer", "transfer-encoding", "upgrade", "user-agent",
+		"x-emby-authorization", "x-emby-token", "x-mediabrowser-token":
+		return "", fmt.Errorf("upstream header %s is managed by Meridian and cannot be overridden", name)
+	}
+	if strings.HasPrefix(lower, "sec-websocket-") {
+		return "", fmt.Errorf("upstream header %s is managed by Meridian and cannot be overridden", name)
+	}
+	return name, nil
+}
+
+func normalizeUpstreamHeaderValue(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > maxUpstreamHeaderValue {
+		return "", fmt.Errorf("upstream header value must be 1-%d bytes", maxUpstreamHeaderValue)
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < 0x20 || value[i] > 0x7e {
+			return "", fmt.Errorf("upstream header value must contain printable ASCII characters only")
+		}
+	}
+	return value, nil
+}
+
+func resolveUpstreamHeaderKey(value string) ([]byte, error) {
+	if value == "" {
+		return nil, nil
+	}
+	if strings.ContainsAny(value, " \t\r\n\v\f") {
+		return nil, fmt.Errorf("UPSTREAM_HEADER_KEY must not contain whitespace")
+	}
+	if len(value) < 32 {
+		return nil, fmt.Errorf("UPSTREAM_HEADER_KEY must be at least 32 bytes")
+	}
+	sum := sha256.Sum256([]byte(value))
+	key := make([]byte, len(sum))
+	copy(key, sum[:])
+	return key, nil
+}
+
+func encryptUpstreamHeaderValue(name, value, authority string, key []byte) (string, error) {
+	if len(key) != 32 {
+		return "", fmt.Errorf("UPSTREAM_HEADER_KEY is required to configure upstream headers")
+	}
+	if authority == "" {
+		return "", fmt.Errorf("a valid target authority is required to configure upstream headers")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generate upstream header nonce: %w", err)
+	}
+	aad := []byte("meridian-upstream-header:v2:" + strings.ToLower(name) + "\x00" + authority)
+	sealed := gcm.Seal(nil, nonce, []byte(value), aad)
+	payload := append(append([]byte{}, nonce...), sealed...)
+	return "v2:" + base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decryptUpstreamHeaderValue(name, ciphertext, authority string, key []byte) (string, error) {
+	if len(key) != 32 {
+		return "", fmt.Errorf("UPSTREAM_HEADER_KEY is required for configured upstream headers")
+	}
+	if !strings.HasPrefix(ciphertext, "v2:") {
+		return "", fmt.Errorf("unsupported upstream header ciphertext version")
+	}
+	if authority == "" {
+		return "", fmt.Errorf("a valid target authority is required for configured upstream headers")
+	}
+	aad := []byte("meridian-upstream-header:v2:" + strings.ToLower(name) + "\x00" + authority)
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(ciphertext, "v2:"))
+	if err != nil {
+		return "", fmt.Errorf("decode upstream header ciphertext: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	if len(payload) < gcm.NonceSize()+gcm.Overhead() {
+		return "", fmt.Errorf("upstream header ciphertext is truncated")
+	}
+	nonce, sealed := payload[:gcm.NonceSize()], payload[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, sealed, aad)
+	if err != nil {
+		return "", fmt.Errorf("decrypt upstream header value: %w", err)
+	}
+	return string(plain), nil
+}
+
+func parseStoredUpstreamHeaders(raw string) ([]storedUpstreamHeader, error) {
+	if strings.TrimSpace(raw) == "" {
+		return []storedUpstreamHeader{}, nil
+	}
+	var headers []storedUpstreamHeader
+	if err := json.Unmarshal([]byte(raw), &headers); err != nil {
+		return nil, fmt.Errorf("invalid stored upstream_headers: %w", err)
+	}
+	if len(headers) > maxUpstreamHeaders {
+		return nil, fmt.Errorf("stored upstream_headers exceeds %d entries", maxUpstreamHeaders)
+	}
+	seen := make(map[string]bool, len(headers))
+	for i := range headers {
+		name, err := normalizeUpstreamHeaderName(headers[i].Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid stored upstream header: %w", err)
+		}
+		key := strings.ToLower(name)
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate stored upstream header %s", name)
+		}
+		seen[key] = true
+		headers[i].Name = name
+		if !strings.HasPrefix(headers[i].Ciphertext, "v2:") {
+			return nil, fmt.Errorf("invalid stored ciphertext for upstream header %s", name)
+		}
+	}
+	if headers == nil {
+		headers = []storedUpstreamHeader{}
+	}
+	return headers, nil
+}
+
+func upstreamHeaderViews(raw string) ([]UpstreamHeaderView, error) {
+	stored, err := parseStoredUpstreamHeaders(raw)
+	if err != nil {
+		return nil, err
+	}
+	views := make([]UpstreamHeaderView, len(stored))
+	for i, header := range stored {
+		views[i] = UpstreamHeaderView{Name: header.Name, Configured: true}
+	}
+	return views, nil
+}
+
+func mergeUpstreamHeaders(existingRaw string, requested []UpstreamHeaderInput, key []byte, targetURL string) (string, error) {
+	if len(requested) > maxUpstreamHeaders {
+		return "", fmt.Errorf("upstream_headers must contain at most %d entries", maxUpstreamHeaders)
+	}
+	existing, err := parseStoredUpstreamHeaders(existingRaw)
+	if err != nil {
+		return "", err
+	}
+	existingByName := make(map[string]storedUpstreamHeader, len(existing))
+	for _, header := range existing {
+		existingByName[strings.ToLower(header.Name)] = header
+	}
+	target, err := normalizeTargetURL(targetURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid target_url: %w", err)
+	}
+	authority := redirectHostKey(target)
+
+	merged := make([]storedUpstreamHeader, 0, len(requested))
+	seen := make(map[string]bool, len(requested))
+	for _, input := range requested {
+		name, err := normalizeUpstreamHeaderName(input.Name)
+		if err != nil {
+			return "", err
+		}
+		nameKey := strings.ToLower(name)
+		if seen[nameKey] {
+			return "", fmt.Errorf("duplicate upstream header %s", name)
+		}
+		seen[nameKey] = true
+
+		value := ""
+		if input.Value != nil {
+			value = strings.TrimSpace(*input.Value)
+		}
+		if value == "" {
+			old, ok := existingByName[nameKey]
+			if !ok {
+				return "", fmt.Errorf("a value is required for new upstream header %s", name)
+			}
+			merged = append(merged, storedUpstreamHeader{Name: name, Ciphertext: old.Ciphertext})
+			continue
+		}
+		value, err = normalizeUpstreamHeaderValue(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid value for upstream header %s: %w", name, err)
+		}
+		ciphertext, err := encryptUpstreamHeaderValue(name, value, authority, key)
+		if err != nil {
+			return "", err
+		}
+		merged = append(merged, storedUpstreamHeader{Name: name, Ciphertext: ciphertext})
+	}
+	raw, err := json.Marshal(merged)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func resolveUpstreamHeaderPolicy(raw string, key []byte, target *url.URL) (upstreamHeaderPolicy, error) {
+	stored, err := parseStoredUpstreamHeaders(raw)
+	if err != nil {
+		return upstreamHeaderPolicy{}, err
+	}
+	policy := upstreamHeaderPolicy{authority: redirectHostKey(target), values: make(http.Header, len(stored))}
+	for _, header := range stored {
+		value, err := decryptUpstreamHeaderValue(header.Name, header.Ciphertext, policy.authority, key)
+		if err != nil {
+			return upstreamHeaderPolicy{}, fmt.Errorf("resolve upstream header %s: %w", header.Name, err)
+		}
+		value, err = normalizeUpstreamHeaderValue(value)
+		if err != nil {
+			return upstreamHeaderPolicy{}, fmt.Errorf("resolve upstream header %s: %w", header.Name, err)
+		}
+		policy.values.Set(header.Name, value)
+	}
+	return policy, nil
+}
+
+func (p upstreamHeaderPolicy) apply(header http.Header, target *url.URL) {
+	for name := range p.values {
+		header.Del(name)
+	}
+	if target == nil || redirectHostKey(target) != p.authority {
+		return
+	}
+	for name, values := range p.values {
+		header[name] = append([]string(nil), values...)
+	}
 }
 
 var jwtSecret []byte
@@ -380,6 +682,19 @@ func isSQLiteBusyError(err error) bool {
 	}
 }
 
+func isSQLiteUniqueConstraintError(err error) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	switch sqliteErr.Code() {
+	case sqlite3.SQLITE_CONSTRAINT_UNIQUE, sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY:
+		return true
+	default:
+		return false
+	}
+}
+
 func (d *DB) migrateOnce() error {
 	ctx := context.Background()
 	conn, err := d.db.Conn(ctx)
@@ -405,11 +720,13 @@ func (d *DB) migrateOnce() error {
 		password_hash TEXT NOT NULL,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);
-	CREATE TABLE IF NOT EXISTS sites (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		name TEXT NOT NULL,
-		listen_port INTEGER NOT NULL UNIQUE,
-		target_url TEXT NOT NULL,
+		CREATE TABLE IF NOT EXISTS sites (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			listen_port INTEGER NOT NULL UNIQUE,
+			public_host TEXT NOT NULL DEFAULT '',
+			ingress_mode TEXT NOT NULL DEFAULT 'port',
+			target_url TEXT NOT NULL,
 		playback_target_url TEXT NOT NULL DEFAULT '',
 		playback_mode TEXT NOT NULL DEFAULT 'direct',
 		stream_hosts TEXT NOT NULL DEFAULT '[]',
@@ -417,6 +734,7 @@ func (d *DB) migrateOnce() error {
 		custom_user_agent TEXT NOT NULL DEFAULT '',
 		custom_client TEXT NOT NULL DEFAULT '',
 		custom_version TEXT NOT NULL DEFAULT '',
+		upstream_headers TEXT NOT NULL DEFAULT '[]',
 		enabled INTEGER DEFAULT 1,
 		traffic_quota BIGINT DEFAULT 0,
 		traffic_used BIGINT DEFAULT 0,
@@ -446,6 +764,9 @@ func (d *DB) migrateOnce() error {
 		{"custom_user_agent", "ALTER TABLE sites ADD COLUMN custom_user_agent TEXT NOT NULL DEFAULT ''"},
 		{"custom_client", "ALTER TABLE sites ADD COLUMN custom_client TEXT NOT NULL DEFAULT ''"},
 		{"custom_version", "ALTER TABLE sites ADD COLUMN custom_version TEXT NOT NULL DEFAULT ''"},
+		{"public_host", "ALTER TABLE sites ADD COLUMN public_host TEXT NOT NULL DEFAULT ''"},
+		{"ingress_mode", "ALTER TABLE sites ADD COLUMN ingress_mode TEXT NOT NULL DEFAULT 'port'"},
+		{"upstream_headers", "ALTER TABLE sites ADD COLUMN upstream_headers TEXT NOT NULL DEFAULT '[]'"},
 	} {
 		exists, err := sqliteColumnExists(ctx, conn, migration.column)
 		if err != nil {
@@ -456,6 +777,15 @@ func (d *DB) migrateOnce() error {
 				return err
 			}
 		}
+	}
+	// public_host was introduced before ingress_mode on the unreleased Issue #28
+	// branch. Migrate those rows to the secure host-only behavior instead of
+	// silently retaining a public high-port listener.
+	if _, err := conn.ExecContext(ctx, "UPDATE sites SET ingress_mode='host' WHERE public_host <> '' AND ingress_mode='port'"); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, "CREATE UNIQUE INDEX IF NOT EXISTS idx_sites_public_host ON sites(public_host COLLATE NOCASE) WHERE public_host <> ''"); err != nil {
+		return err
 	}
 
 	var hasHourlyIndex int
@@ -502,23 +832,53 @@ func sqliteColumnExists(ctx context.Context, conn *sql.Conn, column string) (boo
 }
 
 type Site struct {
-	ID                int64  `json:"id"`
-	Name              string `json:"name"`
-	ListenPort        int    `json:"listen_port"`
-	TargetURL         string `json:"target_url"`
-	PlaybackTargetURL string `json:"playback_target_url"`
-	PlaybackMode      string `json:"playback_mode"`
-	StreamHosts       string `json:"stream_hosts"`
-	UAMode            string `json:"ua_mode"`
-	CustomUserAgent   string `json:"custom_user_agent"`
-	CustomClient      string `json:"custom_client"`
-	CustomVersion     string `json:"custom_version"`
-	Enabled           bool   `json:"enabled"`
-	TrafficQuota      int64  `json:"traffic_quota"`
-	TrafficUsed       int64  `json:"traffic_used"`
-	SpeedLimit        int    `json:"speed_limit"`
-	CreatedAt         string `json:"created_at"`
-	UpdatedAt         string `json:"updated_at"`
+	ID                    int64                `json:"id"`
+	Name                  string               `json:"name"`
+	ListenPort            int                  `json:"listen_port"`
+	PublicHost            string               `json:"public_host"`
+	IngressMode           string               `json:"ingress_mode"`
+	TargetURL             string               `json:"target_url"`
+	PlaybackTargetURL     string               `json:"playback_target_url"`
+	PlaybackMode          string               `json:"playback_mode"`
+	StreamHosts           string               `json:"-"`
+	StreamHostList        []string             `json:"stream_hosts"`
+	UAMode                string               `json:"ua_mode"`
+	CustomUserAgent       string               `json:"custom_user_agent"`
+	CustomClient          string               `json:"custom_client"`
+	CustomVersion         string               `json:"custom_version"`
+	StoredUpstreamHeaders string               `json:"-"`
+	UpstreamHeaders       []UpstreamHeaderView `json:"upstream_headers"`
+	Enabled               bool                 `json:"enabled"`
+	TrafficQuota          int64                `json:"traffic_quota"`
+	TrafficUsed           int64                `json:"traffic_used"`
+	SpeedLimit            int                  `json:"speed_limit"`
+	CreatedAt             string               `json:"created_at"`
+	UpdatedAt             string               `json:"updated_at"`
+}
+
+func hydrateSiteConfiguration(site *Site) error {
+	publicHost, err := normalizePublicHost(site.PublicHost)
+	if err != nil {
+		return err
+	}
+	site.PublicHost = publicHost
+	ingressMode, err := normalizeIngressMode(site.IngressMode, site.PublicHost)
+	if err != nil {
+		return err
+	}
+	site.IngressMode = ingressMode
+	if err := json.Unmarshal([]byte(site.StreamHosts), &site.StreamHostList); err != nil {
+		return fmt.Errorf("invalid stored stream_hosts: %w", err)
+	}
+	if site.StreamHostList == nil {
+		site.StreamHostList = []string{}
+	}
+	views, err := upstreamHeaderViews(site.StoredUpstreamHeaders)
+	if err != nil {
+		return err
+	}
+	site.UpstreamHeaders = views
+	return nil
 }
 
 type TrafficLog struct {
@@ -674,7 +1034,7 @@ func (d *DB) ResetAdminPassword(password string) error {
 }
 
 func (d *DB) ListSites() ([]Site, error) {
-	rows, err := d.db.Query("SELECT id, name, listen_port, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, enabled, traffic_quota, traffic_used, speed_limit, created_at, updated_at FROM sites ORDER BY id")
+	rows, err := d.db.Query("SELECT id, name, listen_port, public_host, ingress_mode, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, upstream_headers, enabled, traffic_quota, traffic_used, speed_limit, created_at, updated_at FROM sites ORDER BY id")
 	if err != nil {
 		return nil, err
 	}
@@ -683,8 +1043,11 @@ func (d *DB) ListSites() ([]Site, error) {
 	for rows.Next() {
 		var s Site
 		var enabled int
-		if err := rows.Scan(&s.ID, &s.Name, &s.ListenPort, &s.TargetURL, &s.PlaybackTargetURL, &s.PlaybackMode, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.Name, &s.ListenPort, &s.PublicHost, &s.IngressMode, &s.TargetURL, &s.PlaybackTargetURL, &s.PlaybackMode, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &s.StoredUpstreamHeaders, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, err
+		}
+		if err := hydrateSiteConfiguration(&s); err != nil {
+			return nil, fmt.Errorf("site %d: %w", s.ID, err)
 		}
 		s.Enabled = enabled == 1
 		sites = append(sites, s)
@@ -701,12 +1064,15 @@ func (d *DB) ListSites() ([]Site, error) {
 func (d *DB) GetSite(id int64) (*Site, error) {
 	var s Site
 	var enabled int
-	err := d.db.QueryRow("SELECT id, name, listen_port, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, enabled, traffic_quota, traffic_used, speed_limit, created_at, updated_at FROM sites WHERE id=?", id).
-		Scan(&s.ID, &s.Name, &s.ListenPort, &s.TargetURL, &s.PlaybackTargetURL, &s.PlaybackMode, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt)
+	err := d.db.QueryRow("SELECT id, name, listen_port, public_host, ingress_mode, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, upstream_headers, enabled, traffic_quota, traffic_used, speed_limit, created_at, updated_at FROM sites WHERE id=?", id).
+		Scan(&s.ID, &s.Name, &s.ListenPort, &s.PublicHost, &s.IngressMode, &s.TargetURL, &s.PlaybackTargetURL, &s.PlaybackMode, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &s.StoredUpstreamHeaders, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
 	s.Enabled = enabled == 1
+	if err := hydrateSiteConfiguration(&s); err != nil {
+		return nil, fmt.Errorf("site %d: %w", s.ID, err)
+	}
 	return &s, nil
 }
 
@@ -735,9 +1101,21 @@ func (d *DB) CreateSiteRecord(site Site) (*Site, error) {
 	if site.StreamHosts == "" {
 		site.StreamHosts = "[]"
 	}
+	if site.StoredUpstreamHeaders == "" {
+		site.StoredUpstreamHeaders = "[]"
+	}
+	publicHost, err := normalizePublicHost(site.PublicHost)
+	if err != nil {
+		return nil, err
+	}
+	site.PublicHost = publicHost
+	site.IngressMode, err = normalizeIngressMode(site.IngressMode, site.PublicHost)
+	if err != nil {
+		return nil, err
+	}
 	res, err := d.db.Exec(
-		"INSERT INTO sites (name, listen_port, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, traffic_quota, speed_limit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
-		site.Name, site.ListenPort, site.TargetURL, site.PlaybackTargetURL, site.PlaybackMode, site.StreamHosts, site.UAMode, site.CustomUserAgent, site.CustomClient, site.CustomVersion, site.TrafficQuota, site.SpeedLimit,
+		"INSERT INTO sites (name, listen_port, public_host, ingress_mode, target_url, playback_target_url, playback_mode, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, upstream_headers, traffic_quota, speed_limit) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+		site.Name, site.ListenPort, site.PublicHost, site.IngressMode, site.TargetURL, site.PlaybackTargetURL, site.PlaybackMode, site.StreamHosts, site.UAMode, site.CustomUserAgent, site.CustomClient, site.CustomVersion, site.StoredUpstreamHeaders, site.TrafficQuota, site.SpeedLimit,
 	)
 	if err != nil {
 		return nil, err
@@ -754,32 +1132,76 @@ func (d *DB) UpdateSite(id int64, name string, port int, targetURL, playbackTarg
 }
 
 func (d *DB) UpdateSiteWithCustomUA(id int64, name string, port int, targetURL, playbackTargetURL, playbackMode, streamHosts, uaMode, customUserAgent, customClient, customVersion string, quota int64, speedLimit int) error {
-	return d.UpdateSiteRecord(Site{
-		ID:                id,
-		Name:              name,
-		ListenPort:        port,
-		TargetURL:         targetURL,
-		PlaybackTargetURL: playbackTargetURL,
-		PlaybackMode:      playbackMode,
-		StreamHosts:       streamHosts,
-		UAMode:            uaMode,
-		CustomUserAgent:   customUserAgent,
-		CustomClient:      customClient,
-		CustomVersion:     customVersion,
-		TrafficQuota:      quota,
-		SpeedLimit:        speedLimit,
-	})
+	site, err := d.GetSite(id)
+	if err != nil {
+		return err
+	}
+	site.Name = name
+	site.ListenPort = port
+	site.TargetURL = targetURL
+	site.PlaybackTargetURL = playbackTargetURL
+	site.PlaybackMode = playbackMode
+	site.StreamHosts = streamHosts
+	site.UAMode = uaMode
+	site.CustomUserAgent = customUserAgent
+	site.CustomClient = customClient
+	site.CustomVersion = customVersion
+	site.TrafficQuota = quota
+	site.SpeedLimit = speedLimit
+	return d.UpdateSiteRecord(*site)
 }
 
 func (d *DB) UpdateSiteRecord(site Site) error {
 	if site.StreamHosts == "" {
 		site.StreamHosts = "[]"
 	}
-	_, err := d.db.Exec(
-		"UPDATE sites SET name=?, listen_port=?, target_url=?, playback_target_url=?, playback_mode=?, stream_hosts=?, ua_mode=?, custom_user_agent=?, custom_client=?, custom_version=?, traffic_quota=?, speed_limit=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
-		site.Name, site.ListenPort, site.TargetURL, site.PlaybackTargetURL, site.PlaybackMode, site.StreamHosts, site.UAMode, site.CustomUserAgent, site.CustomClient, site.CustomVersion, site.TrafficQuota, site.SpeedLimit, site.ID,
+	if site.StoredUpstreamHeaders == "" {
+		site.StoredUpstreamHeaders = "[]"
+	}
+	publicHost, err := normalizePublicHost(site.PublicHost)
+	if err != nil {
+		return err
+	}
+	site.PublicHost = publicHost
+	site.IngressMode, err = normalizeIngressMode(site.IngressMode, site.PublicHost)
+	if err != nil {
+		return err
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var currentTargetURL, currentHeaders string
+	queryErr := tx.QueryRow("SELECT target_url, upstream_headers FROM sites WHERE id=?", site.ID).Scan(&currentTargetURL, &currentHeaders)
+	if queryErr != nil && !errors.Is(queryErr, sql.ErrNoRows) {
+		return queryErr
+	}
+	if queryErr == nil {
+		currentTarget, currentErr := normalizeTargetURL(currentTargetURL)
+		newTarget, newErr := normalizeTargetURL(site.TargetURL)
+		if currentErr != nil {
+			return fmt.Errorf("stored target_url is invalid: %w", currentErr)
+		}
+		if newErr != nil {
+			return fmt.Errorf("invalid target_url: %w", newErr)
+		}
+		if !sameRedirectAuthority(currentTarget, newTarget) && site.StoredUpstreamHeaders == currentHeaders {
+			// Data-layer callers must not accidentally carry an origin secret to
+			// a different scheme/host/port. The HTTP API may supply freshly
+			// encrypted v2 values for the new authority; unchanged ciphertext is
+			// always cleared here, even if a caller bypasses the handler checks.
+			site.StoredUpstreamHeaders = "[]"
+		}
+	}
+	_, err = tx.Exec(
+		"UPDATE sites SET name=?, listen_port=?, public_host=?, ingress_mode=?, target_url=?, playback_target_url=?, playback_mode=?, stream_hosts=?, ua_mode=?, custom_user_agent=?, custom_client=?, custom_version=?, upstream_headers=?, traffic_quota=?, speed_limit=?, updated_at=CURRENT_TIMESTAMP WHERE id=?",
+		site.Name, site.ListenPort, site.PublicHost, site.IngressMode, site.TargetURL, site.PlaybackTargetURL, site.PlaybackMode, site.StreamHosts, site.UAMode, site.CustomUserAgent, site.CustomClient, site.CustomVersion, site.StoredUpstreamHeaders, site.TrafficQuota, site.SpeedLimit, site.ID,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (d *DB) DeleteSite(id int64) error {
@@ -805,6 +1227,25 @@ func (d *DB) ToggleSite(id int64) (bool, error) {
 	newVal := 1 - enabled
 	_, err := d.db.Exec("UPDATE sites SET enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?", newVal, id)
 	return newVal == 1, err
+}
+
+func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
+	value := 0
+	if enabled {
+		value = 1
+	}
+	result, err := d.db.Exec("UPDATE sites SET enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?", value, id)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return fmt.Errorf("updated %d site rows, want 1", rows)
+	}
+	return nil
 }
 
 func (d *DB) AddTraffic(siteID, bytesIn, bytesOut int64) {
@@ -870,9 +1311,52 @@ func (d *DB) GetTrafficLogs(siteID int64, hours int) ([]TrafficLog, error) {
 }
 
 type redirectFollowTransport struct {
-	base          http.RoundTripper
-	playbackHosts map[string]bool
-	policy        UAHeaderPolicy
+	base                 http.RoundTripper
+	playbackHosts        map[string]bool
+	policy               UAHeaderPolicy
+	upstreamHeaderPolicy upstreamHeaderPolicy
+}
+
+func crossAuthorityHeaders(source http.Header, additionalAllowed ...string) http.Header {
+	// Cross-authority redirects go to a distinct trust domain. Rebuild from the
+	// small set needed for media negotiation/resume plus Meridian-normalized
+	// client identity; arbitrary application headers may be API keys or bearer
+	// credentials even when their names are not known in advance.
+	allowed := []string{
+		"Accept", "Accept-Encoding", "Cache-Control", "If-Modified-Since",
+		"If-None-Match", "If-Range", "Pragma", "Range", "User-Agent",
+		"X-Emby-Authorization", "X-Forwarded-For", "X-Forwarded-Host",
+		"X-Forwarded-Proto", "X-Real-IP",
+	}
+	allowed = append(allowed, additionalAllowed...)
+	header := make(http.Header, len(allowed))
+	for _, name := range allowed {
+		if values := source.Values(name); len(values) > 0 {
+			header[http.CanonicalHeaderKey(name)] = append([]string(nil), values...)
+		}
+	}
+	stripSensitiveRedirectHeaders(header)
+	return header
+}
+
+func crossAuthorityRedirectHeaders(source http.Header) http.Header {
+	return crossAuthorityHeaders(source)
+}
+
+func crossAuthorityWebSocketHeaders(source http.Header) http.Header {
+	header := crossAuthorityHeaders(
+		source,
+		"Origin",
+		"Sec-WebSocket-Extensions",
+		"Sec-WebSocket-Key",
+		"Sec-WebSocket-Protocol",
+		"Sec-WebSocket-Version",
+	)
+	// These hop-by-hop fields are generated by Meridian, not copied from the
+	// client. Rebuild them after the cross-authority allowlist has run.
+	header.Set("Connection", "Upgrade")
+	header.Set("Upgrade", "websocket")
+	return header
 }
 
 func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -897,16 +1381,13 @@ func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, 
 		}
 		locURL = req.URL.ResolveReference(locURL)
 		locURL.Scheme = strings.ToLower(locURL.Scheme)
-		if (locURL.Scheme != "http" && locURL.Scheme != "https") || !t.playbackHosts[redirectHostKey(locURL)] {
+		if (locURL.Scheme != "http" && locURL.Scheme != "https") || locURL.User != nil || !t.playbackHosts[redirectHostKey(locURL)] {
 			break
 		}
 		resp.Body.Close()
 		newReq, err := http.NewRequestWithContext(req.Context(), req.Method, locURL.String(), nil)
 		if err != nil {
 			break
-		}
-		for k, v := range req.Header {
-			newReq.Header[k] = v
 		}
 		newReq.Host = locURL.Host
 		if !sameRedirectAuthority(req.URL, locURL) {
@@ -916,9 +1397,12 @@ func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, 
 			// is reapplied below, so identity rewriting stays consistent while
 			// secrets stay behind; passthrough keeps whatever non-secret
 			// identity the client sent.
-			stripSensitiveRedirectHeaders(newReq.Header)
+			newReq.Header = crossAuthorityRedirectHeaders(req.Header)
+		} else {
+			newReq.Header = req.Header.Clone()
 		}
 		applyUAHeaderPolicy(newReq.Header, t.policy)
+		t.upstreamHeaderPolicy.apply(newReq.Header, locURL)
 		resp, err = t.base.RoundTrip(newReq)
 		if err != nil {
 			return nil, err
@@ -1201,9 +1685,22 @@ func stripSensitiveRedirectHeaders(header http.Header) {
 
 type ProxyInstance struct {
 	Site      Site
+	handler   http.Handler
 	server    *http.Server
 	listener  net.Listener
+	transport *http.Transport
 	startedAt time.Time
+	ctx       context.Context
+	cancel    context.CancelFunc
+	// lifecycleMu closes the gate before activeRequests.Wait begins, so no Add
+	// can race a drain. Hijacked WebSocket connections are tracked separately
+	// because net/http no longer owns them after Hijack.
+	lifecycleMu     sync.Mutex
+	closing         bool
+	activeRequests  sync.WaitGroup
+	hijackedConns   map[net.Conn]struct{}
+	portServing     atomic.Bool
+	portServeFailed atomic.Bool
 	// trafficMu serializes this instance's traffic state transitions: flush,
 	// single-site history snapshot and the live overlay in global snapshots.
 	// Lock order is pm.mu -> trafficMu; helpers that take trafficMu (e.g.
@@ -1213,19 +1710,264 @@ type ProxyInstance struct {
 	bytesOut         atomic.Int64
 	reqCount         atomic.Int64
 	persistedTraffic atomic.Int64
+	trustedProxies   []*net.IPNet
 }
 
 type ProxyManager struct {
-	mu       sync.RWMutex
-	proxies  map[int64]*ProxyInstance
-	database *DB
+	mu                  sync.RWMutex
+	lifecycleMu         sync.Mutex
+	proxies             map[int64]*ProxyInstance
+	publicHosts         map[string]int64
+	publicHostModes     map[string]string
+	upstreamHeaderKey   []byte
+	trustedProxies      []*net.IPNet
+	hostOnlyIngressSafe bool
+	shutdownStarted     atomic.Bool
+	database            *DB
 }
 
-func NewProxyManager(db *DB) *ProxyManager {
-	return &ProxyManager{
-		proxies:  make(map[int64]*ProxyInstance),
-		database: db,
+// siteIngressClosedError means StopSite passed the irreversible boundary: new
+// requests are rejected and listeners are closed, but draining and/or the final
+// traffic checkpoint did not finish. Callers must not leave the DB row enabled
+// as if the proxy were still serving.
+type siteIngressClosedError struct {
+	siteID   int64
+	drainErr error
+	flushErr error
+}
+
+func (e *siteIngressClosedError) Error() string {
+	switch {
+	case e.drainErr != nil && e.flushErr != nil:
+		return fmt.Sprintf("site %d ingress closed; drain failed: %v; final traffic flush failed: %v", e.siteID, e.drainErr, e.flushErr)
+	case e.drainErr != nil:
+		return fmt.Sprintf("site %d ingress closed; drain failed: %v", e.siteID, e.drainErr)
+	default:
+		return fmt.Sprintf("site %d ingress closed; final traffic flush failed: %v", e.siteID, e.flushErr)
 	}
+}
+
+func isSiteIngressClosedError(err error) bool {
+	var closedErr *siteIngressClosedError
+	return errors.As(err, &closedErr)
+}
+
+func (inst *ProxyInstance) beginRequest() bool {
+	inst.lifecycleMu.Lock()
+	defer inst.lifecycleMu.Unlock()
+	if inst.closing {
+		return false
+	}
+	inst.activeRequests.Add(1)
+	return true
+}
+
+func (inst *ProxyInstance) endRequest() {
+	inst.activeRequests.Done()
+}
+
+func (inst *ProxyInstance) isAccepting() bool {
+	inst.lifecycleMu.Lock()
+	defer inst.lifecycleMu.Unlock()
+	return !inst.closing
+}
+
+// isOperational distinguishes an open lifecycle gate from a usable ingress.
+// Host-capable instances remain reachable through the shared panel listener;
+// port-only instances are operational only while their dedicated Serve loop is
+// actually alive.
+func (inst *ProxyInstance) isOperational() bool {
+	if !inst.isAccepting() {
+		return false
+	}
+	return ingressUsesHost(inst.Site.IngressMode) || !inst.portServeFailed.Load()
+}
+
+func (inst *ProxyInstance) trackHijackedConn(conn net.Conn) bool {
+	inst.lifecycleMu.Lock()
+	defer inst.lifecycleMu.Unlock()
+	if inst.closing {
+		return false
+	}
+	if inst.hijackedConns == nil {
+		inst.hijackedConns = make(map[net.Conn]struct{})
+	}
+	inst.hijackedConns[conn] = struct{}{}
+	return true
+}
+
+func (inst *ProxyInstance) untrackHijackedConn(conn net.Conn) {
+	inst.lifecycleMu.Lock()
+	delete(inst.hijackedConns, conn)
+	inst.lifecycleMu.Unlock()
+}
+
+func (inst *ProxyInstance) shutdown(ctx context.Context) error {
+	inst.lifecycleMu.Lock()
+	if !inst.closing {
+		inst.closing = true
+		if inst.cancel != nil {
+			inst.cancel()
+		}
+	}
+	connections := make([]net.Conn, 0, len(inst.hijackedConns))
+	for conn := range inst.hijackedConns {
+		connections = append(connections, conn)
+	}
+	inst.lifecycleMu.Unlock()
+
+	if inst.listener != nil {
+		_ = inst.listener.Close()
+	}
+	if inst.server != nil {
+		_ = inst.server.Close()
+	}
+	if inst.transport != nil {
+		inst.transport.CloseIdleConnections()
+	}
+	for _, conn := range connections {
+		_ = conn.Close()
+	}
+
+	drained := make(chan struct{})
+	go func() {
+		inst.activeRequests.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func NewProxyManager(db *DB, upstreamHeaderKey []byte) *ProxyManager {
+	pm := &ProxyManager{
+		proxies:         make(map[int64]*ProxyInstance),
+		publicHosts:     make(map[string]int64),
+		publicHostModes: make(map[string]string),
+		database:        db,
+	}
+	pm.upstreamHeaderKey = append([]byte(nil), upstreamHeaderKey...)
+	return pm
+}
+
+func (pm *ProxyManager) SetTrustedProxies(networks []*net.IPNet) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.trustedProxies = append([]*net.IPNet(nil), networks...)
+}
+
+func (pm *ProxyManager) SetHostOnlyIngressSafe(safe bool) {
+	pm.mu.Lock()
+	pm.hostOnlyIngressSafe = safe
+	pm.mu.Unlock()
+}
+
+func (pm *ProxyManager) HostOnlyIngressSafe() bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return pm.hostOnlyIngressSafe
+}
+
+func (pm *ProxyManager) UpstreamHeadersAvailable() bool {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	return len(pm.upstreamHeaderKey) == 32
+}
+
+func (pm *ProxyManager) validateIngressSafety(mode string) error {
+	if mode != ingressModeHost {
+		return nil
+	}
+	pm.mu.RLock()
+	safe := pm.hostOnlyIngressSafe
+	pm.mu.RUnlock()
+	if !safe {
+		return errUnsafeHostOnlyIngress
+	}
+	return nil
+}
+
+func (pm *ProxyManager) registerSiteHostLocked(site Site) error {
+	desiredHost := ""
+	if ingressUsesHost(site.IngressMode) {
+		desiredHost = site.PublicHost
+		if existing, ok := pm.publicHosts[desiredHost]; ok && existing != site.ID {
+			return fmt.Errorf("public_host %s is already assigned to another site", desiredHost)
+		}
+	}
+	for host, id := range pm.publicHosts {
+		if id == site.ID && host != desiredHost {
+			delete(pm.publicHosts, host)
+			delete(pm.publicHostModes, host)
+		}
+	}
+	if desiredHost == "" {
+		return nil
+	}
+	pm.publicHosts[desiredHost] = site.ID
+	pm.publicHostModes[desiredHost] = site.IngressMode
+	return nil
+}
+
+func (pm *ProxyManager) RegisterSiteHost(site Site) error {
+	pm.lifecycleMu.Lock()
+	defer pm.lifecycleMu.Unlock()
+	if pm.shutdownStarted.Load() {
+		return errProxyManagerShuttingDown
+	}
+	publicHost, err := normalizePublicHost(site.PublicHost)
+	if err != nil {
+		return err
+	}
+	site.PublicHost = publicHost
+	site.IngressMode, err = normalizeIngressMode(site.IngressMode, site.PublicHost)
+	if err != nil {
+		return err
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.registerSiteHostLocked(site)
+}
+
+func (pm *ProxyManager) UnregisterSiteHost(siteID int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	for host, id := range pm.publicHosts {
+		if id == siteID {
+			delete(pm.publicHosts, host)
+			delete(pm.publicHostModes, host)
+		}
+	}
+}
+
+func (pm *ProxyManager) PublicHostHandler(host string) (http.Handler, bool) {
+	handler, configured, _ := pm.PublicHostRoute(host)
+	return handler, configured
+}
+
+func (pm *ProxyManager) PublicHostRoute(host string) (http.Handler, bool, string) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	id, configured := pm.publicHosts[host]
+	if !configured {
+		return nil, false, ""
+	}
+	mode := pm.publicHostModes[host]
+	inst := pm.proxies[id]
+	if inst == nil {
+		return nil, true, mode
+	}
+	return inst.handler, true, mode
+}
+
+func (pm *ProxyManager) PublicHostSiteID(host string) (int64, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	id, ok := pm.publicHosts[host]
+	return id, ok
 }
 
 // metered response writer
@@ -1389,14 +2131,19 @@ func headerHasToken(header http.Header, name, token string) bool {
 // A bare "Upgrade: websocket" header is not enough to qualify: routing an
 // ordinary request into the hijacked tunnel would skip the metering and
 // speed-limit wrappers that the normal proxy path installs, and would relay raw
-// bytes to an upstream that never agreed to switch protocols. Requests that fail
-// this check fall through to httputil.ReverseProxy, which negotiates protocol
-// switches on its own.
+// bytes to an upstream that never agreed to switch protocols. Any request with
+// upgrade intent that fails this check is rejected before ReverseProxy, because
+// its generic 101 tunnel would bypass Meridian's traffic accounting and limits.
 func isWebSocketUpgrade(r *http.Request) bool {
 	return r.Method == http.MethodGet &&
 		strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
 		headerHasToken(r.Header, "Connection", "upgrade") &&
 		r.Header.Get("Sec-WebSocket-Key") != ""
+}
+
+func hasUpgradeIntent(r *http.Request) bool {
+	return strings.TrimSpace(r.Header.Get("Upgrade")) != "" ||
+		headerHasToken(r.Header, "Connection", "upgrade")
 }
 
 func normalizeTargetURL(addr string) (*url.URL, error) {
@@ -1518,6 +2265,86 @@ func applyUpstreamURL(requestURL, upstream *url.URL) {
 	}
 }
 
+func normalizePublicHost(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "", nil
+	}
+	value = strings.TrimSuffix(value, ".")
+	if value == "" || len(value) > 253 || !strings.Contains(value, ".") {
+		return "", fmt.Errorf("public_host must be a fully-qualified DNS name")
+	}
+	if strings.ContainsAny(value, "/:*[]") || net.ParseIP(value) != nil {
+		return "", fmt.Errorf("public_host must not contain a scheme, path, port, wildcard, or IP address")
+	}
+	for _, label := range strings.Split(value, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", fmt.Errorf("public_host contains an invalid DNS label")
+		}
+		for i := 0; i < len(label); i++ {
+			c := label[i]
+			if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-') {
+				return "", fmt.Errorf("public_host must use ASCII DNS labels; encode international names as punycode")
+			}
+		}
+	}
+	return value, nil
+}
+
+func normalizeIngressMode(value, publicHost string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(value))
+	if mode == "" {
+		if publicHost != "" {
+			mode = ingressModeHost
+		} else {
+			mode = ingressModePort
+		}
+	}
+	switch mode {
+	case ingressModePort:
+		if publicHost != "" {
+			return "", fmt.Errorf("public_host must be empty when ingress_mode is port")
+		}
+	case ingressModeHost, ingressModeBoth:
+		if publicHost == "" {
+			return "", fmt.Errorf("public_host is required when ingress_mode is %s", mode)
+		}
+	default:
+		return "", fmt.Errorf("ingress_mode must be port, host, or both")
+	}
+	return mode, nil
+}
+
+func ingressUsesPort(mode string) bool {
+	return mode == ingressModePort || mode == ingressModeBoth
+}
+
+func ingressUsesHost(mode string) bool {
+	return mode == ingressModeHost || mode == ingressModeBoth
+}
+
+func isReservedDynamicRoute(requestPath string) bool {
+	return requestPath == strings.TrimSuffix(dynamicRoutePrefix, "/") || strings.HasPrefix(requestPath, dynamicRoutePrefix)
+}
+
+func requestPublicHost(hostport string) string {
+	hostport = strings.TrimSpace(hostport)
+	if hostport == "" || strings.HasPrefix(hostport, "[") {
+		return ""
+	}
+	host := hostport
+	if parsedHost, _, err := net.SplitHostPort(hostport); err == nil {
+		host = parsedHost
+	} else if strings.Contains(hostport, ":") {
+		return ""
+	}
+	normalized, err := normalizePublicHost(host)
+	if err != nil {
+		return ""
+	}
+	return normalized
+}
+
 func validateSiteSettings(name string, listenPort int, targetURL, playbackTargetURL, playbackMode string, streamHosts []string, uaMode, customUserAgent, customClient, customVersion string, quota int64, speedLimit int) error {
 	name = strings.TrimSpace(name)
 	if name == "" || len(name) > 100 || strings.ContainsAny(name, "\r\n") {
@@ -1526,10 +2353,16 @@ func validateSiteSettings(name string, listenPort int, targetURL, playbackTarget
 	if listenPort < 1 || listenPort > 65535 {
 		return fmt.Errorf("listen_port must be between 1 and 65535")
 	}
+	if len(targetURL) > maxTargetURLLength {
+		return fmt.Errorf("target_url must not exceed %d bytes", maxTargetURLLength)
+	}
 	if _, err := normalizeTargetURL(targetURL); err != nil {
 		return fmt.Errorf("invalid target_url: %w", err)
 	}
 	if strings.TrimSpace(playbackTargetURL) != "" {
+		if len(playbackTargetURL) > maxTargetURLLength {
+			return fmt.Errorf("playback_target_url must not exceed %d bytes", maxTargetURLLength)
+		}
 		if _, err := normalizeTargetURL(playbackTargetURL); err != nil {
 			return fmt.Errorf("invalid playback_target_url: %w", err)
 		}
@@ -1546,10 +2379,17 @@ func validateSiteSettings(name string, listenPort int, targetURL, playbackTarget
 	if speedLimit > maxSpeedLimitMbps {
 		return fmt.Errorf("speed_limit must not exceed %d Mbps", maxSpeedLimitMbps)
 	}
-	if len(streamHosts) > 128 {
-		return fmt.Errorf("stream_hosts must contain at most 128 entries")
+	playbackAddressCount := len(streamHosts)
+	if strings.TrimSpace(playbackTargetURL) != "" {
+		playbackAddressCount++
+	}
+	if playbackAddressCount > maxPlaybackAddresses {
+		return fmt.Errorf("playback addresses must contain at most %d entries", maxPlaybackAddresses)
 	}
 	for _, host := range streamHosts {
+		if len(host) > maxTargetURLLength {
+			return fmt.Errorf("stream host must not exceed %d bytes", maxTargetURLLength)
+		}
 		if _, err := normalizeTargetURL(host); err != nil {
 			return fmt.Errorf("invalid stream host %q: %w", host, err)
 		}
@@ -1582,6 +2422,43 @@ func upstreamTargetForRequest(r *http.Request, apiTarget, playbackTarget *url.UR
 	return apiTarget
 }
 
+// resolvePlaybackConfiguration is the single interpretation of the persisted
+// playback fields used by both runtime routing and diagnostics. The first
+// stream_hosts entry becomes the effective playback target only when the
+// dedicated playback_target_url is empty; every configured authority remains
+// an allowed redirect destination.
+func resolvePlaybackConfiguration(playbackTargetURL, streamHostsRaw string) (*url.URL, map[string]bool, error) {
+	var playbackTarget *url.URL
+	var err error
+	if strings.TrimSpace(playbackTargetURL) != "" {
+		playbackTarget, err = normalizeTargetURL(playbackTargetURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid playback target URL: %w", err)
+		}
+	}
+	var extraHosts []string
+	if strings.TrimSpace(streamHostsRaw) != "" {
+		if err := json.Unmarshal([]byte(streamHostsRaw), &extraHosts); err != nil {
+			return nil, nil, fmt.Errorf("invalid stream_hosts: %w", err)
+		}
+	}
+	playbackHosts := make(map[string]bool, len(extraHosts)+1)
+	if playbackTarget != nil {
+		playbackHosts[redirectHostKey(playbackTarget)] = true
+	}
+	for _, raw := range extraHosts {
+		parsed, err := normalizeTargetURL(raw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid stream host %q: %w", raw, err)
+		}
+		playbackHosts[redirectHostKey(parsed)] = true
+		if playbackTarget == nil {
+			playbackTarget = parsed
+		}
+	}
+	return playbackTarget, playbackHosts, nil
+}
+
 func applyUAProfileHeaders(header http.Header, profile UAProfile) {
 	header.Set("User-Agent", profile.UserAgent)
 	rewriteEmbyAuthorizationHeaders(header, "X-Emby-Authorization", profile)
@@ -1598,40 +2475,135 @@ func applyUAHeaderPolicy(header http.Header, policy UAHeaderPolicy) {
 	applyUAProfileHeaders(header, policy.Profile)
 }
 
+func isManagedForwardingHeaderName(name string) bool {
+	lowerName := strings.ToLower(name)
+	if lowerName == "forwarded" || lowerName == "x-real-ip" || strings.HasPrefix(lowerName, "x-forwarded-") {
+		return true
+	}
+	switch lowerName {
+	case "cf-connecting-ip", "cf-connecting-ipv6", "fastly-client-ip", "fly-client-ip",
+		"true-client-ip", "x-appengine-user-ip", "x-azure-clientip", "x-client-ip",
+		"x-cluster-client-ip", "x-envoy-external-address", "x-original-forwarded-for":
+		return true
+	default:
+		return false
+	}
+}
+
 func removeClientForwardingHeaders(header http.Header) {
 	for name := range header {
-		lowerName := strings.ToLower(name)
-		if lowerName == "forwarded" || lowerName == "x-real-ip" || strings.HasPrefix(lowerName, "x-forwarded-") {
+		if isManagedForwardingHeaderName(name) {
 			delete(header, name)
 		}
 	}
 }
 
-func setTrustedForwardingHeaders(header http.Header, inbound *http.Request) {
+func singleForwardedHeaderValue(header http.Header, name string) (string, bool) {
+	values := header.Values(name)
+	if len(values) != 1 {
+		return "", false
+	}
+	value := strings.TrimSpace(values[0])
+	if value == "" || strings.Contains(value, ",") {
+		return "", false
+	}
+	return value, true
+}
+
+func setTrustedForwardingHeaders(header http.Header, inbound *http.Request, trustedProxies ...[]*net.IPNet) {
 	removeClientForwardingHeaders(header)
 	if inbound == nil {
 		return
 	}
-	if peerIP := remoteAddressIP(inbound.RemoteAddr); peerIP != nil {
-		header.Set("X-Forwarded-For", peerIP.String())
-		header.Set("X-Real-IP", peerIP.String())
+	var configured []*net.IPNet
+	if len(trustedProxies) > 0 {
+		configured = trustedProxies[0]
 	}
-	if inbound.Host != "" {
-		header.Set("X-Forwarded-Host", inbound.Host)
-	}
+	peerIP := remoteAddressIP(inbound.RemoteAddr)
+	clientIP := peerIP
 	forwardedProto := "http"
 	if inbound.TLS != nil {
 		forwardedProto = "https"
 	}
+	if isTrustedProxy(peerIP, configured) {
+		// Trust only the single value a configured edge proxy normalized. Never
+		// relay an arbitrary inbound X-Forwarded-For chain to the upstream.
+		if value, ok := singleForwardedHeaderValue(inbound.Header, "X-Real-IP"); ok {
+			if forwardedIP := net.ParseIP(value); forwardedIP != nil {
+				clientIP = forwardedIP
+			}
+		}
+		if candidateProto, ok := singleForwardedHeaderValue(inbound.Header, "X-Forwarded-Proto"); ok {
+			if strings.EqualFold(candidateProto, "http") || strings.EqualFold(candidateProto, "https") {
+				forwardedProto = strings.ToLower(candidateProto)
+			}
+		}
+	}
+	if clientIP != nil {
+		header.Set("X-Forwarded-For", clientIP.String())
+		header.Set("X-Real-IP", clientIP.String())
+	}
 	header.Set("X-Forwarded-Proto", forwardedProto)
 }
 
-func prepareUpstreamHeaders(header http.Header, inbound *http.Request, policy UAHeaderPolicy) {
-	setTrustedForwardingHeaders(header, inbound)
+type publicHostIngressContextKey struct{}
+
+func applySiteForwardedHost(header http.Header, inbound *http.Request, site Site) {
+	header.Del("X-Forwarded-Host")
+	if inbound == nil || !ingressUsesHost(site.IngressMode) {
+		return
+	}
+	sharedIngress, _ := inbound.Context().Value(publicHostIngressContextKey{}).(bool)
+	if sharedIngress && requestPublicHost(inbound.Host) == site.PublicHost {
+		header.Set("X-Forwarded-Host", site.PublicHost)
+	}
+}
+
+// stripCookieByName removes Meridian's management session before any site
+// request leaves the process. Browser cookies are scoped by host, not port, so
+// a panel session could otherwise ride along to a site listener on the same
+// host. Malformed Cookie input is dropped in full rather than risk retaining a
+// disguised management credential.
+func stripCookieByName(header http.Header, name string) {
+	var rawValues []string
+	for key, values := range header {
+		if strings.EqualFold(key, "Cookie") {
+			rawValues = append(rawValues, values...)
+			delete(header, key)
+		}
+	}
+	if len(rawValues) == 0 {
+		return
+	}
+
+	kept := make([]string, 0)
+	for _, raw := range rawValues {
+		cookies, err := http.ParseCookie(raw)
+		if err != nil {
+			return
+		}
+		for _, cookie := range cookies {
+			if cookie.Name != name {
+				kept = append(kept, cookie.String())
+			}
+		}
+	}
+	if len(kept) > 0 {
+		header.Set("Cookie", strings.Join(kept, "; "))
+	}
+}
+
+func prepareUpstreamHeaders(header http.Header, inbound *http.Request, policy UAHeaderPolicy, trustedProxies ...[]*net.IPNet) {
+	stripCookieByName(header, sessionCookieName)
+	setTrustedForwardingHeaders(header, inbound, trustedProxies...)
 	applyUAHeaderPolicy(header, policy)
 }
 
-func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, policy UAHeaderPolicy) http.Header {
+func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, policy UAHeaderPolicy, upstreamPolicies ...upstreamHeaderPolicy) http.Header {
+	return prepareWebSocketUpstreamHeadersWithTrustedProxies(inbound, target, policy, nil, upstreamPolicies...)
+}
+
+func prepareWebSocketUpstreamHeadersWithTrustedProxies(inbound *http.Request, target *url.URL, policy UAHeaderPolicy, trustedProxies []*net.IPNet, upstreamPolicies ...upstreamHeaderPolicy) http.Header {
 	header := inbound.Header.Clone()
 	// RFC 9110 hop-by-hop: every header named by the inbound Connection header
 	// is consumed by the first recipient and must not be forwarded. Delete them
@@ -1662,8 +2634,27 @@ func prepareWebSocketUpstreamHeaders(inbound *http.Request, target *url.URL, pol
 	header.Set("Connection", "Upgrade")
 	header.Set("Upgrade", "websocket")
 	header.Set("Host", target.Host)
-	prepareUpstreamHeaders(header, inbound, policy)
+	prepareUpstreamHeaders(header, inbound, policy, trustedProxies)
+	if len(upstreamPolicies) > 0 {
+		upstreamPolicies[0].apply(header, target)
+	}
 	return header
+}
+
+// stripPanelSessionSetCookies prevents an upstream site from overwriting the
+// management session on a sibling port/route. Preserve valid application
+// cookies verbatim; malformed individual values fail closed because browser
+// parsers may otherwise interpret them more permissively than net/http.
+func stripPanelSessionSetCookies(header http.Header) {
+	values := header.Values("Set-Cookie")
+	header.Del("Set-Cookie")
+	for _, value := range values {
+		cookie, err := http.ParseSetCookie(value)
+		if err != nil || cookie.Name == sessionCookieName {
+			continue
+		}
+		header.Add("Set-Cookie", value)
+	}
 }
 
 // writeWebSocketGatewayError answers a hijacked client directly, since the
@@ -1673,7 +2664,7 @@ func writeWebSocketGatewayError(conn net.Conn) {
 	_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
 }
 
-func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, policy UAHeaderPolicy, inst *ProxyInstance, speedLimitBytes int64) {
+func handleWebSocket(w http.ResponseWriter, r *http.Request, target, primaryTarget *url.URL, policy UAHeaderPolicy, inst *ProxyInstance, speedLimitBytes int64, upstreamPolicies ...upstreamHeaderPolicy) {
 	// Nothing on this path reads r.Body, so a body would be left sitting in the
 	// hijacked buffer and relayed verbatim to the upstream.
 	if r.ContentLength != 0 || len(r.TransferEncoding) > 0 {
@@ -1696,6 +2687,10 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, po
 		return
 	}
 	defer clientConn.Close()
+	if !inst.trackHijackedConn(clientConn) {
+		return
+	}
+	defer inst.untrackHijackedConn(clientConn)
 
 	// Connect to upstream
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -1733,7 +2728,15 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, po
 		log.Printf("[WS] write request line: %v", err)
 		return
 	}
-	upstreamHeader := prepareWebSocketUpstreamHeaders(r, target, policy)
+	upstreamHeader := prepareWebSocketUpstreamHeadersWithTrustedProxies(r, target, policy, inst.trustedProxies, upstreamPolicies...)
+	if primaryTarget != nil && !sameRedirectAuthority(primaryTarget, target) {
+		// A separately configured playback/CDN authority is a different trust
+		// domain. Preserve only WebSocket negotiation fields and normalized client
+		// identity; browser/API credentials must stay with the main origin.
+		upstreamHeader = crossAuthorityWebSocketHeaders(upstreamHeader)
+		upstreamHeader.Set("Host", target.Host)
+	}
+	applySiteForwardedHost(upstreamHeader, r, inst.Site)
 	if err := upstreamHeader.Write(upstreamConn); err != nil {
 		log.Printf("[WS] write request headers: %v", err)
 		return
@@ -1780,6 +2783,7 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, po
 		writeWebSocketGatewayError(clientConn)
 		return
 	}
+	stripPanelSessionSetCookies(resp.Header)
 
 	// Relay the switch verbatim; the client needs Sec-WebSocket-Accept.
 	if _, err := io.WriteString(clientConn, "HTTP/1.1 101 Switching Protocols\r\n"); err != nil {
@@ -1808,49 +2812,66 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target *url.URL, po
 		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: &inst.bytesOut, bytesPerSec: speedLimitBytes, start: time.Now()}, upstreamReader)
 		done <- struct{}{}
 	}()
+	// The first closed direction must tear down its counterpart, then both copy
+	// goroutines must finish before the request leaves activeRequests. Otherwise
+	// shutdown can perform its final traffic flush while the second goroutine is
+	// still incrementing the old instance's counters.
+	<-done
+	_ = clientConn.Close()
+	_ = upstreamConn.Close()
 	<-done
 }
 
 func (pm *ProxyManager) StartSite(site Site) error {
+	pm.lifecycleMu.Lock()
+	defer pm.lifecycleMu.Unlock()
+	if pm.shutdownStarted.Load() {
+		return errProxyManagerShuttingDown
+	}
+	publicHost, err := normalizePublicHost(site.PublicHost)
+	if err != nil {
+		return fmt.Errorf("invalid public host: %w", err)
+	}
+	site.PublicHost = publicHost
+	site.IngressMode, err = normalizeIngressMode(site.IngressMode, site.PublicHost)
+	if err != nil {
+		return fmt.Errorf("invalid ingress configuration: %w", err)
+	}
+	if err := pm.validateIngressSafety(site.IngressMode); err != nil {
+		return err
+	}
 	target, err := normalizeTargetURL(site.TargetURL)
 	if err != nil {
 		return fmt.Errorf("invalid target URL: %w", err)
 	}
-	var playbackTarget *url.URL
-	if strings.TrimSpace(site.PlaybackTargetURL) != "" {
-		playbackTarget, err = normalizeTargetURL(site.PlaybackTargetURL)
-		if err != nil {
-			return fmt.Errorf("invalid playback target URL: %w", err)
-		}
-	}
-
-	// Build playback hosts set from playback_target_url + stream_hosts
-	playbackHostsSet := make(map[string]bool)
-	if playbackTarget != nil {
-		playbackHostsSet[redirectHostKey(playbackTarget)] = true
-	}
-	var extraHosts []string
-	if strings.TrimSpace(site.StreamHosts) != "" {
-		if err := json.Unmarshal([]byte(site.StreamHosts), &extraHosts); err != nil {
-			return fmt.Errorf("invalid stream_hosts: %w", err)
-		}
-	}
-	for _, raw := range extraHosts {
-		parsed, err := normalizeTargetURL(raw)
-		if err != nil {
-			return fmt.Errorf("invalid stream host %q: %w", raw, err)
-		}
-		playbackHostsSet[redirectHostKey(parsed)] = true
-		if playbackTarget == nil {
-			playbackTarget = parsed
-		}
+	playbackTarget, playbackHostsSet, err := resolvePlaybackConfiguration(site.PlaybackTargetURL, site.StreamHosts)
+	if err != nil {
+		return err
 	}
 
 	policy, err := resolveUAHeaderPolicy(site)
 	if err != nil {
 		return fmt.Errorf("invalid UA profile: %w", err)
 	}
-	inst := &ProxyInstance{Site: site, startedAt: time.Now()}
+	configuredHeaders, err := resolveUpstreamHeaderPolicy(site.StoredUpstreamHeaders, pm.upstreamHeaderKey, target)
+	if err != nil {
+		return fmt.Errorf("invalid upstream headers: %w", err)
+	}
+	instanceCtx, instanceCancel := context.WithCancel(context.Background())
+	inst := &ProxyInstance{
+		Site:           site,
+		startedAt:      time.Now(),
+		ctx:            instanceCtx,
+		cancel:         instanceCancel,
+		hijackedConns:  make(map[net.Conn]struct{}),
+		trustedProxies: append([]*net.IPNet(nil), pm.trustedProxies...),
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			instanceCancel()
+		}
+	}()
 	inst.persistedTraffic.Store(site.TrafficUsed)
 
 	isRedirectMode := playbackTarget != nil && site.PlaybackMode == "redirect"
@@ -1858,6 +2879,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 	proxyTransport.TLSClientConfig = secureTLSConfig("")
 	proxyTransport.ResponseHeaderTimeout = 30 * time.Second
 	proxyTransport.MaxIdleConnsPerHost = 32
+	inst.transport = proxyTransport
 
 	proxy := &httputil.ReverseProxy{
 		Transport: proxyTransport,
@@ -1870,7 +2892,19 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			}
 			applyUpstreamURL(proxyReq.Out.URL, upstream)
 			proxyReq.Out.Host = upstream.Host
-			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, policy)
+			prepareUpstreamHeaders(proxyReq.Out.Header, proxyReq.In, policy, inst.trustedProxies)
+			if !sameRedirectAuthority(target, upstream) {
+				// Direct playback can target a separate CDN. Treat that authority like
+				// a cross-origin redirect and rebuild from a narrow allowlist so client
+				// cookies, bearer tokens, and arbitrary secret headers cannot follow it.
+				proxyReq.Out.Header = crossAuthorityRedirectHeaders(proxyReq.Out.Header)
+			}
+			applySiteForwardedHost(proxyReq.Out.Header, proxyReq.In, site)
+			configuredHeaders.apply(proxyReq.Out.Header, upstream)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			stripPanelSessionSetCookies(resp.Header)
+			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			log.Printf("[%s] proxy error: %v", site.Name, err)
@@ -1882,9 +2916,10 @@ func (pm *ProxyManager) StartSite(site Site) error {
 
 	if isRedirectMode {
 		proxy.Transport = &redirectFollowTransport{
-			base:          proxyTransport,
-			playbackHosts: playbackHostsSet,
-			policy:        policy,
+			base:                 proxyTransport,
+			playbackHosts:        playbackHostsSet,
+			policy:               policy,
+			upstreamHeaderPolicy: configuredHeaders,
 		}
 	}
 
@@ -1892,7 +2927,28 @@ func (pm *ProxyManager) StartSite(site Site) error {
 	speedLimitBytes := int64(site.SpeedLimit) * 125000 // Mbps -> bytes/sec
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !inst.beginRequest() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"site is stopping"}`))
+			return
+		}
+		defer inst.endRequest()
+		requestCtx, requestCancel := context.WithCancel(r.Context())
+		stopInstanceCancel := context.AfterFunc(inst.ctx, requestCancel)
+		defer func() {
+			stopInstanceCancel()
+			requestCancel()
+		}()
+		r = r.WithContext(requestCtx)
 		inst.reqCount.Add(1)
+		if isReservedDynamicRoute(r.URL.Path) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "no-store")
+			w.WriteHeader(http.StatusGone)
+			_, _ = w.Write([]byte(`{"error":"dynamic route is no longer valid"}`))
+			return
+		}
 
 		if site.TrafficQuota > 0 {
 			currentUsed := inst.persistedTraffic.Load() + inst.bytesIn.Load() + inst.bytesOut.Load()
@@ -1904,12 +2960,18 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			}
 		}
 
-		if isWebSocketUpgrade(r) {
+		if hasUpgradeIntent(r) {
+			if !isWebSocketUpgrade(r) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"invalid websocket upgrade"}`))
+				return
+			}
 			wsTarget := upstreamTargetForRequest(r, target, playbackTarget)
 			if isRedirectMode {
 				wsTarget = target
 			}
-			handleWebSocket(w, r, wsTarget, policy, inst, speedLimitBytes)
+			handleWebSocket(w, r, wsTarget, target, policy, inst, speedLimitBytes, configuredHeaders)
 			return
 		}
 
@@ -1931,56 +2993,92 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		proxy.ServeHTTP(rw, r) // #nosec G704 -- forwarding to the administrator-configured, validated upstream is the product's purpose.
 	})
 
-	listenAddr := fmt.Sprintf(":%d", site.ListenPort)
-	listener, err := net.Listen("tcp", listenAddr)
-	if err != nil {
-		return fmt.Errorf("listen %s: %w", listenAddr, err)
+	inst.handler = handler
+	var listener net.Listener
+	var server *http.Server
+	if ingressUsesPort(site.IngressMode) {
+		listenAddr := fmt.Sprintf(":%d", site.ListenPort)
+		listener, err = net.Listen("tcp", listenAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", listenAddr, err)
+		}
+		listener = limitListener(listener, 2048)
+		server = &http.Server{
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       0,
+			WriteTimeout:      0,
+			IdleTimeout:       120 * time.Second,
+			MaxHeaderBytes:    64 << 10,
+		}
+		inst.server = server
+		inst.listener = listener
 	}
-	listener = limitListener(listener, 2048)
-
-	server := &http.Server{
-		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       0,
-		WriteTimeout:      0,
-		IdleTimeout:       120 * time.Second,
-		MaxHeaderBytes:    64 << 10,
+	closeNewListener := func() {
+		if listener != nil {
+			_ = listener.Close()
+		}
 	}
-
-	inst.server = server
-	inst.listener = listener
 
 	pm.mu.Lock()
-	if existing, ok := pm.proxies[site.ID]; ok {
-		// Flush before dropping the instance, the way StopSite does. This branch is
-		// reached when a running site's listen_port changes, which is the one
-		// update path handleSiteByID does not pre-stop, so without this everything
-		// counted since the last 60s tick vanishes from traffic_logs and
-		// sites.traffic_used.
-		if err := pm.flushProxyTraffic(existing); err != nil {
-			// Fail closed: keep the old instance and its pending bytes, release
-			// the new instance's freshly bound listener, and leave the proxies
-			// map untouched. The Serve goroutine below never starts, so closing
-			// the raw listener is enough.
+	if ingressUsesHost(site.IngressMode) {
+		if assignedID, ok := pm.publicHosts[site.PublicHost]; ok && assignedID != site.ID {
 			pm.mu.Unlock()
-			_ = listener.Close()
+			closeNewListener()
+			return fmt.Errorf("public_host %s is already assigned to another site", site.PublicHost)
+		}
+	}
+	existing := pm.proxies[site.ID]
+	pm.mu.Unlock()
+	if existing != nil {
+		// Verify persistence before stopping the old instance. lifecycleMu pins the
+		// selected instance while trafficMu serializes this flush, so the global
+		// routing lock need not be held across a potentially slow SQLite write.
+		if err := pm.flushProxyTraffic(existing); err != nil {
+			closeNewListener()
 			return fmt.Errorf("flush traffic of the instance being replaced: %w", err)
 		}
-		// That flush moved bytes into the row `site` was read from, so carry the
-		// authoritative total forward instead of the snapshot taken before it.
+	}
+
+	if existing != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		shutdownErr := existing.shutdown(shutdownCtx)
+		shutdownCancel()
+		if shutdownErr != nil {
+			closeNewListener()
+			return fmt.Errorf("drain the instance being replaced: %w", shutdownErr)
+		}
+		// Account for bytes produced after the pre-stop flush. If this fails, keep
+		// the closed instance in the map with its counters so a retry can persist
+		// them rather than silently orphaning traffic.
+		if err := pm.flushProxyTraffic(existing); err != nil {
+			closeNewListener()
+			return fmt.Errorf("final traffic flush of the instance being replaced: %w", err)
+		}
 		if flushed := existing.Site.TrafficUsed; flushed > inst.persistedTraffic.Load() {
 			inst.persistedTraffic.Store(flushed)
+			inst.Site.TrafficUsed = flushed
 		}
-		if existing.server != nil {
-			existing.server.Close()
-		}
-		delete(pm.proxies, site.ID)
+	}
+
+	pm.mu.Lock()
+	if err := pm.registerSiteHostLocked(site); err != nil {
+		pm.mu.Unlock()
+		closeNewListener()
+		return err
 	}
 	pm.proxies[site.ID] = inst
 	pm.mu.Unlock()
+	installed = true
 
+	upstreamLogTarget := redactUpstreamURL(target)
+	if server == nil {
+		log.Printf("[%s] shared-host proxy %s -> %s (UA: %s)", site.Name, site.PublicHost, upstreamLogTarget, site.UAMode)
+		return nil
+	}
+	inst.portServing.Store(true)
 	go func() {
-		upstreamLogTarget := redactUpstreamURL(target)
+		defer inst.portServing.Store(false)
 		if len(playbackHostsSet) > 0 {
 			hosts := make([]string, 0, len(playbackHostsSet))
 			for h := range playbackHostsSet {
@@ -1990,8 +3088,17 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		} else {
 			log.Printf("[%s] proxy :%d -> %s (UA: %s)", site.Name, site.ListenPort, upstreamLogTarget, site.UAMode)
 		}
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			log.Printf("[%s] server error: %v", site.Name, err)
+		err := server.Serve(listener)
+		if inst.isAccepting() {
+			// A Serve loop that disappears while the lifecycle gate is still open
+			// makes a port-only site unavailable even though its instance remains in
+			// the map. Record that state for API/runtime diagnostics.
+			inst.portServeFailed.Store(true)
+			if err != nil && err != http.ErrServerClosed {
+				log.Printf("[%s] server error: %v", site.Name, err)
+			} else {
+				log.Printf("[%s] server stopped unexpectedly", site.Name)
+			}
 		}
 	}()
 
@@ -1999,30 +3106,48 @@ func (pm *ProxyManager) StartSite(site Site) error {
 }
 
 func (pm *ProxyManager) StopSite(id int64) error {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
+	pm.lifecycleMu.Lock()
+	defer pm.lifecycleMu.Unlock()
+	pm.mu.RLock()
 	inst, ok := pm.proxies[id]
+	pm.mu.RUnlock()
 	if !ok {
 		return nil
 	}
-	// Flush before dropping the instance so pending bytes reach the DB. If the
-	// flush fails the instance stays running with its pending bytes intact and
-	// the caller must abort (or retry) so instance and DB remain consistent.
+	// Check persistence before closing any listener or request context. A DB
+	// failure therefore leaves a fully usable instance that can be retried.
+	// lifecycleMu pins inst, and trafficMu protects its counters without blocking
+	// shared-host routing on pm.mu.
+	ingressAlreadyClosed := !inst.isAccepting()
 	if err := pm.flushProxyTraffic(inst); err != nil {
+		if ingressAlreadyClosed {
+			return &siteIngressClosedError{siteID: id, flushErr: err}
+		}
 		return err
 	}
-	if inst.server != nil {
-		inst.server.Close()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	shutdownErr := inst.shutdown(shutdownCtx)
+	shutdownCancel()
+	finalFlushErr := pm.flushProxyTraffic(inst)
+	if shutdownErr != nil || finalFlushErr != nil {
+		// Keep the stopped instance and its pending counters addressable so a
+		// subsequent StopSite/GracefulShutdown can retry the final persistence.
+		return &siteIngressClosedError{siteID: id, drainErr: shutdownErr, flushErr: finalFlushErr}
 	}
-	delete(pm.proxies, id)
+	pm.mu.Lock()
+	if pm.proxies[id] == inst {
+		delete(pm.proxies, id)
+	}
+	pm.mu.Unlock()
 	return nil
 }
 
 func (pm *ProxyManager) IsRunning(id int64) bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	_, ok := pm.proxies[id]
-	return ok
+	inst, ok := pm.proxies[id]
+	return ok && inst.isOperational()
 }
 
 func (pm *ProxyManager) StartAllEnabled() (int, error) {
@@ -2030,9 +3155,17 @@ func (pm *ProxyManager) StartAllEnabled() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	for _, site := range sites {
+		if err := pm.RegisterSiteHost(site); err != nil {
+			return 0, err
+		}
+	}
 	for _, s := range sites {
 		if s.Enabled {
 			if err := pm.StartSite(s); err != nil {
+				if errors.Is(err, errUnsafeHostOnlyIngress) {
+					return len(sites), fmt.Errorf("site %q: %w", s.Name, err)
+				}
 				log.Printf("[%s] failed to start: %v", s.Name, err)
 			}
 		}
@@ -2045,8 +3178,12 @@ func (pm *ProxyManager) StartAllEnabled() (int, error) {
 // counters and is logged here, so the next tick retries the same bytes.
 func (pm *ProxyManager) FlushTraffic() {
 	pm.mu.RLock()
-	defer pm.mu.RUnlock()
+	instances := make([]*ProxyInstance, 0, len(pm.proxies))
 	for _, inst := range pm.proxies {
+		instances = append(instances, inst)
+	}
+	pm.mu.RUnlock()
+	for _, inst := range instances {
 		if err := pm.flushProxyTraffic(inst); err != nil {
 			log.Printf("[%s] failed to flush traffic: %v", inst.Site.Name, err)
 		}
@@ -2054,10 +3191,10 @@ func (pm *ProxyManager) FlushTraffic() {
 }
 
 // flushProxyTraffic persists inst's pending bytes into the DB and moves them
-// into the persisted baseline. The caller must hold pm.mu (read or write);
-// inst.trafficMu is acquired here. On failure the pending counters are fully
-// restored so the next flush retries the same bytes. Never call this from
-// code that already holds inst.trafficMu (no nested re-entry).
+// into the persisted baseline. The caller must pin inst through lifecycleMu, a
+// pm.mu snapshot, or another stable reference; inst.trafficMu is acquired here.
+// On failure the pending counters are fully restored so the next flush retries
+// the same bytes. Never call this while already holding inst.trafficMu.
 func (pm *ProxyManager) flushProxyTraffic(inst *ProxyInstance) error {
 	inst.trafficMu.Lock()
 	defer inst.trafficMu.Unlock()
@@ -2156,8 +3293,8 @@ func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistor
 	}
 
 	pm.mu.RLock()
-	inst, running := pm.proxies[site.ID]
-	if !running {
+	inst, present := pm.proxies[site.ID]
+	if !present {
 		pm.mu.RUnlock()
 		logs, err := pm.database.GetTrafficLogs(site.ID, hours)
 		if err != nil {
@@ -2175,7 +3312,7 @@ func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistor
 	if err != nil {
 		return nil, err
 	}
-	snap.Running = true
+	snap.Running = inst.isOperational()
 	snap.PersistedTraffic = inst.persistedTraffic.Load()
 	snap.BytesIn = inst.bytesIn.Load()
 	snap.BytesOut = inst.bytesOut.Load()
@@ -2194,7 +3331,7 @@ func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistor
 func (pm *ProxyManager) overlaySiteTrafficLocked(s Site, st *SiteTraffic) {
 	if inst, ok := pm.proxies[s.ID]; ok {
 		inst.trafficMu.Lock()
-		st.Running = true
+		st.Running = inst.isOperational()
 		st.PersistedTraffic = inst.persistedTraffic.Load()
 		st.BytesIn = inst.bytesIn.Load()
 		st.BytesOut = inst.bytesOut.Load()
@@ -2241,7 +3378,11 @@ func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
 	}
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	snap.RunningSites = len(pm.proxies)
+	for _, inst := range pm.proxies {
+		if inst.isOperational() {
+			snap.RunningSites++
+		}
+	}
 	for _, s := range sites {
 		st := SiteTraffic{
 			ID:               s.ID,
@@ -2265,28 +3406,85 @@ func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
 func (pm *ProxyManager) GetRunningCount() int {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
-	return len(pm.proxies)
+	running := 0
+	for _, inst := range pm.proxies {
+		if inst.isOperational() {
+			running++
+		}
+	}
+	return running
 }
 
-func (pm *ProxyManager) GetSiteRuntime(id int64) (requests int64, startedAt time.Time, running bool) {
+func (pm *ProxyManager) GetSiteRuntime(id int64) (requests int64, startedAt time.Time, running, portListening bool) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	inst, ok := pm.proxies[id]
 	if !ok {
-		return 0, time.Time{}, false
+		return 0, time.Time{}, false, false
 	}
-	return inst.reqCount.Load(), inst.startedAt, true
+	return inst.reqCount.Load(), inst.startedAt, inst.isOperational(), inst.portServing.Load()
 }
 
 // GracefulShutdown stops all proxies gracefully
 func (pm *ProxyManager) GracefulShutdown(ctx context.Context) {
-	pm.FlushTraffic()
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
+	pm.lifecycleMu.Lock()
+	defer pm.lifecycleMu.Unlock()
+	pm.shutdownStarted.Store(true)
+	pm.mu.RLock()
+	instances := make(map[int64]*ProxyInstance, len(pm.proxies))
 	for id, inst := range pm.proxies {
+		instances[id] = inst
+	}
+	pm.mu.RUnlock()
+
+	type shutdownResult struct {
+		id   int64
+		inst *ProxyInstance
+		err  error
+	}
+	results := make(chan shutdownResult, len(instances))
+	for id, inst := range instances {
 		log.Printf("[%s] shutting down...", inst.Site.Name)
-		inst.server.Shutdown(ctx)
-		delete(pm.proxies, id)
+		go func(id int64, inst *ProxyInstance) {
+			// shutdown closes the request gate and every listener/connection before
+			// waiting, so launching all instances in parallel stops every ingress
+			// promptly instead of spending the shared deadline site by site.
+			results <- shutdownResult{id: id, inst: inst, err: inst.shutdown(ctx)}
+		}(id, inst)
+	}
+
+	// Capture an early best-effort checkpoint after all shutdowns have started.
+	// The final pass below always runs, even when one or more drains time out.
+	for _, inst := range instances {
+		if err := pm.flushProxyTraffic(inst); err != nil {
+			log.Printf("[%s] pre-shutdown traffic flush failed: %v", inst.Site.Name, err)
+		}
+	}
+
+	drainErrors := make(map[int64]error, len(instances))
+	for range instances {
+		result := <-results
+		drainErrors[result.id] = result.err
+		if result.err != nil {
+			log.Printf("[%s] shutdown drain failed: %v", result.inst.Site.Name, result.err)
+		}
+	}
+
+	for id, inst := range instances {
+		if err := pm.flushProxyTraffic(inst); err != nil {
+			log.Printf("[%s] final shutdown traffic flush failed: %v", inst.Site.Name, err)
+			continue
+		}
+		if drainErrors[id] != nil {
+			// Keep a timed-out instance addressable: a caller that does not exit the
+			// process may retry and persist counters produced by a late request.
+			continue
+		}
+		pm.mu.Lock()
+		if pm.proxies[id] == inst {
+			delete(pm.proxies, id)
+		}
+		pm.mu.Unlock()
 	}
 }
 
@@ -2351,10 +3549,13 @@ type DiagHeaders struct {
 }
 
 type DiagProxy struct {
-	Running    bool   `json:"running"`
-	ListenPort int    `json:"listen_port"`
-	TotalReqs  int64  `json:"total_requests"`
-	Uptime     string `json:"uptime,omitempty"`
+	Running       bool   `json:"running"`
+	IngressMode   string `json:"ingress_mode"`
+	PublicHost    string `json:"public_host,omitempty"`
+	PortListening bool   `json:"port_listening"`
+	ListenPort    int    `json:"listen_port"`
+	TotalReqs     int64  `json:"total_requests"`
+	Uptime        string `json:"uptime,omitempty"`
 }
 
 func tlsIssuerName(cert *x509.Certificate) string {
@@ -2729,7 +3930,11 @@ func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
 	primary.ShowHealth = true
 	primary.ShowTLS = primary.TLS.Enabled
 
-	playbackRaw := strings.TrimSpace(site.PlaybackTargetURL)
+	playbackTarget, _, playbackConfigErr := resolvePlaybackConfiguration(site.PlaybackTargetURL, site.StreamHosts)
+	playbackRaw := ""
+	if playbackTarget != nil {
+		playbackRaw = playbackTarget.String()
+	}
 	playback := primary
 	playback.ConfiguredURL = ""
 	playback.Configured = false
@@ -2738,7 +3943,15 @@ func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
 	playback.ShowHealth = false
 	playback.ShowTLS = false
 
-	if playbackRaw != "" {
+	if playbackConfigErr != nil {
+		playback = DiagUpstream{
+			Configured:    true,
+			UsingFallback: false,
+			SameAsPrimary: false,
+			ShowHealth:    true,
+			Health:        DiagHealth{Status: "offline", Error: playbackConfigErr.Error()},
+		}
+	} else if playbackRaw != "" {
 		var playbackKey string
 		playback, playbackKey = diagnoseUpstreamTarget(playbackRaw, "playback_path")
 		playback.Configured = true
@@ -2784,7 +3997,7 @@ func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
 	}
 
 	// Proxy status
-	totalRequests, startedAt, running := pm.GetSiteRuntime(site.ID)
+	totalRequests, startedAt, running, portListening := pm.GetSiteRuntime(site.ID)
 	uptime := ""
 	if running && !startedAt.IsZero() {
 		duration := time.Since(startedAt).Round(time.Second)
@@ -2794,28 +4007,99 @@ func diagnoseSite(site *Site, pm *ProxyManager) DiagResult {
 		uptime = duration.String()
 	}
 	result.Proxy = DiagProxy{
-		Running:    running,
-		ListenPort: site.ListenPort,
-		TotalReqs:  totalRequests,
-		Uptime:     uptime,
+		Running:       running,
+		IngressMode:   site.IngressMode,
+		PublicHost:    site.PublicHost,
+		PortListening: portListening,
+		ListenPort:    site.ListenPort,
+		TotalReqs:     totalRequests,
+		Uptime:        uptime,
 	}
 
 	return result
 }
 
 type App struct {
-	db               *DB
-	pm               *ProxyManager
-	siteLifecycleMu  sync.Mutex
-	setupTokenMu     sync.Mutex
-	setupToken       string
-	loginLimiter     *loginRateLimiter
-	loginLimiterOnce sync.Once
-	trustedProxies   []*net.IPNet
+	db                *DB
+	pm                *ProxyManager
+	siteLifecycleMu   sync.Mutex
+	setupTokenMu      sync.Mutex
+	setupToken        string
+	loginLimiter      *loginRateLimiter
+	loginLimiterOnce  sync.Once
+	trustedProxies    []*net.IPNet
+	panelHost         string
+	panelBindLoopback bool
+}
+
+func isLoopbackHealthProbe(r *http.Request) bool {
+	if r == nil || r.Method != http.MethodGet || r.URL.Path != "/api/auth/check" {
+		return false
+	}
+	for name := range r.Header {
+		// A real local health probe arrives directly. If an edge proxy supplied
+		// client-forwarding identity, a loopback transport peer alone must not
+		// bypass strict PANEL_DOMAIN routing.
+		if isManagedForwardingHeaderName(name) {
+			return false
+		}
+	}
+	peerIP := remoteAddressIP(r.RemoteAddr)
+	if peerIP == nil || !peerIP.IsLoopback() {
+		return false
+	}
+	host := strings.TrimSpace(r.Host)
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	} else if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	} else if strings.Count(host, ":") > 1 {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	hostIP := net.ParseIP(host)
+	return hostIP != nil && hostIP.IsLoopback()
+}
+
+func (a *App) publicHostRouter(panel http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := requestPublicHost(r.Host)
+		if host != "" {
+			handler, configured, mode := a.pm.PublicHostRoute(host)
+			if configured {
+				if mode == ingressModeHost && !a.panelBindLoopback && !isTrustedProxy(remoteAddressIP(r.RemoteAddr), a.trustedProxies) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"error":"host-only ingress requires a configured proxy source"}`))
+					return
+				}
+				if handler == nil {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					_, _ = w.Write([]byte(`{"error":"site unavailable"}`))
+					return
+				}
+				r = r.WithContext(context.WithValue(r.Context(), publicHostIngressContextKey{}, true))
+				handler.ServeHTTP(w, r)
+				return
+			}
+		}
+		if a.panelHost == "" || host == a.panelHost || isLoopbackHealthProbe(r) {
+			panel.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		_, _ = w.Write([]byte(`{"error":"unrecognized host"}`))
+	})
 }
 
 const (
-	maxJSONBodyBytes = 64 << 10
+	// 128 playback URLs at the per-entry limit plus site metadata fit below
+	// this ceiling. Individual fields and list counts remain separately bounded.
+	maxJSONBodyBytes = 512 << 10
 	// speedLimitBytes multiplies this field by 125000, so an unbounded value
 	// wraps int64 and silently disables the limit instead of tightening it.
 	// 1000000 matches the max the site form already enforces.
@@ -2972,11 +4256,12 @@ func isTrustedProxy(ip net.IP, networks []*net.IPNet) bool {
 func requestClientKey(r *http.Request, trustedProxies []*net.IPNet) string {
 	peerIP := remoteAddressIP(r.RemoteAddr)
 	if isTrustedProxy(peerIP, trustedProxies) {
-		if forwarded := net.ParseIP(strings.TrimSpace(r.Header.Get("X-Real-IP"))); forwarded != nil {
-			return forwarded.String()
-		}
-		for _, raw := range strings.Split(r.Header.Get("X-Forwarded-For"), ",") {
-			if forwarded := net.ParseIP(strings.TrimSpace(raw)); forwarded != nil {
+		// The trusted edge must normalize the client address into a single
+		// X-Real-IP value. Never select from X-Forwarded-For: common
+		// $proxy_add_x_forwarded_for configurations retain attacker-supplied
+		// left-most values and would let clients rotate the login limiter key.
+		if value, ok := singleForwardedHeaderValue(r.Header, "X-Real-IP"); ok {
+			if forwarded := net.ParseIP(value); forwarded != nil {
 				return forwarded.String()
 			}
 		}
@@ -3074,6 +4359,20 @@ func securityHeaders(next http.Handler) http.Handler {
 	})
 }
 
+func panelBodyReadDeadline(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil && (r.ContentLength != 0 || len(r.TransferEncoding) > 0) {
+			controller := http.NewResponseController(w)
+			// Keep the deadline through net/http's post-handler request-body drain.
+			// Clearing it when the handler returns lets a slow client keep dripping an
+			// unread body indefinitely. The server installs the next request/idle
+			// deadline before reusing a healthy keep-alive connection.
+			_ = controller.SetReadDeadline(time.Now().Add(30 * time.Second))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func staticHandler(staticFS fs.FS) http.Handler {
 	fileServer := http.FileServer(http.FS(staticFS))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3118,8 +4417,8 @@ func requestIsHTTPS(r *http.Request, trustedProxies []*net.IPNet) bool {
 	if !isTrustedProxy(remoteAddressIP(r.RemoteAddr), trustedProxies) {
 		return false
 	}
-	forwardedProto := strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0]
-	return strings.EqualFold(strings.TrimSpace(forwardedProto), "https")
+	forwardedProto, ok := singleForwardedHeaderValue(r.Header, "X-Forwarded-Proto")
+	return ok && strings.EqualFold(forwardedProto, "https")
 }
 
 func (a *App) setSessionCookie(w http.ResponseWriter, r *http.Request, token string) {
@@ -3152,11 +4451,20 @@ func (a *App) clearSessionCookie(w http.ResponseWriter, r *http.Request) {
 }
 
 func sessionIdentity(r *http.Request) (int64, string, error) {
-	cookie, err := r.Cookie(sessionCookieName)
-	if err != nil || cookie.Value == "" {
-		return 0, "", errors.New("missing session")
+	for _, cookie := range r.Cookies() {
+		if cookie.Name != sessionCookieName || cookie.Value == "" {
+			continue
+		}
+		userID, username, err := validateToken(cookie.Value)
+		if err == nil {
+			// Accept the signed management value even if an untrusted sibling
+			// origin managed to prepend an invalid same-name cookie. The attacker
+			// cannot forge a second valid token, so this avoids cookie-shadowing
+			// logout/DoS without weakening authentication.
+			return userID, username, nil
+		}
 	}
-	return validateToken(cookie.Value)
+	return 0, "", errors.New("missing or invalid session")
 }
 
 func (a *App) csrfMiddleware(next http.HandlerFunc) http.HandlerFunc {
@@ -3347,6 +4655,22 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	a.jsonOK(w, snap)
 }
 
+// GET /api/ingress-capabilities exposes only coarse deployment state so the
+// site form can avoid proposing host-only mode when the backend must reject it.
+func (a *App) handleIngressCapabilities(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	a.jsonOK(w, map[string]interface{}{
+		"host_only_available":        a.pm.HostOnlyIngressSafe(),
+		"panel_bind_loopback":        a.panelBindLoopback,
+		"trusted_proxy_configured":   len(a.trustedProxies) > 0,
+		"upstream_headers_available": a.pm.UpstreamHeadersAvailable(),
+		"max_playback_addresses":     maxPlaybackAddresses,
+	})
+}
+
 // GET/POST /api/sites
 func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -3376,18 +4700,21 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 
 	case "POST":
 		var req struct {
-			Name              string   `json:"name"`
-			ListenPort        int      `json:"listen_port"`
-			TargetURL         string   `json:"target_url"`
-			PlaybackTargetURL string   `json:"playback_target_url"`
-			PlaybackMode      string   `json:"playback_mode"`
-			StreamHosts       []string `json:"stream_hosts"`
-			UAMode            string   `json:"ua_mode"`
-			CustomUserAgent   string   `json:"custom_user_agent"`
-			CustomClient      string   `json:"custom_client"`
-			CustomVersion     string   `json:"custom_version"`
-			Quota             int64    `json:"traffic_quota"`
-			SpeedLimit        int      `json:"speed_limit"`
+			Name              string                `json:"name"`
+			ListenPort        int                   `json:"listen_port"`
+			PublicHost        string                `json:"public_host"`
+			IngressMode       string                `json:"ingress_mode"`
+			TargetURL         string                `json:"target_url"`
+			PlaybackTargetURL string                `json:"playback_target_url"`
+			PlaybackMode      string                `json:"playback_mode"`
+			StreamHosts       []string              `json:"stream_hosts"`
+			UAMode            string                `json:"ua_mode"`
+			CustomUserAgent   string                `json:"custom_user_agent"`
+			CustomClient      string                `json:"custom_client"`
+			CustomVersion     string                `json:"custom_version"`
+			UpstreamHeaders   []UpstreamHeaderInput `json:"upstream_headers"`
+			Quota             int64                 `json:"traffic_quota"`
+			SpeedLimit        int                   `json:"speed_limit"`
 		}
 		if err := decodeJSONBody(w, r, &req); err != nil {
 			a.jsonErr(w, 400, "invalid request")
@@ -3405,6 +4732,25 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 		}
 		req.Name = strings.TrimSpace(req.Name)
 		req.PlaybackMode = strings.ToLower(strings.TrimSpace(req.PlaybackMode))
+		publicHost, err := normalizePublicHost(req.PublicHost)
+		if err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if publicHost != "" && publicHost == a.panelHost {
+			a.jsonErr(w, http.StatusBadRequest, "public_host must differ from PANEL_DOMAIN")
+			return
+		}
+		req.PublicHost = publicHost
+		req.IngressMode, err = normalizeIngressMode(req.IngressMode, req.PublicHost)
+		if err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := a.pm.validateIngressSafety(req.IngressMode); err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		normalizedMode, customUserAgent, customClient, customVersion, err := normalizeUAConfig(req.UAMode, req.CustomUserAgent, req.CustomClient, req.CustomVersion)
 		if err != nil {
 			a.jsonErr(w, http.StatusBadRequest, err.Error())
@@ -3422,24 +4768,43 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 		if req.StreamHosts == nil {
 			streamHostsJSON = []byte("[]")
 		}
+		storedHeaders, err := mergeUpstreamHeaders("[]", req.UpstreamHeaders, a.pm.upstreamHeaderKey, req.TargetURL)
+		if err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
+		if req.PublicHost != "" {
+			if _, exists := a.pm.PublicHostSiteID(req.PublicHost); exists {
+				a.jsonErr(w, http.StatusBadRequest, "public_host is already assigned to another site")
+				return
+			}
+		}
 		site, err := a.db.CreateSiteRecord(Site{
-			Name:              req.Name,
-			ListenPort:        req.ListenPort,
-			TargetURL:         req.TargetURL,
-			PlaybackTargetURL: req.PlaybackTargetURL,
-			PlaybackMode:      req.PlaybackMode,
-			StreamHosts:       string(streamHostsJSON),
-			UAMode:            req.UAMode,
-			CustomUserAgent:   req.CustomUserAgent,
-			CustomClient:      req.CustomClient,
-			CustomVersion:     req.CustomVersion,
-			TrafficQuota:      req.Quota,
-			SpeedLimit:        req.SpeedLimit,
+			Name:                  req.Name,
+			ListenPort:            req.ListenPort,
+			PublicHost:            req.PublicHost,
+			IngressMode:           req.IngressMode,
+			TargetURL:             req.TargetURL,
+			PlaybackTargetURL:     req.PlaybackTargetURL,
+			PlaybackMode:          req.PlaybackMode,
+			StreamHosts:           string(streamHostsJSON),
+			UAMode:                req.UAMode,
+			CustomUserAgent:       req.CustomUserAgent,
+			CustomClient:          req.CustomClient,
+			CustomVersion:         req.CustomVersion,
+			StoredUpstreamHeaders: storedHeaders,
+			TrafficQuota:          req.Quota,
+			SpeedLimit:            req.SpeedLimit,
 		})
 		if err != nil {
-			a.jsonErr(w, 500, err.Error())
+			if isSQLiteUniqueConstraintError(err) {
+				a.jsonErr(w, http.StatusBadRequest, "listen_port or public_host is already assigned")
+				return
+			}
+			log.Printf("create site record: %v", err)
+			a.jsonErr(w, http.StatusInternalServerError, "create site failed")
 			return
 		}
 		// Auto start
@@ -3449,6 +4814,7 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 					a.jsonErr(w, 500, fmt.Sprintf("start site: %v; rollback create: %v", err, deleteErr))
 					return
 				}
+				a.pm.UnregisterSiteHost(site.ID)
 				a.jsonErr(w, 500, err.Error())
 				return
 			}
@@ -3485,14 +4851,21 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if site.Enabled {
-			// Turning off: stop (and flush) before flipping the flag, so a failed
-			// flush aborts with the instance still running and the flag still on
-			// - instance and DB stay consistent.
-			if err := a.pm.StopSite(id); err != nil {
-				a.jsonErr(w, 500, err.Error())
+			// A pre-close failure leaves the running instance usable and aborts the
+			// toggle. A post-close failure is different: the listener is already gone,
+			// so persist disabled and surface cleanup_pending instead of leaving an
+			// enabled-but-offline row.
+			stopErr := a.pm.StopSite(id)
+			cleanupPending := isSiteIngressClosedError(stopErr)
+			if stopErr != nil && !cleanupPending {
+				a.jsonErr(w, http.StatusInternalServerError, stopErr.Error())
 				return
 			}
-			if _, err := a.db.ToggleSite(id); err != nil {
+			if err := a.db.SetSiteEnabled(id, false); err != nil {
+				if cleanupPending {
+					a.jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("%v; site ingress is closed but disabling the record failed: %v", stopErr, err))
+					return
+				}
 				// The instance is stopped but the flag stayed on: restart it so the
 				// DB and the running set stay consistent.
 				if restarted, getErr := a.db.GetSite(id); getErr == nil {
@@ -3504,17 +4877,21 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 				a.jsonErr(w, 500, fmt.Sprintf("toggle off: %v; site stopped but flag update failed", err))
 				return
 			}
-			a.jsonOK(w, map[string]interface{}{"enabled": false})
+			result := map[string]interface{}{"enabled": false, "cleanup_pending": cleanupPending}
+			if cleanupPending {
+				result["warning"] = stopErr.Error()
+			}
+			a.jsonOK(w, result)
 			return
 		}
 		// Turning on: flip the flag first so a failed start can roll it back.
-		if _, err := a.db.ToggleSite(id); err != nil {
+		if err := a.db.SetSiteEnabled(id, true); err != nil {
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
 		site, err = a.db.GetSite(id)
 		if err != nil {
-			if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
+			if revertErr := a.db.SetSiteEnabled(id, false); revertErr != nil {
 				a.jsonErr(w, 500, fmt.Sprintf("load site: %v; rollback toggle: %v", err, revertErr))
 				return
 			}
@@ -3522,7 +4899,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := a.pm.StartSite(*site); err != nil {
-			if _, revertErr := a.db.ToggleSite(id); revertErr != nil {
+			if revertErr := a.db.SetSiteEnabled(id, false); revertErr != nil {
 				a.jsonErr(w, 500, fmt.Sprintf("start site: %v; rollback toggle: %v", err, revertErr))
 				return
 			}
@@ -3549,18 +4926,21 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var req struct {
-			Name              string    `json:"name"`
-			ListenPort        int       `json:"listen_port"`
-			TargetURL         string    `json:"target_url"`
-			PlaybackTargetURL *string   `json:"playback_target_url"`
-			PlaybackMode      *string   `json:"playback_mode"`
-			StreamHosts       *[]string `json:"stream_hosts"`
-			UAMode            *string   `json:"ua_mode"`
-			CustomUserAgent   *string   `json:"custom_user_agent"`
-			CustomClient      *string   `json:"custom_client"`
-			CustomVersion     *string   `json:"custom_version"`
-			Quota             *int64    `json:"traffic_quota"`
-			SpeedLimit        *int      `json:"speed_limit"`
+			Name              string                 `json:"name"`
+			ListenPort        int                    `json:"listen_port"`
+			PublicHost        *string                `json:"public_host"`
+			IngressMode       *string                `json:"ingress_mode"`
+			TargetURL         string                 `json:"target_url"`
+			PlaybackTargetURL *string                `json:"playback_target_url"`
+			PlaybackMode      *string                `json:"playback_mode"`
+			StreamHosts       *[]string              `json:"stream_hosts"`
+			UAMode            *string                `json:"ua_mode"`
+			CustomUserAgent   *string                `json:"custom_user_agent"`
+			CustomClient      *string                `json:"custom_client"`
+			CustomVersion     *string                `json:"custom_version"`
+			UpstreamHeaders   *[]UpstreamHeaderInput `json:"upstream_headers"`
+			Quota             *int64                 `json:"traffic_quota"`
+			SpeedLimit        *int                   `json:"speed_limit"`
 		}
 		if err := decodeJSONBody(w, r, &req); err != nil {
 			a.jsonErr(w, 400, "invalid request")
@@ -3587,6 +4967,65 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		if req.Quota != nil {
 			quota = *req.Quota
 		}
+		publicHost := oldSite.PublicHost
+		if req.PublicHost != nil {
+			publicHost, err = normalizePublicHost(*req.PublicHost)
+			if err != nil {
+				a.jsonErr(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+		if publicHost != "" && publicHost == a.panelHost {
+			a.jsonErr(w, http.StatusBadRequest, "public_host must differ from PANEL_DOMAIN")
+			return
+		}
+		ingressMode := oldSite.IngressMode
+		if req.IngressMode != nil {
+			ingressMode = *req.IngressMode
+		} else if req.PublicHost != nil {
+			// Backward-compatible updates that know only public_host inherit the
+			// secure behavior: adding a host chooses host-only; removing it
+			// chooses the legacy dedicated-port entry.
+			if publicHost == "" {
+				ingressMode = ingressModePort
+			} else if oldSite.PublicHost == "" {
+				ingressMode = ingressModeHost
+			}
+		}
+		ingressMode, err = normalizeIngressMode(ingressMode, publicHost)
+		if err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := a.pm.validateIngressSafety(ingressMode); err != nil {
+			a.jsonErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		oldTarget, oldTargetErr := normalizeTargetURL(oldSite.TargetURL)
+		newTarget, newTargetErr := normalizeTargetURL(req.TargetURL)
+		if newTargetErr != nil {
+			a.jsonErr(w, http.StatusBadRequest, fmt.Sprintf("invalid target_url: %v", newTargetErr))
+			return
+		}
+		if oldTargetErr != nil {
+			a.jsonErr(w, http.StatusInternalServerError, "stored target_url is invalid")
+			return
+		}
+		storedHeaders := oldSite.StoredUpstreamHeaders
+		headerMergeBase := oldSite.StoredUpstreamHeaders
+		if !sameRedirectAuthority(oldTarget, newTarget) {
+			// Fixed upstream headers are origin secrets. Never carry ciphertext
+			// across an authority change, even when the client omits this field.
+			storedHeaders = "[]"
+			headerMergeBase = "[]"
+		}
+		if req.UpstreamHeaders != nil {
+			storedHeaders, err = mergeUpstreamHeaders(headerMergeBase, *req.UpstreamHeaders, a.pm.upstreamHeaderKey, req.TargetURL)
+			if err != nil {
+				a.jsonErr(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
 		uaMode, customUserAgent, customClient, customVersion, uaErr := mergeSiteUAConfig(*oldSite, req.UAMode, req.CustomUserAgent, req.CustomClient, req.CustomVersion)
 		if uaErr != nil {
 			a.jsonErr(w, http.StatusBadRequest, uaErr.Error())
@@ -3602,6 +5041,8 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		candidate := *oldSite
 		candidate.Name = req.Name
 		candidate.ListenPort = req.ListenPort
+		candidate.PublicHost = publicHost
+		candidate.IngressMode = ingressMode
 		candidate.TargetURL = req.TargetURL
 		candidate.PlaybackTargetURL = playbackTargetURL
 		candidate.PlaybackMode = playbackMode
@@ -3610,39 +5051,57 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		candidate.CustomUserAgent = customUserAgent
 		candidate.CustomClient = customClient
 		candidate.CustomVersion = customVersion
+		candidate.StoredUpstreamHeaders = storedHeaders
 		candidate.TrafficQuota = quota
 		candidate.SpeedLimit = speedLimit
 		if err := validateSiteSettings(candidate.Name, candidate.ListenPort, candidate.TargetURL, candidate.PlaybackTargetURL, candidate.PlaybackMode, streamHostList, candidate.UAMode, candidate.CustomUserAgent, candidate.CustomClient, candidate.CustomVersion, candidate.TrafficQuota, candidate.SpeedLimit); err != nil {
 			a.jsonErr(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		needsPreStop := oldSite.Enabled && oldSite.ListenPort == candidate.ListenPort && a.pm.IsRunning(id)
+		if candidate.PublicHost != "" {
+			if assignedID, exists := a.pm.PublicHostSiteID(candidate.PublicHost); exists && assignedID != candidate.ID {
+				a.jsonErr(w, http.StatusBadRequest, "public_host is already assigned to another site")
+				return
+			}
+		}
+		needsPreStop := oldSite.Enabled && ingressUsesPort(oldSite.IngressMode) && ingressUsesPort(candidate.IngressMode) && oldSite.ListenPort == candidate.ListenPort && a.pm.IsRunning(id)
 		if needsPreStop {
-			// Stop (and flush) before the DB update, so a failed flush aborts with
-			// the old config still in the DB and the old instance still running -
-			// instance and DB stay consistent.
-			if err := a.pm.StopSite(id); err != nil {
-				a.jsonErr(w, 500, err.Error())
+			// Stop before replacing a listener on the same port. A post-close drain
+			// or final-checkpoint failure cannot restore that listener, so fail closed
+			// by disabling the old record and let an operator retry cleanup/update.
+			if stopErr := a.pm.StopSite(id); stopErr != nil {
+				if isSiteIngressClosedError(stopErr) {
+					if disableErr := a.db.SetSiteEnabled(id, false); disableErr != nil {
+						a.jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("%v; old ingress is closed and disabling the record failed: %v", stopErr, disableErr))
+						return
+					}
+					a.jsonErr(w, http.StatusServiceUnavailable, fmt.Sprintf("update aborted; site disabled; cleanup pending: %v", stopErr))
+					return
+				}
+				a.jsonErr(w, http.StatusInternalServerError, stopErr.Error())
 				return
 			}
 		}
 		if err := a.db.UpdateSiteRecord(candidate); err != nil {
-			if needsPreStop {
-				// The instance is stopped; bring it back from a fresh read (which
-				// includes the flushed traffic) so the DB flag and the running set
-				// stay consistent. If even the reload fails, say so explicitly:
-				// the enabled row must never silently sit without an instance.
-				restored, getErr := a.db.GetSite(id)
-				if getErr != nil {
-					a.jsonErr(w, 500, fmt.Sprintf("update site: %v; site stopped and reload failed: %v", err, getErr))
-					return
-				}
+			// A pre-stop is the normal reason the old runtime is absent here, but
+			// recover from any enabled/non-operational state rather than keying the
+			// invariant to one specific replacement path.
+			restored, getErr := a.db.GetSite(id)
+			if getErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("update site: %v; reload current site: %v", err, getErr))
+				return
+			}
+			if restored.Enabled && !a.pm.IsRunning(id) {
 				if restartErr := a.pm.StartSite(*restored); restartErr != nil {
 					a.jsonErr(w, 500, fmt.Sprintf("update site: %v; restore instance: %v", err, restartErr))
 					return
 				}
 			}
-			a.jsonErr(w, 500, err.Error())
+			if isSQLiteUniqueConstraintError(err) {
+				a.jsonErr(w, http.StatusBadRequest, "listen_port or public_host is already assigned")
+				return
+			}
+			a.jsonErr(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		site, err := a.db.GetSite(id)
@@ -3661,7 +5120,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 				a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; reload rollback site: %v", err, getErr))
 				return
 			}
-			if needsPreStop {
+			if restoredSite.Enabled && !a.pm.IsRunning(id) {
 				if restartErr := a.pm.StartSite(*restoredSite); restartErr != nil {
 					a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; restored configuration is enabled but proxy is not running: %v", err, restartErr))
 					return
@@ -3681,7 +5140,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 					a.jsonErr(w, 500, fmt.Sprintf("start updated site: %v; reload rollback site: %v", err, getErr))
 					return
 				}
-				if needsPreStop {
+				if restoredSite.Enabled && !a.pm.IsRunning(id) {
 					if restartErr := a.pm.StartSite(*restoredSite); restartErr != nil {
 						a.jsonErr(w, 500, fmt.Sprintf("start updated site: %v; restored configuration is enabled but proxy is not running: %v", err, restartErr))
 						return
@@ -3690,16 +5149,31 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 				a.jsonErr(w, 500, err.Error())
 				return
 			}
+		} else if err := a.pm.RegisterSiteHost(*site); err != nil {
+			if rollbackErr := a.db.UpdateSiteRecord(*oldSite); rollbackErr != nil {
+				a.jsonErr(w, 500, fmt.Sprintf("register updated public host: %v; rollback update: %v", err, rollbackErr))
+				return
+			}
+			a.jsonErr(w, 500, err.Error())
+			return
 		}
 		a.jsonOK(w, site)
 
 	case action == "" && r.Method == "DELETE":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
-		// Only delete the DB row after the instance stopped cleanly (flush
-		// succeeded); a failed flush aborts with the instance and row intact.
-		if err := a.pm.StopSite(id); err != nil {
-			a.jsonErr(w, 500, err.Error())
+		// Only delete after a clean stop. If ingress already closed but drain or
+		// final persistence failed, retain a disabled row as the retry handle.
+		if stopErr := a.pm.StopSite(id); stopErr != nil {
+			if isSiteIngressClosedError(stopErr) {
+				if disableErr := a.db.SetSiteEnabled(id, false); disableErr != nil {
+					a.jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("%v; ingress is closed and disabling the record failed: %v", stopErr, disableErr))
+					return
+				}
+				a.jsonErr(w, http.StatusServiceUnavailable, fmt.Sprintf("delete deferred; site disabled; cleanup pending: %v", stopErr))
+				return
+			}
+			a.jsonErr(w, http.StatusInternalServerError, stopErr.Error())
 			return
 		}
 		if err := a.db.DeleteSite(id); err != nil {
@@ -3721,6 +5195,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			a.jsonErr(w, 500, err.Error())
 			return
 		}
+		a.pm.UnregisterSiteHost(id)
 		a.jsonOK(w, map[string]string{"status": "deleted"})
 
 	default:
@@ -3995,6 +5470,15 @@ func main() {
 			}
 		}
 	}
+	addr, err := panelListenAddress(os.Getenv("PANEL_BIND_ADDR"), port)
+	if err != nil {
+		log.Fatalf("invalid panel listen address: %v", err)
+	}
+	panelBindHost, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		log.Fatalf("invalid panel listen address: %v", err)
+	}
+	panelBindIP := net.ParseIP(panelBindHost)
 
 	db, err := openDB(dbPath)
 	if err != nil {
@@ -4010,7 +5494,17 @@ func main() {
 		log.Fatalf("initial setup unavailable: %v", err)
 	}
 
-	pm := NewProxyManager(db)
+	upstreamHeaderKey, err := resolveUpstreamHeaderKey(os.Getenv("UPSTREAM_HEADER_KEY"))
+	if err != nil {
+		log.Fatalf("invalid upstream header key: %v", err)
+	}
+	trustedProxies, err := parseTrustedProxyCIDRs(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	if err != nil {
+		log.Fatalf("invalid trusted proxy configuration: %v", err)
+	}
+	pm := NewProxyManager(db, upstreamHeaderKey)
+	pm.SetTrustedProxies(trustedProxies)
+	pm.SetHostOnlyIngressSafe((panelBindIP != nil && panelBindIP.IsLoopback()) || len(trustedProxies) > 0)
 	loadedSiteCount, err := pm.StartAllEnabled()
 	if err != nil {
 		log.Fatalf("failed to load sites: %v", err)
@@ -4033,16 +5527,23 @@ func main() {
 		}
 	}()
 
-	trustedProxies, err := parseTrustedProxyCIDRs(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	panelHost, err := normalizePublicHost(os.Getenv("PANEL_DOMAIN"))
 	if err != nil {
-		log.Fatalf("invalid trusted proxy configuration: %v", err)
+		log.Fatalf("invalid PANEL_DOMAIN: %v", err)
+	}
+	if panelHost != "" {
+		if _, configured := pm.PublicHostHandler(panelHost); configured {
+			log.Fatalf("PANEL_DOMAIN %s conflicts with a site's public_host", panelHost)
+		}
 	}
 	app := &App{
-		db:             db,
-		pm:             pm,
-		setupToken:     setupToken,
-		loginLimiter:   newLoginRateLimiter(),
-		trustedProxies: trustedProxies,
+		db:                db,
+		pm:                pm,
+		setupToken:        setupToken,
+		loginLimiter:      newLoginRateLimiter(),
+		trustedProxies:    trustedProxies,
+		panelHost:         panelHost,
+		panelBindLoopback: panelBindIP != nil && panelBindIP.IsLoopback(),
 	}
 
 	mux := http.NewServeMux()
@@ -4055,6 +5556,7 @@ func main() {
 
 	// Protected routes
 	mux.HandleFunc("/api/dashboard", cors(app.authMiddleware(app.handleDashboard)))
+	mux.HandleFunc("/api/ingress-capabilities", cors(app.authMiddleware(app.handleIngressCapabilities)))
 	mux.HandleFunc("/api/sites", cors(app.authMiddleware(app.handleSites)))
 	mux.HandleFunc("/api/sites/", cors(app.authMiddleware(app.handleSiteByID)))
 	mux.HandleFunc("/api/traffic/", cors(app.authMiddleware(app.handleTraffic)))
@@ -4073,18 +5575,17 @@ func main() {
 
 	// HTTP server with graceful shutdown. Site listeners remain independently
 	// bound by ProxyManager and are not affected by PANEL_BIND_ADDR.
-	addr, err := panelListenAddress(os.Getenv("PANEL_BIND_ADDR"), port)
-	if err != nil {
-		log.Fatalf("invalid panel listen address: %v", err)
-	}
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           securityHeaders(mux),
+		Handler:           app.publicHostRouter(panelBodyReadDeadline(securityHeaders(mux))),
 		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      0, // no write timeout for streaming
-		IdleTimeout:       120 * time.Second,
-		MaxHeaderBytes:    64 << 10,
+		// Shared-host site traffic can include long-running uploads. Header and
+		// per-endpoint body limits protect the panel without imposing a 30-second
+		// whole-request deadline on media traffic routed by Host.
+		ReadTimeout:    0,
+		WriteTimeout:   0, // no write timeout for streaming
+		IdleTimeout:    120 * time.Second,
+		MaxHeaderBytes: 64 << 10,
 	}
 
 	log.Println("============================================================")
@@ -4111,11 +5612,25 @@ func main() {
 	cancel()
 
 	// Shutdown proxies (flushes traffic)
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer shutdownCancel()
+	proxyShutdownCtx, proxyShutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	pm.GracefulShutdown(proxyShutdownCtx)
+	proxyShutdownCancel()
 
-	pm.GracefulShutdown(shutdownCtx)
-	srv.Shutdown(shutdownCtx)
+	// Give the management/shared-host server its own drain budget. A slow site
+	// shutdown must not hand an already-expired context to the panel server.
+	panelShutdownCtx, panelShutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	if err := srv.Shutdown(panelShutdownCtx); err != nil {
+		log.Printf("panel shutdown failed: %v", err)
+	}
+	panelShutdownCancel()
+
+	// A request that exceeded the first proxy drain budget may finish while the
+	// panel/shared listener is shutting down. Give retained instances one final
+	// bounded drain/checkpoint pass so those tail counters are not abandoned just
+	// before process exit, and retry any transient final SQLite write failure.
+	finalProxyCtx, finalProxyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	pm.GracefulShutdown(finalProxyCtx)
+	finalProxyCancel()
 
 	log.Println("Meridian stopped cleanly")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1064,7 +1064,7 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read embedded index HTML: %v", err)
 	}
-	for _, asset := range []string{"/css/style.css?v=1.6.1", "/js/pages/sites.js?v=1.6.1", "/js/app.js?v=1.6.1"} {
+	for _, asset := range []string{"/css/style.css?v=1.7.0", "/js/pages/sites.js?v=1.7.0", "/js/app.js?v=1.7.0"} {
 		if !strings.Contains(string(indexHTML), asset) {
 			t.Errorf("index must cache-bust updated asset %q", asset)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"database/sql"
 	"encoding/json"
@@ -40,10 +41,13 @@ func newTestApp(t *testing.T) *App {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	return &App{
-		db: db,
-		pm: NewProxyManager(db),
+	app := &App{
+		db:                db,
+		pm:                NewProxyManager(db, bytes.Repeat([]byte{0x42}, 32)),
+		panelBindLoopback: true,
 	}
+	app.pm.SetHostOnlyIngressSafe(true)
+	return app
 }
 
 // reservedPorts keeps ephemeral ports out of the kernel's free pool between
@@ -328,11 +332,34 @@ func TestHTTPPassthroughPreservesClientIdentityAndRebuildsForwarding(t *testing.
 	if got := header.Get("X-Forwarded-For"); got != "198.51.100.26" {
 		t.Fatalf("X-Forwarded-For = %q, want rebuilt from the peer address", got)
 	}
-	if got := header.Get("X-Forwarded-Host"); got != "meridian.example:50001" {
-		t.Fatalf("X-Forwarded-Host = %q", got)
+	if got := header.Get("X-Forwarded-Host"); got != "" {
+		t.Fatalf("dedicated-port X-Forwarded-Host = %q, want empty", got)
 	}
 	if got := header.Get("X-Forwarded-Proto"); got != "http" {
 		t.Fatalf("X-Forwarded-Proto = %q", got)
+	}
+}
+
+func TestApplySiteForwardedHostOnlyForCanonicalSharedIngress(t *testing.T) {
+	site := Site{PublicHost: "media.example.com", IngressMode: ingressModeBoth}
+
+	shared := httptest.NewRequest(http.MethodGet, "http://media.example.com/Videos/1", nil)
+	shared = shared.WithContext(context.WithValue(shared.Context(), publicHostIngressContextKey{}, true))
+	sharedHeader := make(http.Header)
+	applySiteForwardedHost(sharedHeader, shared, site)
+	if got := sharedHeader.Get("X-Forwarded-Host"); got != site.PublicHost {
+		t.Fatalf("shared-ingress X-Forwarded-Host=%q, want %q", got, site.PublicHost)
+	}
+
+	for _, req := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "http://attacker.example:50001/Videos/1", nil),
+		httptest.NewRequest(http.MethodGet, "http://media.example.com:50001/Videos/1", nil),
+	} {
+		header := http.Header{"X-Forwarded-Host": []string{"attacker.example"}}
+		applySiteForwardedHost(header, req, site)
+		if got := header.Get("X-Forwarded-Host"); got != "" {
+			t.Errorf("non-shared ingress X-Forwarded-Host=%q, want empty", got)
+		}
 	}
 }
 
@@ -441,7 +468,7 @@ func TestMigrateAddsCustomUAColumnsForLegacyDatabases(t *testing.T) {
 			}
 			defer db.Close()
 
-			for _, column := range []string{"playback_target_url", "playback_mode", "stream_hosts", "custom_user_agent", "custom_client", "custom_version"} {
+			for _, column := range []string{"playback_target_url", "playback_mode", "stream_hosts", "custom_user_agent", "custom_client", "custom_version", "public_host", "ingress_mode", "upstream_headers"} {
 				var count int
 				if err := db.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('sites') WHERE name=?", column).Scan(&count); err != nil {
 					t.Fatalf("inspect %s: %v", column, err)
@@ -450,12 +477,22 @@ func TestMigrateAddsCustomUAColumnsForLegacyDatabases(t *testing.T) {
 					t.Fatalf("column %s count=%d, want 1", column, count)
 				}
 			}
+			var publicHostIndexCount int
+			if err := db.db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_sites_public_host'").Scan(&publicHostIndexCount); err != nil {
+				t.Fatalf("inspect public host index: %v", err)
+			}
+			if publicHostIndexCount != 1 {
+				t.Fatalf("public host index count=%d, want 1", publicHostIndexCount)
+			}
 			site, err := db.GetSite(1)
 			if err != nil {
 				t.Fatalf("read migrated site: %v", err)
 			}
 			if site.UAMode != "infuse" || site.CustomUserAgent != "" || site.CustomClient != "" || site.CustomVersion != "" {
 				t.Fatalf("migrated site UA config = %#v", site)
+			}
+			if site.PublicHost != "" || site.IngressMode != ingressModePort || len(site.UpstreamHeaders) != 0 || site.StoredUpstreamHeaders != "[]" {
+				t.Fatalf("migrated site ingress config = %#v", site)
 			}
 		})
 	}
@@ -838,12 +875,14 @@ func TestReverseProxyRebuildsForwardingHeadersAfterHopHeaderRemoval(t *testing.T
 	for name, want := range map[string]string{
 		"X-Forwarded-For":   "198.51.100.24",
 		"X-Real-IP":         "198.51.100.24",
-		"X-Forwarded-Host":  "meridian.example:50001",
 		"X-Forwarded-Proto": "http",
 	} {
 		if got := captured.Header.Get(name); got != want {
 			t.Errorf("%s = %q, want %q", name, got, want)
 		}
+	}
+	if got := captured.Header.Get("X-Forwarded-Host"); got != "" {
+		t.Errorf("dedicated-port X-Forwarded-Host = %q, want empty", got)
 	}
 	for _, name := range []string{"Forwarded", "X-Forwarded-Custom"} {
 		if got := captured.Header.Get(name); got != "" {
@@ -880,17 +919,76 @@ func TestPrepareWebSocketUpstreamHeadersRebuildsForwardingHeaders(t *testing.T) 
 		"User-Agent":        policy.Profile.UserAgent,
 		"X-Forwarded-For":   "198.51.100.25",
 		"X-Real-IP":         "198.51.100.25",
-		"X-Forwarded-Host":  "meridian.example:50001",
 		"X-Forwarded-Proto": "http",
 	} {
 		if got := header.Get(name); got != want {
 			t.Errorf("%s = %q, want %q", name, got, want)
 		}
 	}
+	if got := header.Get("X-Forwarded-Host"); got != "" {
+		t.Errorf("dedicated-port WebSocket X-Forwarded-Host = %q, want empty", got)
+	}
 	for _, name := range []string{"Forwarded", "X-Forwarded-Custom", "Proxy-Connection"} {
 		if got := header.Get(name); got != "" {
 			t.Errorf("untrusted WebSocket header %s leaked upstream: %q", name, got)
 		}
+	}
+}
+
+func TestTrustedProxyForwardingUsesOnlyNormalizedEdgeValues(t *testing.T) {
+	_, loopback, err := net.ParseCIDR("127.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	trusted := []*net.IPNet{loopback}
+	req := httptest.NewRequest(http.MethodGet, "http://media.example.com/socket", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Header.Set("X-Real-IP", "198.51.100.42")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 10.0.0.1")
+	req.Header.Set("X-Forwarded-Proto", "HTTPS")
+	req.Header.Set("X-Forwarded-Custom", "drop-me")
+
+	header := req.Header.Clone()
+	prepareUpstreamHeaders(header, req, UAHeaderPolicy{}, trusted)
+	for name, want := range map[string]string{
+		"X-Forwarded-For":   "198.51.100.42",
+		"X-Real-IP":         "198.51.100.42",
+		"X-Forwarded-Proto": "https",
+	} {
+		if got := header.Get(name); got != want {
+			t.Errorf("trusted HTTP %s=%q, want %q", name, got, want)
+		}
+	}
+	if got := header.Get("X-Forwarded-Host"); got != "" {
+		t.Errorf("dedicated-port trusted X-Forwarded-Host=%q, want empty", got)
+	}
+	if got := header.Get("X-Forwarded-Custom"); got != "" {
+		t.Fatalf("unrecognized forwarding header leaked upstream: %q", got)
+	}
+
+	target, err := normalizeTargetURL("http://origin.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wsHeader := prepareWebSocketUpstreamHeadersWithTrustedProxies(req, target, UAHeaderPolicy{}, trusted)
+	if got := wsHeader.Get("X-Forwarded-For"); got != "198.51.100.42" {
+		t.Fatalf("trusted WebSocket X-Forwarded-For=%q", got)
+	}
+	if got := wsHeader.Get("X-Forwarded-Proto"); got != "https" {
+		t.Fatalf("trusted WebSocket X-Forwarded-Proto=%q", got)
+	}
+
+	bad := req.Clone(req.Context())
+	bad.Header = req.Header.Clone()
+	bad.Header.Set("X-Real-IP", "not-an-ip")
+	bad.Header.Set("X-Forwarded-Proto", "javascript")
+	badHeader := bad.Header.Clone()
+	prepareUpstreamHeaders(badHeader, bad, UAHeaderPolicy{}, trusted)
+	if got := badHeader.Get("X-Real-IP"); got != "127.0.0.1" {
+		t.Fatalf("invalid trusted X-Real-IP fallback=%q", got)
+	}
+	if got := badHeader.Get("X-Forwarded-Proto"); got != "http" {
+		t.Fatalf("invalid trusted proto fallback=%q", got)
 	}
 }
 
@@ -954,6 +1052,11 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	for _, snippet := range []string{`id="m-speed"`, "speed_limit: parseInt(document.getElementById('m-speed').value || 0)"} {
 		if !strings.Contains(string(sitesJS), snippet) {
 			t.Errorf("site form must expose and submit speed limit; missing %q", snippet)
+		}
+	}
+	for _, snippet := range []string{`id="m-public-host"`, `id="m-upstream-headers"`, `type="password"`, "upstream_headers: buildUpstreamHeaderPayload(upstreamHeaders)"} {
+		if !strings.Contains(string(sitesJS), snippet) {
+			t.Errorf("site form must expose safe shared ingress and write-only headers; missing %q", snippet)
 		}
 	}
 
@@ -1500,6 +1603,19 @@ func TestJWTSecretRotationInvalidatesExistingToken(t *testing.T) {
 	jwtSecret = []byte("new-test-signing-secret-000000000000")
 	if _, _, err := validateToken(token); err == nil {
 		t.Fatal("token signed before JWT secret rotation remained valid")
+	}
+}
+
+func TestSessionIdentityIgnoresInvalidSameNameCookieShadow(t *testing.T) {
+	token, err := generateToken(7, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "https://panel.example.com/api/dashboard", nil)
+	req.Header.Set("Cookie", sessionCookieName+"=attacker-shadow; "+sessionCookieName+"="+token)
+	userID, username, err := sessionIdentity(req)
+	if err != nil || userID != 7 || username != "admin" {
+		t.Fatalf("sessionIdentity shadow handling=(%d, %q, %v)", userID, username, err)
 	}
 }
 
@@ -4137,10 +4253,10 @@ func TestHandleSitesGETOverlaysLiveTrafficWithoutDBWrite(t *testing.T) {
 		t.Fatalf("decode /api/sites: %v", err)
 	}
 	expectedKeys := map[string]bool{
-		"id": true, "name": true, "listen_port": true, "target_url": true,
+		"id": true, "name": true, "listen_port": true, "public_host": true, "ingress_mode": true, "target_url": true,
 		"playback_target_url": true, "playback_mode": true, "stream_hosts": true,
 		"ua_mode": true, "custom_user_agent": true, "custom_client": true,
-		"custom_version": true, "enabled": true, "traffic_quota": true,
+		"custom_version": true, "upstream_headers": true, "enabled": true, "traffic_quota": true,
 		"traffic_used": true, "speed_limit": true, "created_at": true,
 		"updated_at": true, "running": true,
 	}
@@ -4900,6 +5016,846 @@ func TestProxyPlaybackRequestsFallBackToMainTarget(t *testing.T) {
 	if body := mustReadBody(t, resp); !strings.Contains(body, "api:/Videos/42/stream") {
 		t.Fatalf("fallback playback body = %q", body)
 	}
+}
+
+func TestNormalizePublicHostUsesExactDNSNames(t *testing.T) {
+	valid := map[string]string{
+		" MEDIA.Example.COM. ": "media.example.com",
+		"xn--fiqs8s.example":   "xn--fiqs8s.example",
+	}
+	for input, want := range valid {
+		got, err := normalizePublicHost(input)
+		if err != nil || got != want {
+			t.Errorf("normalizePublicHost(%q) = %q, %v; want %q", input, got, err, want)
+		}
+	}
+	for _, input := range []string{
+		"localhost", "https://media.example.com", "media.example.com:443",
+		"*.example.com", "127.0.0.1", "bad_label.example.com", "-bad.example.com",
+	} {
+		if _, err := normalizePublicHost(input); err == nil {
+			t.Errorf("normalizePublicHost(%q) unexpectedly succeeded", input)
+		}
+	}
+	if got := requestPublicHost("MEDIA.EXAMPLE.COM:443"); got != "media.example.com" {
+		t.Fatalf("requestPublicHost = %q, want media.example.com", got)
+	}
+}
+
+func TestUpstreamHeadersAreEncryptedWriteOnlyAndAuthorityScoped(t *testing.T) {
+	key := bytes.Repeat([]byte{0x24}, 32)
+	secret := "emos-secret-value"
+	mainTarget, _ := url.Parse("https://origin.example.com:443/emby")
+	playbackTarget, _ := url.Parse("https://cdn.example.net/video")
+	raw, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "emos-proxy-id", Value: &secret}}, key, mainTarget.String())
+	if err != nil {
+		t.Fatalf("mergeUpstreamHeaders: %v", err)
+	}
+	if strings.Contains(raw, secret) || !strings.Contains(raw, "ciphertext") {
+		t.Fatalf("stored upstream headers are not encrypted: %s", raw)
+	}
+	views, err := upstreamHeaderViews(raw)
+	if err != nil || len(views) != 1 || views[0].Name != "Emos-Proxy-Id" || !views[0].Configured {
+		t.Fatalf("upstreamHeaderViews = %#v, %v", views, err)
+	}
+	encoded, err := json.Marshal(Site{StoredUpstreamHeaders: raw, UpstreamHeaders: views})
+	if err != nil {
+		t.Fatalf("marshal site: %v", err)
+	}
+	if strings.Contains(string(encoded), secret) || strings.Contains(string(encoded), "ciphertext") || !strings.Contains(string(encoded), `"configured":true`) {
+		t.Fatalf("site API representation exposed a secret or lost write-only metadata: %s", encoded)
+	}
+
+	policy, err := resolveUpstreamHeaderPolicy(raw, key, mainTarget)
+	if err != nil {
+		t.Fatalf("resolveUpstreamHeaderPolicy: %v", err)
+	}
+	otherAuthority, _ := url.Parse("https://other-origin.example.com/emby")
+	if _, err := resolveUpstreamHeaderPolicy(raw, key, otherAuthority); err == nil {
+		t.Fatal("v2 ciphertext unexpectedly decrypted for a different target authority")
+	}
+	header := make(http.Header)
+	header.Set("Emos-Proxy-Id", "client-spoof")
+	policy.apply(header, mainTarget)
+	if got := header.Get("Emos-Proxy-Id"); got != secret {
+		t.Fatalf("main target header = %q, want configured value", got)
+	}
+	policy.apply(header, playbackTarget)
+	if got := header.Get("Emos-Proxy-Id"); got != "" {
+		t.Fatalf("playback target received configured header %q", got)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "http://client.example/socket", nil)
+	request.Header.Set("Connection", "Upgrade")
+	request.Header.Set("Upgrade", "websocket")
+	wsMain := prepareWebSocketUpstreamHeaders(request, mainTarget, UAHeaderPolicy{}, policy)
+	if got := wsMain.Get("Emos-Proxy-Id"); got != secret {
+		t.Fatalf("main websocket header = %q", got)
+	}
+	wsPlayback := prepareWebSocketUpstreamHeaders(request, playbackTarget, UAHeaderPolicy{}, policy)
+	if got := wsPlayback.Get("Emos-Proxy-Id"); got != "" {
+		t.Fatalf("playback websocket leaked configured header %q", got)
+	}
+
+	retained, err := mergeUpstreamHeaders(raw, []UpstreamHeaderInput{{Name: "EMOS-PROXY-ID"}}, nil, mainTarget.String())
+	if err != nil || retained != raw {
+		t.Fatalf("write-only retain changed ciphertext: retained=%s err=%v", retained, err)
+	}
+	if _, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "Authorization", Value: &secret}}, key, mainTarget.String()); err == nil {
+		t.Fatal("managed Authorization header unexpectedly accepted")
+	}
+	if _, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-New-Secret", Value: &secret}}, nil, mainTarget.String()); err == nil {
+		t.Fatal("new secret unexpectedly accepted without UPSTREAM_HEADER_KEY")
+	}
+	if _, err := resolveUpstreamHeaderPolicy(raw, bytes.Repeat([]byte{0x99}, 32), mainTarget); err == nil {
+		t.Fatal("configured header unexpectedly decrypted with the wrong key")
+	}
+	stored, err := parseStoredUpstreamHeaders(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored[0].Name = "X-Swapped-Name"
+	tampered, _ := json.Marshal(stored)
+	if _, err := resolveUpstreamHeaderPolicy(string(tampered), key, mainTarget); err == nil {
+		t.Fatal("ciphertext unexpectedly survived header-name swapping")
+	}
+	invalidCiphertext, err := encryptUpstreamHeaderValue("X-Invalid-Value", "line-one\r\nline-two", redirectHostKey(mainTarget), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidRaw, _ := json.Marshal([]storedUpstreamHeader{{Name: "X-Invalid-Value", Ciphertext: invalidCiphertext}})
+	if _, err := resolveUpstreamHeaderPolicy(string(invalidRaw), key, mainTarget); err == nil {
+		t.Fatal("decrypted header value containing CRLF unexpectedly accepted")
+	}
+}
+
+func TestResolveUpstreamHeaderKeyRejectsWhitespace(t *testing.T) {
+	valid := strings.Repeat("a", 32)
+	if key, err := resolveUpstreamHeaderKey(valid); err != nil || len(key) != 32 {
+		t.Fatalf("valid upstream header key resolved to len=%d err=%v", len(key), err)
+	}
+	for _, value := range []string{valid + " ", " " + valid, strings.Repeat("a", 16) + "\t" + strings.Repeat("b", 16)} {
+		if _, err := resolveUpstreamHeaderKey(value); err == nil {
+			t.Fatalf("whitespace-containing key %q unexpectedly accepted", value)
+		}
+	}
+}
+
+func TestLegacyUpdateHelperPreservesSharedIngressConfiguration(t *testing.T) {
+	app := newTestApp(t)
+	secret := "persist-me"
+	stored, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &secret}}, app.pm.upstreamHeaderKey, "http://127.0.0.1:8096")
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{
+		Name:                  "before",
+		ListenPort:            freePort(t),
+		PublicHost:            "media.example.com",
+		TargetURL:             "http://127.0.0.1:8096",
+		PlaybackMode:          "direct",
+		StreamHosts:           "[]",
+		UAMode:                "infuse",
+		StoredUpstreamHeaders: stored,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.UpdateSiteWithCustomUA(site.ID, "after", site.ListenPort, site.TargetURL, "", "direct", "[]", "web", "", "", "", 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.PublicHost != site.PublicHost || updated.StoredUpstreamHeaders != stored || len(updated.UpstreamHeaders) != 1 {
+		t.Fatalf("legacy update erased shared ingress configuration: %#v", updated)
+	}
+	if err := app.db.UpdateSiteWithCustomUA(site.ID, "moved", site.ListenPort, "http://127.0.0.1:8097", "", "direct", "[]", "web", "", "", "", 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	moved, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moved.StoredUpstreamHeaders != "[]" || len(moved.UpstreamHeaders) != 0 {
+		t.Fatalf("data-layer update carried an origin secret to a new authority: %#v", moved)
+	}
+}
+
+func TestRedirectFollowRemovesConfiguredHeadersFromCrossAuthorityHop(t *testing.T) {
+	key := bytes.Repeat([]byte{0x35}, 32)
+	secret := "main-origin-only"
+	raw, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &secret}}, key, "https://origin.example.com/start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainTarget, _ := url.Parse("https://origin.example.com/start")
+	cdnTarget, _ := url.Parse("https://cdn.example.net/video")
+	policy, err := resolveUpstreamHeaderPolicy(raw, key, mainTarget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secondHopHeader string
+	calls := 0
+	transport := &redirectFollowTransport{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			calls++
+			if calls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusFound,
+					Header:     http.Header{"Location": []string{cdnTarget.String()}},
+					Body:       io.NopCloser(strings.NewReader("")),
+					Request:    req,
+				}, nil
+			}
+			secondHopHeader = req.Header.Get("X-Origin-Secret")
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader("ok")), Request: req}, nil
+		}),
+		playbackHosts:        map[string]bool{redirectHostKey(cdnTarget): true},
+		upstreamHeaderPolicy: policy,
+	}
+	req := httptest.NewRequest(http.MethodGet, mainTarget.String(), nil)
+	policy.apply(req.Header, mainTarget)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	if calls != 2 || secondHopHeader != "" {
+		t.Fatalf("redirect calls=%d configured header on CDN=%q", calls, secondHopHeader)
+	}
+}
+
+func TestPublicHostRouterAndEncryptedHeaderAPI(t *testing.T) {
+	app := newTestApp(t)
+	app.panelHost = "panel.example.com"
+	receivedHeader := make(chan string, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader <- r.Header.Get("Emos-Proxy-Id")
+		w.Header().Add("Set-Cookie", "meridian_session=upstream-must-not-overwrite; Path=/")
+		w.Header().Add("Set-Cookie", "emby_session=upstream-keep; Path=/")
+		_, _ = w.Write([]byte("upstream"))
+	}))
+	defer upstream.Close()
+
+	port := freePort(t)
+	releasePort(port)
+	secret := "write-only-emos-value"
+	payload, err := json.Marshal(map[string]interface{}{
+		"name":             "shared-entry",
+		"listen_port":      port,
+		"public_host":      "Media.Example.COM",
+		"target_url":       upstream.URL,
+		"ua_mode":          "infuse",
+		"upstream_headers": []map[string]string{{"name": "EMOS-PROXY-ID", "value": secret}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := httptest.NewRecorder()
+	app.handleSites(created, httptest.NewRequest(http.MethodPost, "/api/sites", bytes.NewReader(payload)))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
+	}
+	if strings.Contains(created.Body.String(), secret) || strings.Contains(created.Body.String(), "ciphertext") {
+		t.Fatalf("create response exposed configured header: %s", created.Body.String())
+	}
+
+	sites, err := app.db.ListSites()
+	if err != nil || len(sites) != 1 {
+		t.Fatalf("ListSites = %#v, %v", sites, err)
+	}
+	site := sites[0]
+	t.Cleanup(func() { _ = app.pm.StopSite(site.ID) })
+	if site.PublicHost != "media.example.com" || len(site.UpstreamHeaders) != 1 {
+		t.Fatalf("stored site public configuration = %#v", site)
+	}
+	var stored string
+	if err := app.db.db.QueryRow("SELECT upstream_headers FROM sites WHERE id=?", site.ID).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stored, secret) {
+		t.Fatalf("database stored plaintext upstream header: %s", stored)
+	}
+
+	panel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("panel")) })
+	router := app.publicHostRouter(panel)
+	proxied := httptest.NewRecorder()
+	proxiedRequest := httptest.NewRequest(http.MethodGet, "https://media.example.com/System/Info/Public", nil)
+	proxiedRequest.Host = "MEDIA.EXAMPLE.COM:443"
+	router.ServeHTTP(proxied, proxiedRequest)
+	if proxied.Code != http.StatusOK || proxied.Body.String() != "upstream" {
+		t.Fatalf("public host route status=%d body=%q", proxied.Code, proxied.Body.String())
+	}
+	responseCookies := strings.Join(proxied.Header().Values("Set-Cookie"), "\n")
+	if strings.Contains(responseCookies, "upstream-must-not-overwrite") || !strings.Contains(responseCookies, "emby_session=upstream-keep") {
+		t.Fatalf("HTTP response Cookie sanitization=%q", responseCookies)
+	}
+	select {
+	case got := <-receivedHeader:
+		if got != secret {
+			t.Fatalf("upstream header = %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream request was not observed")
+	}
+
+	panelRequest := httptest.NewRequest(http.MethodGet, "https://panel.example.com/", nil)
+	panelResponse := httptest.NewRecorder()
+	router.ServeHTTP(panelResponse, panelRequest)
+	if panelResponse.Body.String() != "panel" {
+		t.Fatalf("panel host was not reserved: %q", panelResponse.Body.String())
+	}
+
+	if err := app.pm.StopSite(site.ID); err != nil {
+		t.Fatal(err)
+	}
+	unavailable := httptest.NewRecorder()
+	unavailableRequest := httptest.NewRequest(http.MethodGet, "https://media.example.com/", nil)
+	router.ServeHTTP(unavailable, unavailableRequest)
+	if unavailable.Code != http.StatusServiceUnavailable || strings.Contains(unavailable.Body.String(), "panel") {
+		t.Fatalf("disabled public host did not fail closed: status=%d body=%s", unavailable.Code, unavailable.Body.String())
+	}
+}
+
+func TestPublicHostUniqueIndexIsCaseInsensitive(t *testing.T) {
+	app := newTestApp(t)
+	first, err := app.db.CreateSiteRecord(Site{Name: "one", ListenPort: freePort(t), PublicHost: "media.example.com", TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", UAMode: "infuse"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.CreateSiteRecord(Site{Name: "two", ListenPort: freePort(t), PublicHost: "MEDIA.EXAMPLE.COM", TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", UAMode: "infuse"}); err == nil {
+		t.Fatalf("duplicate public host accepted after site %d", first.ID)
+	}
+}
+
+func TestPrepareUpstreamHeadersStripsOnlyManagementSessionCookie(t *testing.T) {
+	header := http.Header{
+		"Cookie": []string{
+			"meridian_session=panel-secret; emby_session=keep",
+			"meridian_session_backup=also-keep; preference=dark",
+		},
+	}
+	request := httptest.NewRequest(http.MethodGet, "http://media.example.com/", nil)
+	prepareUpstreamHeaders(header, request, UAHeaderPolicy{})
+
+	parsed, err := http.ParseCookie(header.Get("Cookie"))
+	if err != nil {
+		t.Fatalf("parse sanitized Cookie: %v; value=%q", err, header.Get("Cookie"))
+	}
+	values := make(map[string]string, len(parsed))
+	for _, cookie := range parsed {
+		values[cookie.Name] = cookie.Value
+	}
+	if _, exists := values[sessionCookieName]; exists {
+		t.Fatalf("management session leaked upstream: %q", header.Get("Cookie"))
+	}
+	for name, want := range map[string]string{"emby_session": "keep", "meridian_session_backup": "also-keep", "preference": "dark"} {
+		if got := values[name]; got != want {
+			t.Fatalf("cookie %s=%q, want %q; header=%q", name, got, want, header.Get("Cookie"))
+		}
+	}
+
+	wsRequest := httptest.NewRequest(http.MethodGet, "http://media.example.com/socket", nil)
+	wsRequest.Header.Set("Cookie", "emby_session=keep; meridian_session=panel-secret")
+	wsTarget, err := url.Parse("http://origin.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wsHeader := prepareWebSocketUpstreamHeaders(wsRequest, wsTarget, UAHeaderPolicy{})
+	if strings.Contains(wsHeader.Get("Cookie"), sessionCookieName) || !strings.Contains(wsHeader.Get("Cookie"), "emby_session=keep") {
+		t.Fatalf("websocket Cookie sanitization = %q", wsHeader.Get("Cookie"))
+	}
+
+	malformed := http.Header{"Cookie": []string{"invalid cookie; meridian_session=panel-secret"}}
+	stripCookieByName(malformed, sessionCookieName)
+	if got := malformed.Values("Cookie"); len(got) != 0 {
+		t.Fatalf("malformed Cookie was not dropped fail-closed: %q", got)
+	}
+}
+
+func TestStripPanelSessionSetCookiesPreservesOnlyValidNonManagementCookies(t *testing.T) {
+	header := make(http.Header)
+	header.Add("Set-Cookie", "meridian_session=replace-panel; Path=/; HttpOnly")
+	header.Add("Set-Cookie", "emby_session=keep; Path=/; Expires=Wed, 21 Oct 2030 07:28:00 GMT")
+	header.Add("Set-Cookie", "meridian_session_backup=keep-too; Path=/")
+	header.Add("Set-Cookie", "Meridian_session=case-sensitive-name; Path=/")
+	header.Add("Set-Cookie", "malformed cookie without equals")
+	stripPanelSessionSetCookies(header)
+
+	got := header.Values("Set-Cookie")
+	if len(got) != 3 {
+		t.Fatalf("sanitized Set-Cookie=%q, want three valid non-management values", got)
+	}
+	joined := strings.Join(got, "\n")
+	if strings.Contains(joined, "replace-panel") || strings.Contains(joined, "malformed cookie") {
+		t.Fatalf("unsafe Set-Cookie survived: %q", got)
+	}
+	for _, marker := range []string{"emby_session=keep", "Expires=Wed, 21 Oct 2030 07:28:00 GMT", "meridian_session_backup=keep-too", "Meridian_session=case-sensitive-name"} {
+		if !strings.Contains(joined, marker) {
+			t.Fatalf("valid upstream cookie %q was not preserved verbatim: %q", marker, got)
+		}
+	}
+}
+
+func TestNormalizeIngressMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		publicHost string
+		want       string
+		wantErr    bool
+	}{
+		{name: "legacy port", want: ingressModePort},
+		{name: "secure shared default", publicHost: "media.example.com", want: ingressModeHost},
+		{name: "host", mode: ingressModeHost, publicHost: "media.example.com", want: ingressModeHost},
+		{name: "both", mode: ingressModeBoth, publicHost: "media.example.com", want: ingressModeBoth},
+		{name: "port rejects host", mode: ingressModePort, publicHost: "media.example.com", wantErr: true},
+		{name: "host requires domain", mode: ingressModeHost, wantErr: true},
+		{name: "unknown", mode: "unsafe", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeIngressMode(tt.mode, tt.publicHost)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeIngressMode(%q, %q) error=%v, wantErr=%v", tt.mode, tt.publicHost, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeIngressMode(%q, %q)=%q, want %q", tt.mode, tt.publicHost, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostOnlyStartSkipsReservedPortAndRoutesSharedHost(t *testing.T) {
+	app := newTestApp(t)
+	app.panelHost = "panel.example.com"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("shared-upstream"))
+	}))
+	defer upstream.Close()
+
+	reservedPort := freePort(t) // deliberately keep the reservation open
+	site, err := app.db.CreateSiteRecord(Site{
+		Name:         "host-only",
+		ListenPort:   reservedPort,
+		PublicHost:   "media.example.com",
+		IngressMode:  ingressModeHost,
+		TargetURL:    upstream.URL,
+		PlaybackMode: "direct",
+		StreamHosts:  "[]",
+		UAMode:       "infuse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("host-only StartSite tried to bind reserved port: %v", err)
+	}
+
+	app.pm.mu.RLock()
+	inst := app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	if inst == nil || inst.server != nil || inst.listener != nil {
+		t.Fatalf("host-only runtime = %#v, want handler with nil server/listener", inst)
+	}
+
+	router := app.publicHostRouter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("panel"))
+	}))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://media.example.com/System/Info/Public", nil)
+	router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || rr.Body.String() != "shared-upstream" {
+		t.Fatalf("shared route status=%d body=%q", rr.Code, rr.Body.String())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	app.pm.GracefulShutdown(ctx)
+	if app.pm.IsRunning(site.ID) {
+		t.Fatal("host-only runtime survived graceful shutdown")
+	}
+}
+
+func TestHostOnlyIngressRequiresLoopbackPanelBinding(t *testing.T) {
+	app := newTestApp(t)
+	app.pm.SetHostOnlyIngressSafe(false)
+	site := Site{ID: 501, Name: "strict-host", ListenPort: freePort(t), PublicHost: "media.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse"}
+	if err := app.pm.StartSite(site); !errors.Is(err, errUnsafeHostOnlyIngress) {
+		t.Fatalf("host-only start on public panel bind error=%v, want safety rejection", err)
+	}
+	if err := app.pm.validateIngressSafety(ingressModeBoth); err != nil {
+		t.Fatalf("explicit high-risk both mode was unexpectedly rejected: %v", err)
+	}
+	app.pm.SetHostOnlyIngressSafe(true)
+	if err := app.pm.StartSite(site); err != nil {
+		t.Fatalf("host-only start on loopback-safe panel bind: %v", err)
+	}
+	if err := app.pm.StopSite(site.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHostOnlyIngressOnPublicBindAllowsOnlyTrustedProxySources(t *testing.T) {
+	app := newTestApp(t)
+	app.panelBindLoopback = false
+	_, loopback, err := net.ParseCIDR("127.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.trustedProxies = []*net.IPNet{loopback}
+	app.pm.SetTrustedProxies(app.trustedProxies)
+	app.pm.SetHostOnlyIngressSafe(true)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("trusted")) }))
+	defer upstream.Close()
+	site := Site{ID: 503, Name: "allowlisted-host", ListenPort: freePort(t), PublicHost: "allowlisted.example.com", IngressMode: ingressModeHost, TargetURL: upstream.URL, PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse"}
+	if err := app.pm.StartSite(site); err != nil {
+		t.Fatal(err)
+	}
+	defer app.pm.StopSite(site.ID)
+	router := app.publicHostRouter(http.NotFoundHandler())
+
+	direct := httptest.NewRequest(http.MethodGet, "http://allowlisted.example.com/", nil)
+	direct.RemoteAddr = "198.51.100.10:45678"
+	directResponse := httptest.NewRecorder()
+	router.ServeHTTP(directResponse, direct)
+	if directResponse.Code != http.StatusForbidden {
+		t.Fatalf("direct source reached host-only route: status=%d body=%q", directResponse.Code, directResponse.Body.String())
+	}
+
+	proxied := httptest.NewRequest(http.MethodGet, "http://allowlisted.example.com/", nil)
+	proxied.RemoteAddr = "127.0.0.1:45678"
+	proxiedResponse := httptest.NewRecorder()
+	router.ServeHTTP(proxiedResponse, proxied)
+	if proxiedResponse.Code != http.StatusOK || proxiedResponse.Body.String() != "trusted" {
+		t.Fatalf("trusted proxy source rejected: status=%d body=%q", proxiedResponse.Code, proxiedResponse.Body.String())
+	}
+}
+
+func TestBothIngressServesSharedHostAndDedicatedPort(t *testing.T) {
+	app := newTestApp(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("both-upstream"))
+	}))
+	defer upstream.Close()
+	port := freePort(t)
+	releasePort(port)
+	site := Site{ID: 502, Name: "both", ListenPort: port, PublicHost: "both.example.com", IngressMode: ingressModeBoth, TargetURL: upstream.URL, PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse"}
+	if err := app.pm.StartSite(site); err != nil {
+		t.Fatal(err)
+	}
+	defer app.pm.StopSite(site.ID)
+
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/System/Info/Public", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	portBody := mustReadBody(t, resp)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || portBody != "both-upstream" {
+		t.Fatalf("dedicated port status=%d body=%q", resp.StatusCode, portBody)
+	}
+	hostHandler, configured := app.pm.PublicHostHandler(site.PublicHost)
+	if !configured || hostHandler == nil {
+		t.Fatal("both mode did not register shared Host handler")
+	}
+	rr := httptest.NewRecorder()
+	hostHandler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "http://both.example.com/System/Info/Public", nil))
+	if rr.Code != http.StatusOK || rr.Body.String() != "both-upstream" {
+		t.Fatalf("shared Host status=%d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHostOnlyStopCancelsInflightRequestAndFlushesFinalTraffic(t *testing.T) {
+	app := newTestApp(t)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	var inst *ProxyInstance
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(canceled)
+	}))
+	defer upstream.Close()
+	site, err := app.db.CreateSiteRecord(Site{Name: "drain-host", ListenPort: freePort(t), PublicHost: "drain.example.com", IngressMode: ingressModeHost, TargetURL: upstream.URL, PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatal(err)
+	}
+	app.pm.mu.RLock()
+	inst = app.pm.proxies[site.ID]
+	app.pm.mu.RUnlock()
+	handler, configured := app.pm.PublicHostHandler(site.PublicHost)
+	if !configured || handler == nil || inst == nil {
+		t.Fatal("host-only runtime not available")
+	}
+	requestDone := make(chan struct{})
+	go func() {
+		defer close(requestDone)
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "http://drain.example.com/stream", nil))
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight upstream request did not start")
+	}
+	if err := app.pm.StopSite(site.ID); err != nil {
+		t.Fatal(err)
+	}
+	for name, ch := range map[string]<-chan struct{}{"upstream cancellation": canceled, "proxy request drain": requestDone} {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s did not complete", name)
+		}
+	}
+	if app.pm.IsRunning(site.ID) {
+		t.Fatal("host-only site still reports running after StopSite")
+	}
+	updated, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The canceled proxy writes its local 502 through the metered writer before
+	// the active request drains. Traffic mutation from the upstream server's own
+	// goroutine would not model Meridian I/O and can legitimately occur after
+	// RoundTrip has returned, so only proxy-owned metering belongs in this test.
+	if updated.TrafficUsed == 0 || inst.bytesIn.Load() != 0 || inst.bytesOut.Load() != 0 {
+		t.Fatalf("final traffic was not conserved: persisted=%d pending_in=%d pending_out=%d", updated.TrafficUsed, inst.bytesIn.Load(), inst.bytesOut.Load())
+	}
+	rejected := httptest.NewRecorder()
+	handler.ServeHTTP(rejected, httptest.NewRequest(http.MethodGet, "http://drain.example.com/after-stop", nil))
+	if rejected.Code != http.StatusServiceUnavailable {
+		t.Fatalf("captured handler accepted a new request after stop: %d", rejected.Code)
+	}
+}
+
+func TestPublicHostRouterRejectsUnknownHostsWhenPanelDomainConfigured(t *testing.T) {
+	app := newTestApp(t)
+	app.panelHost = "panel.example.com"
+	panel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("panel-secret")) })
+	router := app.publicHostRouter(panel)
+
+	for _, rawURL := range []string{"https://unknown.example.com/", "http://127.0.0.1:9090/"} {
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, rawURL, nil))
+		if rr.Code != http.StatusMisdirectedRequest || strings.Contains(rr.Body.String(), "panel-secret") {
+			t.Fatalf("unknown Host %s status=%d body=%q", rawURL, rr.Code, rr.Body.String())
+		}
+	}
+
+	panelResponse := httptest.NewRecorder()
+	router.ServeHTTP(panelResponse, httptest.NewRequest(http.MethodGet, "https://PANEL.EXAMPLE.COM:443/", nil))
+	if panelResponse.Body.String() != "panel-secret" {
+		t.Fatalf("configured panel Host rejected: status=%d body=%q", panelResponse.Code, panelResponse.Body.String())
+	}
+
+	health := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/api/auth/check", nil)
+	health.RemoteAddr = "127.0.0.1:54321"
+	healthResponse := httptest.NewRecorder()
+	router.ServeHTTP(healthResponse, health)
+	if healthResponse.Body.String() != "panel-secret" {
+		t.Fatalf("loopback health probe rejected: status=%d body=%q", healthResponse.Code, healthResponse.Body.String())
+	}
+	for _, tc := range []struct {
+		url    string
+		remote string
+	}{
+		{url: "http://localhost:9090/api/auth/check", remote: "127.0.0.1:54321"},
+		{url: "http://[::1]:9090/api/auth/check", remote: "[::1]:54321"},
+	} {
+		req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+		req.RemoteAddr = tc.remote
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		if rr.Body.String() != "panel-secret" {
+			t.Fatalf("local health probe %s from %s rejected: status=%d body=%q", tc.url, tc.remote, rr.Code, rr.Body.String())
+		}
+	}
+
+	unknownViaLoopback := httptest.NewRequest(http.MethodGet, "http://unknown.example.com/api/auth/check", nil)
+	unknownViaLoopback.RemoteAddr = "127.0.0.1:54321"
+	unknownResponse := httptest.NewRecorder()
+	router.ServeHTTP(unknownResponse, unknownViaLoopback)
+	if unknownResponse.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("unknown Host via loopback proxy status=%d, want 421", unknownResponse.Code)
+	}
+	loopbackHostViaRemote := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/api/auth/check", nil)
+	loopbackHostViaRemote.RemoteAddr = "198.51.100.8:54321"
+	remoteResponse := httptest.NewRecorder()
+	router.ServeHTTP(remoteResponse, loopbackHostViaRemote)
+	if remoteResponse.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("loopback Host from non-loopback peer status=%d, want 421", remoteResponse.Code)
+	}
+
+	otherLoopback := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/", nil)
+	otherLoopback.RemoteAddr = "127.0.0.1:54321"
+	otherResponse := httptest.NewRecorder()
+	router.ServeHTTP(otherResponse, otherLoopback)
+	if otherResponse.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("loopback non-health path status=%d, want 421", otherResponse.Code)
+	}
+
+	app.panelHost = ""
+	compat := httptest.NewRecorder()
+	app.publicHostRouter(panel).ServeHTTP(compat, httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/", nil))
+	if compat.Body.String() != "panel-secret" {
+		t.Fatalf("domainless compatibility route status=%d body=%q", compat.Code, compat.Body.String())
+	}
+}
+
+func TestReservedDynamicRouteReturnsGoneWithoutProxying(t *testing.T) {
+	app := newTestApp(t)
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		_, _ = w.Write([]byte("upstream"))
+	}))
+	defer upstream.Close()
+
+	site := Site{ID: 101, Name: "reserved-route", ListenPort: freePort(t), PublicHost: "media.example.com", IngressMode: ingressModeHost, TargetURL: upstream.URL, PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse"}
+	if err := app.pm.StartSite(site); err != nil {
+		t.Fatal(err)
+	}
+	defer app.pm.StopSite(site.ID)
+	handler, configured := app.pm.PublicHostHandler(site.PublicHost)
+	if !configured || handler == nil {
+		t.Fatal("host handler not registered")
+	}
+	for _, requestPath := range []string{"/_meridian/d", "/_meridian/d/stale-token"} {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, requestPath, nil))
+		if rr.Code != http.StatusGone {
+			t.Fatalf("reserved path %s status=%d, want 410", requestPath, rr.Code)
+		}
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("reserved dynamic route reached upstream %d times", got)
+	}
+}
+
+func TestUpdateTargetAuthorityDoesNotCarryEncryptedHeaders(t *testing.T) {
+	t.Run("omitted headers are cleared", func(t *testing.T) {
+		app := newTestApp(t)
+		secret := "origin-one-secret"
+		stored, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &secret}}, app.pm.upstreamHeaderKey, "https://origin-one.example.com/emby")
+		if err != nil {
+			t.Fatal(err)
+		}
+		site, err := app.db.CreateSiteRecord(Site{Name: "authority-change", ListenPort: freePort(t), PublicHost: "one.example.com", IngressMode: ingressModeHost, TargetURL: "https://origin-one.example.com/emby", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse", StoredUpstreamHeaders: stored})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer app.pm.StopSite(site.ID)
+		payload, _ := json.Marshal(map[string]interface{}{"name": site.Name, "listen_port": site.ListenPort, "public_host": site.PublicHost, "ingress_mode": ingressModeHost, "target_url": "https://origin-two.example.com/emby"})
+		rr := httptest.NewRecorder()
+		app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), bytes.NewReader(payload)))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("update status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		updated, err := app.db.GetSite(site.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if updated.StoredUpstreamHeaders != "[]" || len(updated.UpstreamHeaders) != 0 {
+			t.Fatalf("old authority secret survived update: %#v", updated)
+		}
+	})
+
+	t.Run("blank retained value is rejected", func(t *testing.T) {
+		app := newTestApp(t)
+		secret := "origin-one-secret"
+		stored, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &secret}}, app.pm.upstreamHeaderKey, "https://origin-one.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		site, err := app.db.CreateSiteRecord(Site{Name: "authority-reentry", ListenPort: freePort(t), PublicHost: "two.example.com", IngressMode: ingressModeHost, TargetURL: "https://origin-one.example.com", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse", StoredUpstreamHeaders: stored})
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, _ := json.Marshal(map[string]interface{}{"name": site.Name, "listen_port": site.ListenPort, "public_host": site.PublicHost, "ingress_mode": ingressModeHost, "target_url": "https://origin-two.example.com", "upstream_headers": []map[string]string{{"name": "X-Origin-Secret", "value": ""}}})
+		rr := httptest.NewRecorder()
+		app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), bytes.NewReader(payload)))
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("blank secret update status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		unchanged, err := app.db.GetSite(site.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if unchanged.TargetURL != site.TargetURL || unchanged.StoredUpstreamHeaders != stored {
+			t.Fatalf("rejected update changed stored site: %#v", unchanged)
+		}
+	})
+
+	t.Run("same authority path retains headers", func(t *testing.T) {
+		app := newTestApp(t)
+		secret := "same-origin-secret"
+		stored, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &secret}}, app.pm.upstreamHeaderKey, "https://origin.example.com/emby")
+		if err != nil {
+			t.Fatal(err)
+		}
+		site, err := app.db.CreateSiteRecord(Site{Name: "same-authority", ListenPort: freePort(t), PublicHost: "three.example.com", IngressMode: ingressModeHost, TargetURL: "https://origin.example.com/emby", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse", StoredUpstreamHeaders: stored})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer app.pm.StopSite(site.ID)
+		payload, _ := json.Marshal(map[string]interface{}{"name": site.Name, "listen_port": site.ListenPort, "public_host": site.PublicHost, "ingress_mode": ingressModeHost, "target_url": "https://origin.example.com:443/other"})
+		rr := httptest.NewRecorder()
+		app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), bytes.NewReader(payload)))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("same-authority update status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		updated, err := app.db.GetSite(site.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if updated.StoredUpstreamHeaders != stored {
+			t.Fatalf("same-authority update changed encrypted headers: got=%s want=%s", updated.StoredUpstreamHeaders, stored)
+		}
+	})
+
+	t.Run("new authority accepts only a freshly entered secret", func(t *testing.T) {
+		app := newTestApp(t)
+		oldSecret := "old-origin-secret"
+		newSecret := "new-origin-secret"
+		stored, err := mergeUpstreamHeaders("[]", []UpstreamHeaderInput{{Name: "X-Origin-Secret", Value: &oldSecret}}, app.pm.upstreamHeaderKey, "https://origin-one.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		site, err := app.db.CreateSiteRecord(Site{Name: "authority-new-secret", ListenPort: freePort(t), PublicHost: "four.example.com", IngressMode: ingressModeHost, TargetURL: "https://origin-one.example.com", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "infuse", StoredUpstreamHeaders: stored})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer app.pm.StopSite(site.ID)
+		payload, _ := json.Marshal(map[string]interface{}{
+			"name": site.Name, "listen_port": site.ListenPort, "public_host": site.PublicHost,
+			"ingress_mode": ingressModeHost, "target_url": "https://origin-two.example.com",
+			"upstream_headers": []map[string]string{{"name": "X-Origin-Secret", "value": newSecret}},
+		})
+		rr := httptest.NewRecorder()
+		app.handleSiteByID(rr, httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/sites/%d", site.ID), bytes.NewReader(payload)))
+		if rr.Code != http.StatusOK {
+			t.Fatalf("new-authority secret update status=%d body=%s", rr.Code, rr.Body.String())
+		}
+		updated, err := app.db.GetSite(site.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newTarget, _ := normalizeTargetURL(updated.TargetURL)
+		policy, err := resolveUpstreamHeaderPolicy(updated.StoredUpstreamHeaders, app.pm.upstreamHeaderKey, newTarget)
+		if err != nil || policy.values.Get("X-Origin-Secret") != newSecret {
+			t.Fatalf("freshly entered secret did not bind to new authority: policy=%#v err=%v", policy, err)
+		}
+		oldTarget, _ := normalizeTargetURL(site.TargetURL)
+		if _, err := resolveUpstreamHeaderPolicy(updated.StoredUpstreamHeaders, app.pm.upstreamHeaderKey, oldTarget); err == nil {
+			t.Fatal("new-authority ciphertext unexpectedly decrypted on the old authority")
+		}
+	})
 }
 
 func lenMust(sites []Site, err error) int {

--- a/security_regression_test.go
+++ b/security_regression_test.go
@@ -1,0 +1,509 @@
+package main
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type securityDeadlineWriter struct {
+	header    http.Header
+	deadlines []time.Time
+}
+
+func (w *securityDeadlineWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *securityDeadlineWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *securityDeadlineWriter) WriteHeader(int) {}
+
+func (w *securityDeadlineWriter) SetReadDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
+}
+
+func startSecurityHostSite(t *testing.T, targetURL, playbackTargetURL, playbackMode, publicHost string) http.Handler {
+	t.Helper()
+	app := newTestApp(t)
+	site, err := app.db.CreateSiteRecord(Site{
+		Name:              "security-regression-site",
+		ListenPort:        freePort(t),
+		PublicHost:        publicHost,
+		IngressMode:       ingressModeHost,
+		TargetURL:         targetURL,
+		PlaybackTargetURL: playbackTargetURL,
+		PlaybackMode:      playbackMode,
+		StreamHosts:       "[]",
+		UAMode:            passthroughUAMode,
+	})
+	if err != nil {
+		t.Fatalf("CreateSiteRecord: %v", err)
+	}
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatalf("StartSite: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := app.pm.StopSite(site.ID); err != nil {
+			t.Errorf("StopSite: %v", err)
+		}
+	})
+	handler, configured := app.pm.PublicHostHandler(publicHost)
+	if !configured || handler == nil {
+		t.Fatalf("public host %q has no active handler", publicHost)
+	}
+	return handler
+}
+
+func TestSecurityRegressionVendorForwardingHeadersAreStrippedFromHTTPAndWebSocket(t *testing.T) {
+	vendorHeaders := []string{
+		"CF-Connecting-IP",
+		"CF-Connecting-IPv6",
+		"Fastly-Client-IP",
+		"Fly-Client-IP",
+		"True-Client-IP",
+		"X-Appengine-User-IP",
+		"X-Azure-ClientIP",
+		"X-Client-IP",
+		"X-Cluster-Client-IP",
+		"X-Envoy-External-Address",
+		"X-Original-Forwarded-For",
+	}
+
+	newRequest := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "http://media.example.com/socket", nil)
+		req.RemoteAddr = "198.51.100.23:45678"
+		for _, name := range vendorHeaders {
+			req.Header.Set(name, "203.0.113.99")
+		}
+		return req
+	}
+	assertSanitized := func(t *testing.T, header http.Header) {
+		t.Helper()
+		for _, name := range vendorHeaders {
+			if got := header.Get(name); got != "" {
+				t.Errorf("%s survived forwarding-header sanitization: %q", name, got)
+			}
+		}
+		for _, name := range []string{"X-Real-IP", "X-Forwarded-For"} {
+			if got := header.Get(name); got != "198.51.100.23" {
+				t.Errorf("%s = %q, want transport peer", name, got)
+			}
+		}
+	}
+
+	t.Run("HTTP", func(t *testing.T) {
+		req := newRequest()
+		header := req.Header.Clone()
+		prepareUpstreamHeaders(header, req, UAHeaderPolicy{})
+		assertSanitized(t, header)
+	})
+
+	t.Run("WebSocket", func(t *testing.T) {
+		req := newRequest()
+		req.Header.Set("Connection", "Upgrade")
+		req.Header.Set("Upgrade", "websocket")
+		target, err := url.Parse("https://origin.example.com/emby")
+		if err != nil {
+			t.Fatal(err)
+		}
+		header := prepareWebSocketUpstreamHeaders(req, target, UAHeaderPolicy{})
+		assertSanitized(t, header)
+	})
+}
+
+func TestSecurityRegressionFixedHeadersRejectAuthAndForwardingIdentity(t *testing.T) {
+	key := bytes.Repeat([]byte{0x5a}, 32)
+	value := "must-not-be-configurable"
+	for _, name := range []string{
+		"X-MediaBrowser-Token",
+		"CF-Connecting-IP",
+		"True-Client-IP",
+		"X-Client-IP",
+		"X-Forwarded-For",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := mergeUpstreamHeaders(
+				"[]",
+				[]UpstreamHeaderInput{{Name: name, Value: &value}},
+				key,
+				"https://origin.example.com/emby",
+			)
+			if err == nil {
+				t.Fatalf("managed header %s was accepted as a fixed upstream header", name)
+			}
+		})
+	}
+}
+
+func TestSecurityRegressionAuthClientKeyNeverTrustsForwardedForChain(t *testing.T) {
+	_, trustedNetwork, err := net.ParseCIDR("172.17.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	trusted := []*net.IPNet{trustedNetwork}
+
+	for _, tc := range []struct {
+		name    string
+		realIP  string
+		wantKey string
+	}{
+		{name: "missing normalized real IP", wantKey: "172.17.0.1"},
+		{name: "invalid normalized real IP", realIP: "not-an-ip", wantKey: "172.17.0.1"},
+		{name: "multiple real IP values", realIP: "203.0.113.25, 198.51.100.7", wantKey: "172.17.0.1"},
+		{name: "valid normalized real IP", realIP: "203.0.113.25", wantKey: "203.0.113.25"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/login", nil)
+			req.RemoteAddr = "172.17.0.1:45678"
+			req.Header.Set("X-Forwarded-For", "198.51.100.77, 203.0.113.25")
+			if tc.realIP != "" {
+				req.Header.Set("X-Real-IP", tc.realIP)
+			}
+			if got := requestClientKey(req, trusted); got != tc.wantKey {
+				t.Fatalf("requestClientKey = %q, want %q", got, tc.wantKey)
+			}
+		})
+	}
+}
+
+func TestSecurityRegressionLoopbackHealthExceptionRejectsForwardedRequests(t *testing.T) {
+	app := &App{pm: NewProxyManager(nil, nil), panelHost: "panel.example.com"}
+	var panelCalls atomic.Int64
+	router := app.publicHostRouter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		panelCalls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	direct := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/api/auth/check", nil)
+	direct.RemoteAddr = "127.0.0.1:54321"
+	directResponse := httptest.NewRecorder()
+	router.ServeHTTP(directResponse, direct)
+	if directResponse.Code != http.StatusNoContent || panelCalls.Load() != 1 {
+		t.Fatalf("direct loopback health check status=%d panel_calls=%d", directResponse.Code, panelCalls.Load())
+	}
+
+	for _, name := range []string{"X-Real-IP", "X-Forwarded-For", "CF-Connecting-IP"} {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:9090/api/auth/check", nil)
+			req.RemoteAddr = "127.0.0.1:54321"
+			req.Header.Set(name, "198.51.100.8")
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+			if rr.Code != http.StatusMisdirectedRequest {
+				t.Fatalf("forwarded loopback health check status=%d, want 421", rr.Code)
+			}
+			if got := panelCalls.Load(); got != 1 {
+				t.Fatalf("forwarded loopback health check reached panel; calls=%d", got)
+			}
+		})
+	}
+}
+
+func TestSecurityRegressionReservedDynamicRouteIsGoneAndNotCacheable(t *testing.T) {
+	app := newTestApp(t)
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	site, err := app.db.CreateSiteRecord(Site{
+		Name:         "reserved-security-regression",
+		ListenPort:   freePort(t),
+		PublicHost:   "reserved-security.example.com",
+		IngressMode:  ingressModeHost,
+		TargetURL:    upstream.URL,
+		PlaybackMode: "direct",
+		StreamHosts:  "[]",
+		UAMode:       "infuse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.pm.StartSite(*site); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := app.pm.StopSite(site.ID); err != nil {
+			t.Errorf("StopSite: %v", err)
+		}
+	})
+
+	handler, configured := app.pm.PublicHostHandler(site.PublicHost)
+	if !configured || handler == nil {
+		t.Fatal("host-only site handler was not registered")
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/_meridian/d/stale-token", nil))
+	if rr.Code != http.StatusGone {
+		t.Fatalf("reserved route status=%d, want 410", rr.Code)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("reserved route Cache-Control=%q, want no-store", got)
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("reserved route reached upstream %d times", got)
+	}
+}
+
+func TestSecurityRegressionDirectPlaybackCredentialsRespectAuthorityBoundary(t *testing.T) {
+	setClientHeaders := func(req *http.Request) {
+		req.Header.Set("Cookie", "emby_session=application-secret; "+sessionCookieName+"=panel-secret")
+		req.Header.Set("Authorization", "Bearer application-bearer")
+		req.Header.Set("X-Emby-Token", "emby-token")
+		req.Header.Set("X-MediaBrowser-Token", "media-browser-token")
+		req.Header.Set("X-Emby-Authorization", `MediaBrowser Device="TV", Token="embedded-token", Client="Security Test", Version="1.0"`)
+		req.Header.Set("X-Api-Key", "arbitrary-api-key")
+		req.Header.Set("Range", "bytes=0-99")
+		req.Header.Set("User-Agent", "Meridian-Security-Test/1.0")
+	}
+
+	t.Run("cross authority strips credentials", func(t *testing.T) {
+		var primaryCalls atomic.Int64
+		primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			primaryCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer primary.Close()
+
+		playbackHeaders := make(chan http.Header, 1)
+		playback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			playbackHeaders <- r.Header.Clone()
+			_, _ = w.Write([]byte("playback"))
+		}))
+		defer playback.Close()
+
+		handler := startSecurityHostSite(
+			t,
+			primary.URL,
+			playback.URL,
+			"direct",
+			"cross-playback-security.example.test",
+		)
+		req := httptest.NewRequest(http.MethodGet, "http://cross-playback-security.example.test/Videos/1/stream", nil)
+		setClientHeaders(req)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("direct playback status=%d body=%q", rr.Code, rr.Body.String())
+		}
+		if got := primaryCalls.Load(); got != 0 {
+			t.Fatalf("playback request reached primary %d times", got)
+		}
+
+		var header http.Header
+		select {
+		case header = <-playbackHeaders:
+		case <-time.After(2 * time.Second):
+			t.Fatal("playback upstream did not receive the request")
+		}
+		for _, name := range []string{
+			"Cookie",
+			"Authorization",
+			"X-Emby-Token",
+			"X-MediaBrowser-Token",
+			"X-Api-Key",
+		} {
+			if got := header.Get(name); got != "" {
+				t.Errorf("cross-authority %s leaked: %q", name, got)
+			}
+		}
+		if got := header.Get("X-Emby-Authorization"); strings.Contains(strings.ToLower(got), "token=") || strings.Contains(got, "embedded-token") {
+			t.Errorf("cross-authority X-Emby-Authorization retained a token: %q", got)
+		}
+		if got := header.Get("Range"); got != "bytes=0-99" {
+			t.Errorf("Range=%q, want bytes=0-99", got)
+		}
+		if got := header.Get("User-Agent"); got != "Meridian-Security-Test/1.0" {
+			t.Errorf("User-Agent=%q, want passthrough value", got)
+		}
+	})
+
+	t.Run("same authority preserves application credentials", func(t *testing.T) {
+		received := make(chan struct {
+			path   string
+			header http.Header
+		}, 1)
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			received <- struct {
+				path   string
+				header http.Header
+			}{path: r.URL.Path, header: r.Header.Clone()}
+			_, _ = w.Write([]byte("playback"))
+		}))
+		defer upstream.Close()
+
+		handler := startSecurityHostSite(
+			t,
+			upstream.URL+"/api",
+			upstream.URL+"/playback",
+			"direct",
+			"same-playback-security.example.test",
+		)
+		req := httptest.NewRequest(http.MethodGet, "http://same-playback-security.example.test/Videos/1/stream", nil)
+		setClientHeaders(req)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("direct playback status=%d body=%q", rr.Code, rr.Body.String())
+		}
+
+		var got struct {
+			path   string
+			header http.Header
+		}
+		select {
+		case got = <-received:
+		case <-time.After(2 * time.Second):
+			t.Fatal("same-authority upstream did not receive the request")
+		}
+		if got.path != "/playback/Videos/1/stream" {
+			t.Errorf("playback path=%q, want /playback/Videos/1/stream", got.path)
+		}
+		if cookie := got.header.Get("Cookie"); !strings.Contains(cookie, "emby_session=application-secret") || strings.Contains(cookie, sessionCookieName) {
+			t.Errorf("same-authority Cookie=%q, want application cookie without panel session", cookie)
+		}
+		for name, want := range map[string]string{
+			"Authorization":        "Bearer application-bearer",
+			"X-Emby-Token":         "emby-token",
+			"X-MediaBrowser-Token": "media-browser-token",
+			"X-Api-Key":            "arbitrary-api-key",
+			"Range":                "bytes=0-99",
+			"User-Agent":           "Meridian-Security-Test/1.0",
+			"X-Emby-Authorization": `MediaBrowser Device="TV", Token="embedded-token", Client="Security Test", Version="1.0"`,
+		} {
+			if value := got.header.Get(name); value != want {
+				t.Errorf("same-authority %s=%q, want %q", name, value, want)
+			}
+		}
+	})
+}
+
+func TestSecurityRegressionCrossAuthorityWebSocketHeadersPreserveHandshakeOnly(t *testing.T) {
+	source := make(http.Header)
+	source.Set("Connection", "keep-alive, Upgrade")
+	source.Set("Upgrade", "websocket")
+	source.Set("Origin", "https://media.example.test")
+	source.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	source.Set("Sec-WebSocket-Version", "13")
+	source.Set("Sec-WebSocket-Protocol", "emby")
+	source.Set("Sec-WebSocket-Extensions", "permessage-deflate")
+	source.Set("Cookie", "emby_session=secret")
+	source.Set("Authorization", "Bearer secret")
+	source.Set("X-Emby-Token", "emby-token")
+	source.Set("X-MediaBrowser-Token", "media-token")
+	source.Set("X-Emby-Authorization", `MediaBrowser Device="TV", Token="embedded-token", Client="Security Test"`)
+	source.Set("X-Api-Key", "arbitrary-secret")
+	source.Set("Range", "bytes=100-199")
+	source.Set("User-Agent", "Meridian-WS-Security-Test/1.0")
+
+	header := crossAuthorityWebSocketHeaders(source)
+	for name, want := range map[string]string{
+		"Connection":               "Upgrade",
+		"Upgrade":                  "websocket",
+		"Origin":                   "https://media.example.test",
+		"Sec-WebSocket-Key":        "dGhlIHNhbXBsZSBub25jZQ==",
+		"Sec-WebSocket-Version":    "13",
+		"Sec-WebSocket-Protocol":   "emby",
+		"Sec-WebSocket-Extensions": "permessage-deflate",
+		"Range":                    "bytes=100-199",
+		"User-Agent":               "Meridian-WS-Security-Test/1.0",
+	} {
+		if got := header.Get(name); got != want {
+			t.Errorf("%s=%q, want %q", name, got, want)
+		}
+	}
+	for _, name := range []string{"Cookie", "Authorization", "X-Emby-Token", "X-MediaBrowser-Token", "X-Api-Key"} {
+		if got := header.Get(name); got != "" {
+			t.Errorf("cross-authority WebSocket %s leaked: %q", name, got)
+		}
+	}
+	if got := header.Get("X-Emby-Authorization"); strings.Contains(strings.ToLower(got), "token=") || strings.Contains(got, "embedded-token") {
+		t.Errorf("cross-authority WebSocket authorization retained a token: %q", got)
+	}
+}
+
+func TestSecurityRegressionInvalidUpgradeNeverReachesUpstream(t *testing.T) {
+	var upstreamCalls atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.Header().Set("Connection", "Upgrade")
+		w.Header().Set("Upgrade", "websocket")
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	}))
+	defer upstream.Close()
+
+	handler := startSecurityHostSite(
+		t,
+		upstream.URL,
+		"",
+		"direct",
+		"upgrade-security.example.test",
+	)
+	for _, tc := range []struct {
+		name       string
+		connection string
+		upgrade    string
+		key        string
+	}{
+		{name: "websocket without key", connection: "Upgrade", upgrade: "websocket"},
+		{name: "unsupported protocol", connection: "keep-alive, Upgrade", upgrade: "h2c", key: "unused-key"},
+		{name: "upgrade header without connection token", connection: "keep-alive", upgrade: "websocket", key: "unused-key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://upgrade-security.example.test/socket", nil)
+			req.Header.Set("Connection", tc.connection)
+			req.Header.Set("Upgrade", tc.upgrade)
+			if tc.key != "" {
+				req.Header.Set("Sec-WebSocket-Key", tc.key)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%q, want 400", rr.Code, rr.Body.String())
+			}
+		})
+	}
+	if got := upstreamCalls.Load(); got != 0 {
+		t.Fatalf("invalid upgrades reached upstream %d times", got)
+	}
+}
+
+func TestSecurityRegressionPanelBodyDeadlineIsNotClearedAfterHandler(t *testing.T) {
+	writer := &securityDeadlineWriter{}
+	handlerCalled := false
+	handler := panelBodyReadDeadline(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "http://panel.example.test/api/auth/login", strings.NewReader(`{"username":"admin"}`))
+	started := time.Now()
+	handler.ServeHTTP(writer, req)
+
+	if !handlerCalled {
+		t.Fatal("wrapped panel handler was not called")
+	}
+	if len(writer.deadlines) != 1 {
+		t.Fatalf("SetReadDeadline calls=%d, want exactly one non-clearing call", len(writer.deadlines))
+	}
+	if writer.deadlines[0].IsZero() {
+		t.Fatal("panel body read deadline was cleared to zero")
+	}
+	if writer.deadlines[0].Before(started.Add(25 * time.Second)) {
+		t.Fatalf("panel body read deadline=%v, want roughly 30 seconds after start", writer.deadlines[0])
+	}
+}

--- a/tests/html_escaping.test.js
+++ b/tests/html_escaping.test.js
@@ -61,6 +61,14 @@ test('diagnostics proxy card escapes listen port and keeps its placeholder', () 
   assert.ok(!html.includes(PAYLOAD), 'proxy.listen_port must not be interpolated raw');
 
   // Pinned so a later switch to diagText cannot silently turn 0 into "0".
-  assert.ok(renderProxyCard({ listen_port: 8096 }, 'stagger-6').includes('>8096<'));
-  assert.ok(renderProxyCard({ listen_port: 0 }, 'stagger-6').includes('>--<'));
+	assert.ok(renderProxyCard({ ingress_mode: 'port', port_listening: true, listen_port: 8096 }, 'stagger-6').includes('>:8096（监听中）<'));
+	assert.ok(renderProxyCard({ ingress_mode: 'port', listen_port: 0 }, 'stagger-6').includes('>:--（未监听）<'));
+});
+
+test('diagnostics proxy card escapes an unknown ingress mode', () => {
+  const { renderProxyCard } = loadScripts('api.js', 'pages/diag.js');
+
+  const html = renderProxyCard({ ingress_mode: PAYLOAD, listen_port: 8096 }, 'stagger-6');
+  assert.ok(!html.includes(PAYLOAD), 'unknown ingress_mode must not be interpolated raw');
+  assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'), 'unknown ingress_mode must be escaped');
 });

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 # This file is a mock harness: the mock functions it defines are invoked
 # indirectly by the sourced install.sh, which ShellCheck cannot statically
 # trace, so every mock body would otherwise look unreachable.
@@ -302,6 +302,50 @@ fi
 assert_eq 'v9.9.9' "$(get_current_version)" 'first installed version'
 assert_file "${DATA_DIR}/.env"
 assert_eq '0.0.0.0' "$(read_env_value PANEL_BIND_ADDR)" 'fresh IP bind'
+upstream_header_key=$(read_env_value UPSTREAM_HEADER_KEY)
+if [ "${#upstream_header_key}" -lt 32 ]; then
+    echo 'FAIL: fresh install must generate UPSTREAM_HEADER_KEY' >&2
+    exit 1
+fi
+
+# Existing valid encryption keys are immutable; an explicitly empty legacy key
+# is repaired, while ambiguous or weak non-empty values fail without rewriting
+# the file.
+key_test_tmp=$(mktemp -d "${TEST_ROOT}/key-test.XXXXXX")
+ensure_upstream_header_key "$key_test_tmp"
+assert_eq "$upstream_header_key" "$(read_env_value UPSTREAM_HEADER_KEY)" 'valid upstream header key is preserved'
+
+awk -F= '$1 == "UPSTREAM_HEADER_KEY" { print "UPSTREAM_HEADER_KEY="; next } { print }' "${DATA_DIR}/.env" > "${key_test_tmp}/empty.env"
+mv "${key_test_tmp}/empty.env" "${DATA_DIR}/.env"
+ensure_upstream_header_key "$key_test_tmp"
+repaired_key=$(read_env_value UPSTREAM_HEADER_KEY)
+if [ "${#repaired_key}" -lt 32 ]; then
+    echo 'FAIL: empty UPSTREAM_HEADER_KEY was not repaired' >&2
+    exit 1
+fi
+
+awk -F= '$1 == "UPSTREAM_HEADER_KEY" { print "UPSTREAM_HEADER_KEY=too-short"; next } { print }' "${DATA_DIR}/.env" > "${key_test_tmp}/short.env"
+mv "${key_test_tmp}/short.env" "${DATA_DIR}/.env"
+short_key_hash=$(sha256_file "${DATA_DIR}/.env")
+if (ensure_upstream_header_key "$key_test_tmp") >"${TEST_ROOT}/short-key.log" 2>&1; then
+    echo 'FAIL: short non-empty UPSTREAM_HEADER_KEY was silently replaced' >&2
+    exit 1
+fi
+assert_eq "$short_key_hash" "$(sha256_file "${DATA_DIR}/.env")" 'short key failure preserves .env'
+
+printf 'UPSTREAM_HEADER_KEY=%s\n' "$repaired_key" >> "${DATA_DIR}/.env"
+duplicate_key_hash=$(sha256_file "${DATA_DIR}/.env")
+if (ensure_upstream_header_key "$key_test_tmp") >"${TEST_ROOT}/duplicate-key.log" 2>&1; then
+    echo 'FAIL: duplicate UPSTREAM_HEADER_KEY definitions were accepted' >&2
+    exit 1
+fi
+assert_eq "$duplicate_key_hash" "$(sha256_file "${DATA_DIR}/.env")" 'duplicate key failure preserves .env'
+
+awk -F= -v key="$repaired_key" '
+    $1 == "UPSTREAM_HEADER_KEY" { if (!seen++) print "UPSTREAM_HEADER_KEY=" key; next }
+    { print }
+' "${DATA_DIR}/.env" > "${key_test_tmp}/restored.env"
+mv "${key_test_tmp}/restored.env" "${DATA_DIR}/.env"
 
 MOCK_LATEST='v9.9.10'
 DOMAIN_MODE='ask'
@@ -339,6 +383,7 @@ if ! (do_update) >"${TEST_ROOT}/update-legacy-setup.log" 2>&1; then
     exit 1
 fi
 [ -n "$(read_env_value SETUP_TOKEN)" ] || { echo 'FAIL: legacy update did not backfill SETUP_TOKEN' >&2; exit 1; }
+[ -n "$(read_env_value UPSTREAM_HEADER_KEY)" ] || { echo 'FAIL: legacy update did not backfill UPSTREAM_HEADER_KEY' >&2; exit 1; }
 assert_contains "${TEST_ROOT}/update-legacy-setup.log" '初始化令牌'
 
 # A newer installed version must never be silently downgraded.

--- a/tests/sites_ingress_mode.test.js
+++ b/tests/sites_ingress_mode.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function loadHelpers() {
+  const source = loadSitesSource();
+  const sandbox = { window: {}, URL, esc: value => String(value) };
+  vm.createContext(sandbox);
+  vm.runInContext(source, sandbox, { filename: 'sites.js' });
+  return sandbox;
+}
+
+function loadSitesSource() {
+  return fs.readFileSync(path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'sites.js'), 'utf8');
+}
+
+test('ingress form exposes the secure host-only mode without a listener', () => {
+  const { ingressFormState } = loadHelpers();
+  const host = ingressFormState('host');
+  assert.equal(host.showPublicHost, true);
+  assert.equal(host.requirePublicHost, true);
+  assert.match(host.portLabel, /保留端口/);
+  assert.match(host.warning, /不会绑定/);
+});
+
+test('ingress payload clears stale host for port mode and preserves it otherwise', () => {
+  const { buildIngressPayload } = loadHelpers();
+  assert.deepEqual(JSON.parse(JSON.stringify(buildIngressPayload('port', '8001', 'stale.example.com'))), {
+    ingress_mode: 'port', listen_port: 8001, public_host: '',
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(buildIngressPayload('host', '8002', ' media.example.com '))), {
+    ingress_mode: 'host', listen_port: 8002, public_host: 'media.example.com',
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(buildIngressPayload('both', '8003', 'media.example.com'))), {
+    ingress_mode: 'both', listen_port: 8003, public_host: 'media.example.com',
+  });
+});
+
+test('new-site ingress defaults follow backend host-only capability', () => {
+  const { defaultIngressMode } = loadHelpers();
+  assert.equal(defaultIngressMode({ host_only_available: true }), 'host');
+  assert.equal(defaultIngressMode({ host_only_available: false }), 'port');
+  assert.equal(defaultIngressMode(undefined), 'host');
+});
+
+test('ingress summary never presents a host-only reserve port as listening', () => {
+  const { renderIngressSummary } = loadHelpers();
+  const hostOnly = renderIngressSummary({ ingress_mode: 'host', public_host: 'media.example.com', listen_port: 8123 });
+  assert.match(hostOnly, /仅共享域名/);
+  assert.match(hostOnly, /media\.example\.com/);
+	assert.match(hostOnly, /Host:/);
+	assert.ok(!hostOnly.includes('https://'));
+  assert.ok(!hostOnly.includes(':8123'));
+
+  const both = renderIngressSummary({ ingress_mode: 'both', public_host: 'media.example.com', listen_port: 8123 });
+  assert.match(both, /:8123/);
+});
+
+test('target authority comparison ignores path and explicit default ports', () => {
+  const { normalizedTargetAuthority } = loadHelpers();
+	assert.equal(normalizedTargetAuthority('https://origin.example.com/emby'), 'https://origin.example.com:443');
+	assert.equal(normalizedTargetAuthority('https://origin.example.com:443/other'), 'https://origin.example.com:443');
+	assert.equal(normalizedTargetAuthority('origin.example.com:443/other'), 'https://origin.example.com:443');
+  assert.notEqual(normalizedTargetAuthority('https://origin.example.com'), normalizedTargetAuthority('https://other.example.com'));
+});
+
+test('site modal always loads deployment capabilities for create and edit flows', () => {
+  const source = loadSitesSource();
+  const start = source.indexOf('async function showSiteModal(site)');
+  const end = source.indexOf('// Global actions', start);
+  const modalSource = source.slice(start, end);
+
+  assert.match(modalSource, /normalizeSiteCapabilities\(await API\.ingressCapabilities\(\)\)/);
+  assert.doesNotMatch(modalSource, /if \(!isEdit\)[\s\S]{0,200}ingressCapabilities/);
+});
+
+test('stream host normalization accepts the array API and legacy JSON strings', () => {
+  const { normalizeStreamHosts, renderPlaybackRow } = loadHelpers();
+  assert.deepEqual(JSON.parse(JSON.stringify(normalizeStreamHosts([' one.example ', '', 42, 'two.example']))), [
+    'one.example',
+    'two.example',
+  ]);
+  assert.deepEqual(JSON.parse(JSON.stringify(normalizeStreamHosts('[" legacy-one.example ","legacy-two.example"]'))), [
+    'legacy-one.example',
+    'legacy-two.example',
+  ]);
+  assert.deepEqual(JSON.parse(JSON.stringify(normalizeStreamHosts('{'))), []);
+
+  const html = renderPlaybackRow({
+    playback_target_url: 'https://primary.example',
+    stream_hosts: ['https://array-extra.example'],
+    playback_mode: 'redirect',
+  });
+  assert.match(html, /array-extra\.example/);
+});
+
+test('playback limit follows backend capabilities and has a safe compatibility default', () => {
+  const { normalizeSiteCapabilities, canAddPlaybackAddress } = loadHelpers();
+  const configured = normalizeSiteCapabilities({
+    host_only_available: false,
+    upstream_headers_available: false,
+    max_playback_addresses: 100,
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(configured)), {
+    host_only_available: false,
+    upstream_headers_available: false,
+    max_playback_addresses: 100,
+  });
+  assert.equal(canAddPlaybackAddress(99, configured.max_playback_addresses), true);
+  assert.equal(canAddPlaybackAddress(100, configured.max_playback_addresses), false);
+
+  const fallback = normalizeSiteCapabilities({});
+  assert.equal(fallback.host_only_available, true);
+  assert.equal(fallback.upstream_headers_available, true);
+  assert.equal(fallback.max_playback_addresses, 128);
+});
+
+test('missing upstream header key disables edits but leaves deletion available', () => {
+  const { renderUpstreamHeaderRows } = loadHelpers();
+  const disabled = renderUpstreamHeaderRows([
+    { name: 'X-Origin-Secret', configured: true },
+  ], false);
+  assert.equal((disabled.match(/ disabled/g) || []).length, 2, 'name and value inputs must be disabled');
+  const removeButton = disabled.match(/<button[^>]*m-upstream-header-remove[^>]*>/)?.[0] || '';
+  assert.ok(removeButton, 'configured row must retain a delete control');
+  assert.ok(!removeButton.includes('disabled'), 'delete control must remain enabled');
+
+  const enabled = renderUpstreamHeaderRows([
+    { name: 'X-Origin-Secret', configured: true },
+  ], true);
+  assert.ok(!enabled.includes(' disabled'), 'configured key must keep inputs editable');
+});

--- a/tests/sites_ua_mode.test.js
+++ b/tests/sites_ua_mode.test.js
@@ -94,6 +94,20 @@ test('passthrough payload clears the custom triplet', () => {
   assert.equal(payload.custom_version, '');
 });
 
+test('upstream header payload keeps configured rows write-only', () => {
+	const { buildUpstreamHeaderPayload } = loadSiteHelpers();
+	const payload = buildUpstreamHeaderPayload([
+		{ name: ' EMOS-PROXY-ID ', value: '', configured: true },
+		{ name: ' X-New-Header ', value: ' new-value ', configured: false },
+		{ name: '', value: '', configured: false },
+	]);
+
+	assert.deepEqual(JSON.parse(JSON.stringify(payload)), [
+		{ name: 'EMOS-PROXY-ID', value: '' },
+		{ name: 'X-New-Header', value: 'new-value' },
+	]);
+});
+
 test('passthrough mode label maps to 透传 with an existing pill class', () => {
   const sandbox = loadPageScripts('pages/dashboard.js', 'pages/sites.js');
   const { uaNameMap, uaClassMap } = vm.runInContext('({ uaNameMap, uaClassMap })', sandbox);

--- a/tests/upstream_header_key_test.sh
+++ b/tests/upstream_header_key_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+export MERIDIAN_DATA_DIR="${TEST_ROOT}/data"
+mkdir -p "$MERIDIAN_DATA_DIR"
+
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/install.sh"
+
+as_root() { command "$@"; }
+is_systemd() { return 1; }
+install_env_file() {
+    cp "$1" "$(env_file_path)"
+    chmod 0600 "$(env_file_path)"
+}
+
+work_dir="${TEST_ROOT}/work"
+mkdir -p "$work_dir"
+valid_key=$(printf 'a%.0s' {1..64})
+printf 'JWT_SECRET=test\nUPSTREAM_HEADER_KEY=%s\nPORT=9090\n' "$valid_key" > "${MERIDIAN_DATA_DIR}/.env"
+
+ensure_upstream_header_key "$work_dir"
+[ "$(read_env_value UPSTREAM_HEADER_KEY)" = "$valid_key" ] || {
+    echo 'FAIL: valid UPSTREAM_HEADER_KEY changed' >&2
+    exit 1
+}
+
+printf 'JWT_SECRET=test\nUPSTREAM_HEADER_KEY=\nPORT=9090\n' > "${MERIDIAN_DATA_DIR}/.env"
+ensure_upstream_header_key "$work_dir"
+repaired_key=$(read_env_value UPSTREAM_HEADER_KEY)
+[ "${#repaired_key}" -ge 32 ] || {
+    echo 'FAIL: empty UPSTREAM_HEADER_KEY was not repaired' >&2
+    exit 1
+}
+
+printf 'JWT_SECRET=test\nUPSTREAM_HEADER_KEY=too-short\nPORT=9090\n' > "${MERIDIAN_DATA_DIR}/.env"
+before=$(sha256_file "${MERIDIAN_DATA_DIR}/.env")
+if (ensure_upstream_header_key "$work_dir") >/dev/null 2>&1; then
+    echo 'FAIL: short UPSTREAM_HEADER_KEY was accepted' >&2
+    exit 1
+fi
+[ "$(sha256_file "${MERIDIAN_DATA_DIR}/.env")" = "$before" ] || {
+    echo 'FAIL: rejected short key changed .env' >&2
+    exit 1
+}
+
+printf 'JWT_SECRET=test\nUPSTREAM_HEADER_KEY=%s  \nPORT=9090\n' "$valid_key" > "${MERIDIAN_DATA_DIR}/.env"
+before=$(sha256_file "${MERIDIAN_DATA_DIR}/.env")
+if (ensure_upstream_header_key "$work_dir") >/dev/null 2>&1; then
+    echo 'FAIL: whitespace-containing UPSTREAM_HEADER_KEY was accepted' >&2
+    exit 1
+fi
+[ "$(sha256_file "${MERIDIAN_DATA_DIR}/.env")" = "$before" ] || {
+    echo 'FAIL: rejected whitespace-containing key changed .env' >&2
+    exit 1
+}
+
+printf 'JWT_SECRET=test\nUPSTREAM_HEADER_KEY=%s\nUPSTREAM_HEADER_KEY=%s\nPORT=9090\n' "$valid_key" "$valid_key" > "${MERIDIAN_DATA_DIR}/.env"
+before=$(sha256_file "${MERIDIAN_DATA_DIR}/.env")
+if (ensure_upstream_header_key "$work_dir") >/dev/null 2>&1; then
+    echo 'FAIL: duplicate UPSTREAM_HEADER_KEY was accepted' >&2
+    exit 1
+fi
+[ "$(sha256_file "${MERIDIAN_DATA_DIR}/.env")" = "$before" ] || {
+    echo 'FAIL: rejected duplicate key changed .env' >&2
+    exit 1
+}
+
+echo 'upstream header key tests passed'

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.6.1">
-<link rel="stylesheet" href="/css/style.css?v=1.6.1">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.7.0">
+<link rel="stylesheet" href="/css/style.css?v=1.7.0">
 </head>
 <body>
 
@@ -101,13 +101,13 @@
 
 </div>
 
-<script src="/js/api.js?v=1.6.1"></script>
-<script src="/js/toast.js?v=1.6.1"></script>
-<script src="/js/router.js?v=1.6.1"></script>
-<script src="/js/pages/dashboard.js?v=1.6.1"></script>
-<script src="/js/pages/sites.js?v=1.6.1"></script>
-<script src="/js/pages/traffic.js?v=1.6.1"></script>
-<script src="/js/pages/diag.js?v=1.6.1"></script>
-<script src="/js/app.js?v=1.6.1"></script>
+<script src="/js/api.js?v=1.7.0"></script>
+<script src="/js/toast.js?v=1.7.0"></script>
+<script src="/js/router.js?v=1.7.0"></script>
+<script src="/js/pages/dashboard.js?v=1.7.0"></script>
+<script src="/js/pages/sites.js?v=1.7.0"></script>
+<script src="/js/pages/traffic.js?v=1.7.0"></script>
+<script src="/js/pages/diag.js?v=1.7.0"></script>
+<script src="/js/app.js?v=1.7.0"></script>
 </body>
 </html>

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -57,6 +57,7 @@ const API = {
   dashboard() { return this.request('GET', '/api/dashboard'); },
 
   // Sites
+  ingressCapabilities() { return this.request('GET', '/api/ingress-capabilities'); },
   listSites() { return this.request('GET', '/api/sites'); },
   createSite(data) { return this.request('POST', '/api/sites', data); },
   updateSite(id, data) { return this.request('PUT', '/api/sites/' + id, data); },

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -45,7 +45,7 @@ function renderDashboard() {
       <div style="overflow-x:auto">
         <table>
           <thead><tr>
-            <th>站点</th><th>状态</th><th>回源地址</th><th>UA 模式</th><th>端口</th><th>已用流量</th>
+            <th>站点</th><th>状态</th><th>回源地址</th><th>UA 模式</th><th>入口</th><th>已用流量</th>
           </tr></thead>
           <tbody id="dash-table"></tbody>
         </table>
@@ -192,13 +192,20 @@ async function loadDashboardTable() {
         <td><span class="status-badge"><span class="status-led ${s.running ? 'on' : 'off'}"></span>${s.running ? '运行中' : '已停止'}</span></td>
         <td class="mono">${esc(s.target_url)}</td>
         <td><span class="pill ${uaClassMap[s.ua_mode] || 'pill-blue'}">${esc(uaNameMap[s.ua_mode] || s.ua_mode)}</span></td>
-        <td class="mono">:${s.listen_port}</td>
+		<td class="mono">${dashboardIngressLabel(s)}</td>
         <td>${formatBytes(s.traffic_used)}</td>
       </tr>
     `).join('');
   } catch (e) {
     console.error('Dashboard table load error:', e);
   }
+}
+
+function dashboardIngressLabel(site) {
+	const mode = String(site.ingress_mode || (site.public_host ? 'host' : 'port')).toLowerCase();
+	if (mode === 'host') return `Host: ${esc(site.public_host || '')}`;
+	if (mode === 'both') return `Host + :${site.listen_port}`;
+	return `:${site.listen_port}`;
 }
 
 async function loadDashboardData() {

--- a/web/static/js/pages/diag.js
+++ b/web/static/js/pages/diag.js
@@ -206,6 +206,14 @@ function renderHeadersCard(headers, staggerClass) {
 }
 
 function renderProxyCard(proxy, staggerClass) {
+	const mode = String(proxy.ingress_mode || (proxy.public_host ? 'host' : 'port')).toLowerCase();
+	const modeLabel = { port: '仅独立端口', host: '仅共享域名', both: '共享域名 + 独立端口' }[mode] || mode;
+	const hostRow = proxy.public_host
+	  ? `<div class="diag-row"><span class="diag-key">共享域名</span><span class="diag-val">${esc(proxy.public_host)}</span></div>`
+	  : '';
+	const portValue = proxy.port_listening
+	  ? `:${esc(proxy.listen_port || '--')}（监听中）`
+	  : mode === 'host' ? `:${esc(proxy.listen_port || '--')}（仅保留，未监听）` : `:${esc(proxy.listen_port || '--')}（未监听）`;
   return `
     <div class="diag-card fade-up ${staggerClass}">
       <div class="diag-head">
@@ -218,8 +226,10 @@ function renderProxyCard(proxy, staggerClass) {
         </div>
       </div>
       <div class="diag-rows">
-        <div class="diag-row"><span class="diag-key">代理运行</span><span class="diag-val ${proxy.running ? 'good' : 'bad'}">${proxy.running ? '运行中' : '已停止'}</span></div>
-        <div class="diag-row"><span class="diag-key">监听端口</span><span class="diag-val">${esc(proxy.listen_port || '--')}</span></div>
+		<div class="diag-row"><span class="diag-key">代理运行</span><span class="diag-val ${proxy.running ? 'good' : 'bad'}">${proxy.running ? '运行中' : '已停止'}</span></div>
+			<div class="diag-row"><span class="diag-key">入口模式</span><span class="diag-val">${esc(modeLabel)}</span></div>
+		${hostRow}
+		<div class="diag-row"><span class="diag-key">端口状态</span><span class="diag-val">${portValue}</span></div>
         <div class="diag-row"><span class="diag-key">总请求数</span><span class="diag-val">${typeof proxy.total_requests === 'number' ? proxy.total_requests : '--'}</span></div>
       </div>
     </div>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -29,10 +29,12 @@ async function loadSites() {
       return;
     }
 
-    grid.innerHTML = sites.map((s, i) => {
+	grid.innerHTML = sites.map((s, i) => {
       const pct = s.traffic_quota > 0 ? (s.traffic_used / s.traffic_quota * 100).toFixed(1) : 0;
       const pctClass = pct > 85 ? 'danger' : pct > 50 ? 'warn' : 'normal';
-      const playbackRow = renderPlaybackRow(s);
+		const playbackRow = renderPlaybackRow(s);
+		const upstreamHeaderCount = Array.isArray(s.upstream_headers) ? s.upstream_headers.length : 0;
+		const ingressRows = renderIngressSummary(s);
 
       return `
       <div class="site-card fade-up stagger-${Math.min(i + 1, 6)}">
@@ -49,10 +51,12 @@ async function loadSites() {
             <span class="mono">${esc(s.target_url)}</span>
           </div>
           ${playbackRow}
-          <div class="site-row">
-            <span class="site-row-label">监听端口</span>
-            <span class="mono">:${s.listen_port}</span>
-          </div>
+		  ${ingressRows}
+		  ${upstreamHeaderCount > 0 ? `
+		  <div class="site-row">
+			<span class="site-row-label">上游请求头</span>
+			<span>${upstreamHeaderCount} 个（加密）</span>
+		  </div>` : ''}
           <div class="site-row">
             <span class="site-row-label">UA 模式</span>
             <span class="pill ${uaClassMap[s.ua_mode] || 'pill-blue'}">${esc(uaNameMap[s.ua_mode] || s.ua_mode)}</span>
@@ -100,8 +104,7 @@ async function loadSites() {
 
 function renderPlaybackRow(site) {
   const playback = (site.playback_target_url || '').trim();
-  let extraHosts = [];
-  try { extraHosts = JSON.parse(site.stream_hosts || '[]'); } catch(e) {}
+  const extraHosts = normalizeStreamHosts(site.stream_hosts);
   const totalHosts = (playback ? 1 : 0) + extraHosts.length;
 
   if (totalHosts === 0) {
@@ -172,9 +175,148 @@ function buildCustomUAPayload(mode, customUserAgent, customClient, customVersion
   };
 }
 
-function showSiteModal(site) {
+function buildUpstreamHeaderPayload(headers) {
+	return headers
+		.filter(header => header.configured || String(header.name || '').trim() || String(header.value || '').trim())
+		.map(header => ({
+			name: String(header.name || '').trim(),
+			value: String(header.value || '').trim(),
+		}));
+}
+
+const DEFAULT_MAX_PLAYBACK_ADDRESSES = 128;
+
+function normalizeStreamHosts(value) {
+	let hosts = value;
+	if (typeof hosts === 'string') {
+		try {
+			hosts = JSON.parse(hosts || '[]');
+		} catch (_) {
+			return [];
+		}
+	}
+	if (!Array.isArray(hosts)) return [];
+	return hosts
+		.filter(host => typeof host === 'string' && host.trim())
+		.map(host => host.trim());
+}
+
+function normalizeSiteCapabilities(value) {
+	const capabilities = value && typeof value === 'object' ? value : {};
+	const requestedMax = Number(capabilities.max_playback_addresses);
+	return {
+		host_only_available: capabilities.host_only_available !== false,
+		upstream_headers_available: capabilities.upstream_headers_available !== false,
+		max_playback_addresses: Number.isInteger(requestedMax) && requestedMax > 0
+			? requestedMax
+			: DEFAULT_MAX_PLAYBACK_ADDRESSES,
+	};
+}
+
+function canAddPlaybackAddress(currentCount, maxPlaybackAddresses) {
+	return currentCount < maxPlaybackAddresses;
+}
+
+function renderUpstreamHeaderRows(headers, upstreamHeadersAvailable) {
+	return headers.map((header, idx) => `
+		<div style="display:flex;gap:6px;margin-bottom:6px;align-items:center">
+		  <input type="text" class="form-input m-upstream-header-name" data-idx="${idx}" value="${esc(header.name)}" placeholder="Header 名称" maxlength="64" autocapitalize="none" autocorrect="off" spellcheck="false" style="flex:1" ${upstreamHeadersAvailable ? '' : 'disabled'}>
+		  <input type="password" class="form-input m-upstream-header-value" data-idx="${idx}" value="" placeholder="${header.configured ? '已配置；留空保持不变' : 'Header 值'}" maxlength="1024" autocomplete="new-password" style="flex:1" ${upstreamHeadersAvailable ? '' : 'disabled'}>
+		  <button type="button" class="btn-ghost danger m-upstream-header-remove" data-idx="${idx}" style="padding:4px 8px;font-size:13px;flex-shrink:0">删除</button>
+		</div>
+	`).join('');
+}
+
+function normalizedIngressMode(site) {
+	const mode = String((site && site.ingress_mode) || '').trim().toLowerCase();
+	if (mode === 'port' || mode === 'host' || mode === 'both') return mode;
+	return site && String(site.public_host || '').trim() ? 'host' : 'port';
+}
+
+function ingressFormState(mode) {
+	const normalized = ['port', 'host', 'both'].includes(mode) ? mode : 'host';
+	return {
+		mode: normalized,
+		showPublicHost: normalized !== 'port',
+		requirePublicHost: normalized !== 'port',
+		portLabel: normalized === 'host' ? '保留端口（此模式不监听）' : '监听端口',
+		warning: normalized === 'both'
+			? '此模式会同时开放独立高端口；若前方使用 CDN，请用防火墙限制该端口，避免绕过 CDN。'
+			: normalized === 'port'
+				? '独立端口会绑定所有网络接口；公网部署时请配置防火墙。'
+				: '仅通过共享 Host 入口代理，不会绑定保留端口；要求面板绑定回环地址，或用 TRUSTED_PROXY_CIDRS 限定可信入口来源。',
+	};
+}
+
+function buildIngressPayload(mode, port, publicHost) {
+	const state = ingressFormState(mode);
+	return {
+		ingress_mode: state.mode,
+		listen_port: parseInt(port),
+		public_host: state.showPublicHost ? String(publicHost || '').trim() : '',
+	};
+}
+
+function defaultIngressMode(capabilities) {
+	return capabilities && capabilities.host_only_available === false ? 'port' : 'host';
+}
+
+function renderIngressSummary(site) {
+	const mode = normalizedIngressMode(site);
+	const labels = { port: '仅独立端口', host: '仅共享域名', both: '共享域名 + 独立端口' };
+	let rows = `
+	  <div class="site-row">
+		<span class="site-row-label">入口模式</span>
+		<span>${labels[mode]}</span>
+	  </div>`;
+	if (mode === 'port' || mode === 'both') {
+		rows += `
+	  <div class="site-row">
+		<span class="site-row-label">监听端口</span>
+		<span class="mono">:${site.listen_port}</span>
+	  </div>`;
+	}
+	if (mode === 'host' || mode === 'both') {
+		rows += `
+	  <div class="site-row">
+		<span class="site-row-label">共享入口</span>
+		<span class="mono">Host: ${esc(site.public_host || '')}</span>
+	  </div>`;
+	}
+	return rows;
+}
+
+function normalizedTargetAuthority(value) {
+	let candidate = String(value || '').trim().replaceAll('：', ':');
+	if (!candidate) return '';
+	if (!candidate.includes('://')) {
+		const authority = candidate.split(/[/?#]/, 1)[0];
+		candidate = authority.endsWith(':443') ? `https://${candidate}` : `http://${candidate}`;
+	}
+	try {
+		const parsed = new URL(candidate);
+		const scheme = parsed.protocol.toLowerCase();
+		if (scheme !== 'http:' && scheme !== 'https:') return '';
+		const defaultPort = scheme === 'https:' ? '443' : '80';
+		return `${scheme}//${parsed.hostname.toLowerCase()}:${parsed.port || defaultPort}`;
+	} catch (_) {
+		return '';
+	}
+}
+
+async function showSiteModal(site) {
   const isEdit = !!site;
   const title = isEdit ? '编辑站点' : '添加站点';
+	let siteCapabilities;
+	try {
+		siteCapabilities = normalizeSiteCapabilities(await API.ingressCapabilities());
+	} catch (error) {
+		Toast.error(`无法读取站点能力：${error.message}`);
+		return;
+	}
+	const hostOnlyAvailable = siteCapabilities.host_only_available;
+	const upstreamHeadersAvailable = siteCapabilities.upstream_headers_available;
+	const maxPlaybackAddresses = siteCapabilities.max_playback_addresses;
 
   document.getElementById('modal-title').textContent = title;
   document.getElementById('modal-body').innerHTML = `
@@ -191,7 +333,7 @@ function showSiteModal(site) {
       <label>播放回源列表（可选，留空跟随主回源）</label>
       <div id="m-playback-list"></div>
       <button type="button" class="btn-ghost" id="m-add-playback" style="margin-top:6px;font-size:13px">+ 添加播放回源</button>
-      <div class="form-help">播放、转码或直链资源的独立上游地址。可添加多个；未写协议时，:443 自动使用 HTTPS。</div>
+      <div class="form-help">第一个地址是实际播放回源；额外地址仅作为重定向模式的允许列表，不会自动探测、轮询或故障转移（最多 ${maxPlaybackAddresses} 个）。未写协议时，:443 自动使用 HTTPS。</div>
     </div>
     <div class="form-group" id="playback-mode-group" style="display:none">
       <label>播放模式</label>
@@ -201,10 +343,32 @@ function showSiteModal(site) {
       </select>
       <div class="form-help">直连分流：播放请求直接发送到首个播放回源（适合完整 Emby 实例）。重定向跟随：所有请求经主回源，自动跟随重定向到任一播放回源（适合多节点 CDN）。</div>
     </div>
-    <div class="form-group">
-      <label>监听端口</label>
-      <input type="number" class="form-input" id="m-port" value="${isEdit ? site.listen_port : ''}" placeholder="如：8001" min="1" max="65535" inputmode="numeric" required>
-    </div>
+	<div class="form-group">
+	  <label>入口模式</label>
+	  <select class="form-select modal-select" id="m-ingress-mode">
+		<option value="host" ${hostOnlyAvailable ? '' : 'disabled'}>仅共享域名（推荐${hostOnlyAvailable ? '' : '，当前部署不可用'}）</option>
+		<option value="port">仅独立端口</option>
+		<option value="both">共享域名 + 独立端口（高风险）</option>
+	  </select>
+	  <div class="form-help" id="m-ingress-warning"></div>
+	  ${hostOnlyAvailable ? '' : '<div class="form-help">当前面板既未绑定回环地址，也没有可信代理来源白名单；请先设置 PANEL_BIND_ADDR 或 TRUSTED_PROXY_CIDRS 并重启，才能启用仅共享域名。</div>'}
+	</div>
+	<div class="form-group" id="m-port-group">
+	  <label id="m-port-label">监听端口</label>
+	  <input type="number" class="form-input" id="m-port" value="${isEdit ? site.listen_port : ''}" placeholder="如：8001" min="1" max="65535" inputmode="numeric" required>
+	</div>
+	<div class="form-group" id="m-public-host-group">
+	  <label>共享入口域名</label>
+	  <input type="text" class="form-input" id="m-public-host" value="${isEdit ? esc(site.public_host || '') : ''}" placeholder="如：emby.example.com" autocapitalize="none" autocorrect="off" spellcheck="false" maxlength="253">
+	  <div class="form-help">通过面板监听入口按精确 Host 转发到本站点。只填域名，不填协议、端口、路径或通配符。</div>
+	</div>
+		<div class="form-group">
+		  <label>主回源固定请求头（可选）</label>
+		  <div id="m-upstream-headers"></div>
+		  <button type="button" class="btn-ghost" id="m-add-upstream-header" style="margin-top:6px;font-size:13px" ${upstreamHeadersAvailable ? '' : 'disabled'}>+ 添加请求头</button>
+		  <div class="form-help">值使用 UPSTREAM_HEADER_KEY 加密保存且不会回显，只发送给主回源的精确协议、域名和端口；更换主回源的协议、域名或端口后必须重新输入这些值。</div>
+		  ${upstreamHeadersAvailable ? '' : '<div class="form-help" style="color:var(--orange)">当前部署未配置 UPSTREAM_HEADER_KEY，不能新增、重命名或修改 Header 值；仍可删除旧配置。配置密钥并重启后可恢复编辑。</div>'}
+		</div>
     <div class="form-group">
       <label>UA 模式</label>
       <select class="form-select modal-select" id="m-ua">
@@ -238,9 +402,25 @@ function showSiteModal(site) {
     <button class="btn-modal primary" id="m-submit">${isEdit ? '保存' : '创建'}</button>
   `;
 
-  document.getElementById('m-cancel').addEventListener('click', closeModal);
+	document.getElementById('m-cancel').addEventListener('click', closeModal);
 
-  const uaSelect = document.getElementById('m-ua');
+	const ingressSelect = document.getElementById('m-ingress-mode');
+	const publicHostGroup = document.getElementById('m-public-host-group');
+	const publicHostInput = document.getElementById('m-public-host');
+	const portLabel = document.getElementById('m-port-label');
+	const ingressWarning = document.getElementById('m-ingress-warning');
+	ingressSelect.value = isEdit ? normalizedIngressMode(site) : defaultIngressMode(siteCapabilities);
+	function updateIngressFields() {
+		const state = ingressFormState(ingressSelect.value);
+		publicHostGroup.hidden = !state.showPublicHost;
+		publicHostInput.required = state.requirePublicHost;
+		portLabel.textContent = state.portLabel;
+		ingressWarning.textContent = state.warning;
+	}
+	updateIngressFields();
+	ingressSelect.addEventListener('change', updateIngressFields);
+
+	const uaSelect = document.getElementById('m-ua');
   const customUAGroup = document.getElementById('m-custom-ua-group');
   const customUAInputs = [
     document.getElementById('m-custom-ua'),
@@ -266,15 +446,19 @@ function showSiteModal(site) {
   // Build initial playback list from existing data
   const listContainer = document.getElementById('m-playback-list');
   const modeGroup = document.getElementById('playback-mode-group');
+  const addPlaybackButton = document.getElementById('m-add-playback');
   let existingHosts = [];
   if (isEdit) {
     if ((site.playback_target_url || '').trim()) existingHosts.push(site.playback_target_url.trim());
-    try {
-      const extra = JSON.parse(site.stream_hosts || '[]');
-      for (const h of extra) if (h && h.trim()) existingHosts.push(h.trim());
-    } catch(e) {}
+    for (const host of normalizeStreamHosts(site.stream_hosts)) existingHosts.push(host);
   }
   if (existingHosts.length === 0) existingHosts = [''];
+
+  function updatePlaybackAddState() {
+    const canAdd = canAddPlaybackAddress(existingHosts.length, maxPlaybackAddresses);
+    addPlaybackButton.disabled = !canAdd;
+    addPlaybackButton.title = canAdd ? '' : `每个站点最多配置 ${maxPlaybackAddresses} 个播放回源`;
+  }
 
   function renderPlaybackInputs() {
     listContainer.innerHTML = existingHosts.map((val, idx) => `
@@ -293,10 +477,15 @@ function showSiteModal(site) {
     listContainer.querySelectorAll('.m-pb-input').forEach((inp, idx) => {
       inp.oninput = () => { existingHosts[idx] = inp.value; toggleModeGroup(); };
     });
+    updatePlaybackAddState();
   }
   renderPlaybackInputs();
 
-  document.getElementById('m-add-playback').onclick = () => {
+  addPlaybackButton.onclick = () => {
+    if (!canAddPlaybackAddress(existingHosts.length, maxPlaybackAddresses)) {
+      Toast.error(`每个站点最多配置 ${maxPlaybackAddresses} 个播放回源`);
+      return;
+    }
     existingHosts.push('');
     renderPlaybackInputs();
     const inputs = listContainer.querySelectorAll('.m-pb-input');
@@ -309,8 +498,50 @@ function showSiteModal(site) {
   }
   toggleModeGroup();
 
+  const upstreamHeadersContainer = document.getElementById('m-upstream-headers');
+  let upstreamHeaders = isEdit && Array.isArray(site.upstream_headers)
+    ? site.upstream_headers.map(header => ({ name: header.name || '', value: '', configured: !!header.configured }))
+    : [];
+
+  function renderUpstreamHeaders() {
+    upstreamHeadersContainer.innerHTML = renderUpstreamHeaderRows(upstreamHeaders, upstreamHeadersAvailable);
+    upstreamHeadersContainer.querySelectorAll('.m-upstream-header-name').forEach(input => {
+      input.oninput = () => { upstreamHeaders[Number(input.dataset.idx)].name = input.value; };
+    });
+    upstreamHeadersContainer.querySelectorAll('.m-upstream-header-value').forEach(input => {
+      input.oninput = () => { upstreamHeaders[Number(input.dataset.idx)].value = input.value; };
+    });
+    upstreamHeadersContainer.querySelectorAll('.m-upstream-header-remove').forEach(button => {
+      button.onclick = () => {
+        upstreamHeaders.splice(Number(button.dataset.idx), 1);
+        renderUpstreamHeaders();
+      };
+    });
+  }
+  renderUpstreamHeaders();
+
+  const addUpstreamHeaderButton = document.getElementById('m-add-upstream-header');
+  addUpstreamHeaderButton.onclick = () => {
+    if (!upstreamHeadersAvailable) {
+      Toast.error('请先配置 UPSTREAM_HEADER_KEY 并重启 Meridian');
+      return;
+    }
+    if (upstreamHeaders.length >= 16) {
+      Toast.error('每个站点最多配置 16 个上游请求头');
+      return;
+    }
+    upstreamHeaders.push({ name: '', value: '', configured: false });
+    renderUpstreamHeaders();
+    const inputs = upstreamHeadersContainer.querySelectorAll('.m-upstream-header-name');
+    if (inputs.length) inputs[inputs.length - 1].focus();
+  };
+
   document.getElementById('m-submit').onclick = async () => {
     const allHosts = existingHosts.map(h => h.trim()).filter(Boolean);
+    if (allHosts.length > maxPlaybackAddresses) {
+      Toast.error(`每个站点最多配置 ${maxPlaybackAddresses} 个播放回源`);
+      return;
+    }
     const uaMode = uaSelect.value;
     const customUAPayload = buildCustomUAPayload(
       uaMode,
@@ -318,27 +549,50 @@ function showSiteModal(site) {
       customUAInputs[1].value,
       customUAInputs[2].value,
     );
-    const data = {
-      name: document.getElementById('m-name').value.trim(),
-      target_url: document.getElementById('m-target').value.trim(),
+		const ingressPayload = buildIngressPayload(
+		  ingressSelect.value,
+		  document.getElementById('m-port').value,
+		  publicHostInput.value,
+		);
+		const data = {
+	      name: document.getElementById('m-name').value.trim(),
+	      target_url: document.getElementById('m-target').value.trim(),
       playback_target_url: allHosts.length > 0 ? allHosts[0] : '',
       playback_mode: document.getElementById('m-playback-mode').value,
-      stream_hosts: allHosts.length > 1 ? allHosts.slice(1) : [],
-      listen_port: parseInt(document.getElementById('m-port').value),
+		stream_hosts: allHosts.length > 1 ? allHosts.slice(1) : [],
+			...ingressPayload,
+		upstream_headers: buildUpstreamHeaderPayload(upstreamHeaders),
       ua_mode: uaMode,
       ...customUAPayload,
       traffic_quota: parseInt(document.getElementById('m-quota').value || 0) * 1073741824,
       speed_limit: parseInt(document.getElementById('m-speed').value || 0),
     };
 
-    if (!data.name || !data.target_url || !data.listen_port) {
-      Toast.error('请填写所有必填项');
-      return;
-    }
-    if (uaMode === 'custom' && (!data.custom_user_agent || !data.custom_client || !data.custom_version)) {
+		if (!data.name || !data.target_url || !data.listen_port || ((data.ingress_mode === 'host' || data.ingress_mode === 'both') && !data.public_host)) {
+	      Toast.error('请填写所有必填项');
+	      return;
+	    }
+	  if (uaMode === 'custom' && (!data.custom_user_agent || !data.custom_client || !data.custom_version)) {
       Toast.error('请完整填写自定义 User-Agent、Client 和 Version');
-      return;
-    }
+		return;
+	  }
+	  const invalidHeader = upstreamHeaders.some(header => {
+		const name = String(header.name || '').trim();
+		const value = String(header.value || '').trim();
+		if (!header.configured && !name && !value) return false;
+		return !name || (!header.configured && !value);
+	  });
+		if (invalidHeader) {
+			Toast.error('请完整填写新增请求头的名称和值；已有值可留空保持不变');
+			return;
+		}
+		if (isEdit && normalizedTargetAuthority(site.target_url) !== normalizedTargetAuthority(data.target_url)) {
+			const retainedSecret = upstreamHeaders.some(header => header.configured && !String(header.value || '').trim());
+			if (retainedSecret) {
+				Toast.error('主回源的协议、域名或端口已变化，请重新输入每个已配置的固定请求头，或删除对应行');
+				return;
+			}
+		}
 
     try {
       if (isEdit) {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -115,7 +116,7 @@ func newWSProxyServer(t *testing.T, upstreamAddr string, inst *ProxyInstance, sp
 		t.Fatalf("normalizeTargetURL: %v", err)
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleWebSocket(w, r, target, policy, inst, speedLimitBytes)
+		handleWebSocket(w, r, target, target, policy, inst, speedLimitBytes)
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -189,7 +190,9 @@ func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
 	upstream := startFakeWSUpstream(t, "HTTP/1.1 101 Switching Protocols\r\n"+
 		"Upgrade: websocket\r\n"+
 		"Connection: Upgrade\r\n"+
-		"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"+
+		"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n"+
+		"Set-Cookie: meridian_session=upstream-must-not-overwrite; Path=/\r\n"+
+		"Set-Cookie: emby_session=upstream-keep; Path=/\r\n\r\n"+
 		serverPayload)
 	inst := &ProxyInstance{server: &http.Server{}}
 	srv := newWSProxyServer(t, upstream.ln.Addr().String(), inst, 0, UAHeaderPolicy{Rewrite: true, Profile: getUAProfile("infuse")})
@@ -224,6 +227,12 @@ func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
 	if !strings.Contains(strings.ToLower(seen), "sec-websocket-accept:") {
 		t.Fatalf("handshake response dropped Sec-WebSocket-Accept: %q", seen)
 	}
+	if strings.Contains(seen, "upstream-must-not-overwrite") {
+		t.Fatalf("WebSocket handshake leaked management Set-Cookie: %q", seen)
+	}
+	if !strings.Contains(seen, "emby_session=upstream-keep") {
+		t.Fatalf("WebSocket handshake dropped upstream application cookie: %q", seen)
+	}
 
 	const clientPayload = "CLIENT-FRAMES"
 	if _, err := io.WriteString(conn, clientPayload); err != nil {
@@ -233,6 +242,39 @@ func TestHandleWebSocketRelaysSwitchAndMetersBothDirections(t *testing.T) {
 
 	waitForTunnelCounter(t, &inst.bytesOut, int64(len(serverPayload)), "bytesOut")
 	waitForTunnelCounter(t, &inst.bytesIn, int64(len(clientPayload)), "bytesIn")
+}
+
+func TestProxyInstanceShutdownClosesHijackedConnectionAndDrains(t *testing.T) {
+	instanceCtx, cancel := context.WithCancel(context.Background())
+	inst := &ProxyInstance{ctx: instanceCtx, cancel: cancel, hijackedConns: make(map[net.Conn]struct{})}
+	if !inst.beginRequest() {
+		t.Fatal("fresh instance rejected request")
+	}
+	proxyConn, peerConn := net.Pipe()
+	defer peerConn.Close()
+	if !inst.trackHijackedConn(proxyConn) {
+		t.Fatal("fresh instance rejected hijacked connection")
+	}
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		defer inst.endRequest()
+		defer inst.untrackHijackedConn(proxyConn)
+		_, _ = proxyConn.Read(make([]byte, 1))
+	}()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), time.Second)
+	defer shutdownCancel()
+	if err := inst.shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("hijacked connection did not close during shutdown")
+	}
+	if inst.trackHijackedConn(peerConn) {
+		t.Fatal("closing instance accepted a new hijacked connection")
+	}
 }
 
 func TestHandleWebSocketRejectsUpgradeCarryingBody(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add secure `host`, `port`, and `both` ingress modes with exact Host routing.
- Support a manually configured playback backend list with up to 128 total addresses.
- Add AES-GCM encrypted, write-only fixed upstream headers bound to the configured target authority.
- Strip management cookies, authorization credentials, Emby tokens, API keys, Referer, fixed headers, and spoofed forwarding headers at cross-authority direct/redirect/WebSocket boundaries.
- Add safe lifecycle handling for stop, update, delete, WebSocket draining, final traffic persistence, and failed-update configuration rollback.
- Update the UI, migrations, installer, documentation, CI, and release checks.

## Security behavior

- Unknown shared-listener hosts return `421`.
- Retired `/_meridian/d` routes return `410` with `Cache-Control: no-store` and never reach an origin.
- Host-only ingress requires a safe loopback/trusted-proxy deployment.
- Fixed upstream header values are never returned by the API and are not stored in plaintext.
- Cross-authority playback requests use a narrow allowlist and remove application credentials.
- A failed update restores the exact pre-update `.env` even when the full data-directory restore needs a later retry or manual recovery.

## Validation

- Local Go 1.26.5: all 280 tests passed; `go vet ./...` passed.
- Node: 37/37 tests passed.
- Shell syntax and upstream-header-key regression tests passed.
- gosec reported no medium-or-higher findings; govulncheck reported no reachable vulnerabilities.
- Cross-platform vet/build checks passed.
- Debian 12 acceptance host (SSH host key pinned, temporary directory only):
  - native/Windows/Darwin vet and full Go/Node tests passed;
  - real API checks passed for host/port/both ingress, unknown Host, and retired routes;
  - 100 playback addresses round-tripped and 129 were rejected;
  - direct and redirect credential-boundary checks passed;
  - fixed header plaintext was absent from SQLite files;
  - the service stopped cleanly and all temporary files/listeners were removed.
- GitHub Actions passed the Linux race detector, ShellCheck, full installer regression suite, security scans, CodeQL, and build gates.

## Non-goals

This PR does not add automatic backend discovery, health polling, or failover. Playback backends remain explicitly configured, with a maximum of 128 total addresses.

Closes #28
