### PR TITLE
Use the official repository in installer defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Public operations are intentionally limited to install, update, password,
 # and uninstall. Backups and rollback remain internal safety mechanisms.
 
-REPO="${MERIDIAN_REPO:-chanhui800/Meridian}"
+REPO="${MERIDIAN_REPO:-snnabb/Meridian}"
 INSTALL_DIR="${MERIDIAN_INSTALL_DIR:-/usr/local/bin}"
 DATA_DIR="${MERIDIAN_DATA_DIR:-/opt/meridian}"
 BACKUP_DIR="${MERIDIAN_BACKUP_DIR:-/opt/meridian-backups}"

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -78,6 +78,8 @@ assert_not_contains() {
     fi
 }
 
+assert_eq 'snnabb/Meridian' "$REPO" 'default repository owner'
+
 write_legacy_systemd_service() {
     cat > "$SERVICE_FILE" <<'UNIT'
 [Unit]


### PR DESCRIPTION
## Summary

- Change the installer default repository from `chanhui800/Meridian` to `snnabb/Meridian`.
- Keep `MERIDIAN_REPO` as an explicit override for downstream/fork deployments.
- Add a regression assertion for the official default.

This prevents `install.sh update` from checking a different fork and incorrectly reporting an older release as the latest version.

## Validation

- `bash -n install.sh`
- `bash -n tests/install_test.sh`
- `shellcheck install.sh tests/install_test.sh`
- `bash tests/install_test.sh`
