### PR TITLE
Polish dashboard trends and site editor UI

### DIFF
--- a/request_logs.go
+++ b/request_logs.go
@@ -208,7 +208,7 @@ func (d *DB) ListRequestLogs(filter RequestLogFilter) ([]RequestLog, error) {
 		return nil, fmt.Errorf("invalid request log category")
 	}
 	switch filter.StatusGroup {
-	case "", "all", "4xx", "5xx":
+	case "", "all", "2xx", "3xx", "4xx", "5xx":
 	default:
 		return nil, fmt.Errorf("invalid request log status filter")
 	}
@@ -253,6 +253,10 @@ func (d *DB) ListRequestLogs(filter RequestLogFilter) ([]RequestLog, error) {
 		}
 	}
 	switch filter.StatusGroup {
+	case "2xx":
+		conditions = append(conditions, "status_code BETWEEN 200 AND 299")
+	case "3xx":
+		conditions = append(conditions, "status_code BETWEEN 300 AND 399")
 	case "4xx":
 		conditions = append(conditions, "status_code BETWEEN 400 AND 499")
 	case "5xx":

--- a/tests/auth_bootstrap.test.js
+++ b/tests/auth_bootstrap.test.js
@@ -85,6 +85,7 @@ class FakeDocument {
     this.activeElement = null;
     this.body = new FakeElement('body');
     this.body.ownerDocument = this;
+    this.body.classList.add('auth-checking');
 
     const ids = [
       'page-login', 'app-shell', 'loginForm', 'login-footer', 'btn-login',
@@ -286,6 +287,7 @@ test('auth check is authoritative and a failed check can be retried', async () =
   assert.equal(harness.get('btn-login').textContent, '正在检查...');
   assert.equal(harness.get('loginForm').getAttribute('aria-busy'), 'true');
   assert.equal(harness.get('auth-check-status').hidden, false);
+  assert.equal(harness.document.body.classList.contains('auth-checking'), true);
 
   firstCheck.reject(new Error('offline'));
   await flushTasks();
@@ -295,6 +297,7 @@ test('auth check is authoritative and a failed check can be retried', async () =
   assert.equal(harness.get('auth-check-status').getAttribute('role'), 'alert');
   assert.equal(harness.get('btn-auth-retry').hidden, false);
   assert.equal(harness.get('btn-auth-retry').disabled, false);
+  assert.equal(harness.document.body.classList.contains('auth-checking'), false);
   assert.equal(harness.get('setup-token-group').hidden, true);
 
   const retry = harness.get('btn-auth-retry').dispatch('click');
@@ -320,6 +323,7 @@ test('setup and existing-admin login remain separate with no manual register pat
   assert.equal(setup.get('setup-token-group').hidden, false);
   assert.equal(setup.get('inp-setup-token').required, true);
   assert.equal(setup.get('inp-password').autocomplete, 'new-password');
+  assert.equal(setup.document.body.classList.contains('auth-checking'), false);
 
   const login = loadAuthHarness({
     checks: [{ needs_setup: false, authenticated: false, mode: 'single_admin' }],
@@ -331,6 +335,7 @@ test('setup and existing-admin login remain separate with no manual register pat
   assert.equal(login.get('setup-token-group').hidden, true);
   assert.equal(login.get('inp-setup-token').required, false);
   assert.equal(login.get('inp-password').autocomplete, 'current-password');
+  assert.equal(login.document.body.classList.contains('auth-checking'), false);
   assert.doesNotMatch(login.get('login-footer').innerHTML, /创建管理员|link-register|<a\b/);
 
   login.get('inp-username').value = 'u'.repeat(65);

--- a/tests/request_logs.test.js
+++ b/tests/request_logs.test.js
@@ -107,11 +107,14 @@ test('request log panel exposes only concrete resource-category filters and live
     path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'request-logs.js'),
     'utf8',
   );
-  for (const category of ['playback', 'playback_sync', 'stream', 'manifest', 'segment', 'image', 'metadata', 'subtitle', 'asset', 'websocket', 'api', 'auth']) {
-    assert.match(source, new RegExp(`data-category="${category}"`));
+  for (const category of ['playback', 'playback_sync', 'video', 'image', 'asset', 'api', 'auth']) {
+    assert.match(source, new RegExp(`value="${category}"`));
   }
-  assert.doesNotMatch(source, /data-category="video"/);
-  assert.doesNotMatch(source, /request-log-advanced-filters|<details|高级分类/);
+  assert.match(source, /value="2xx"/);
+  assert.match(source, /value="3xx"/);
+  assert.match(source, /value="4xx"/);
+  assert.match(source, /value="5xx"/);
+  assert.doesNotMatch(source, /request-log-category-pills|request-log-status-pills/);
   assert.match(source, /requestLogRefreshTimer = setInterval/);
   assert.match(source, /Router\.current === 'request-logs'/);
   assert.match(source, /class="request-log-ip mono"/);

--- a/tests/sites_ingress_mode.test.js
+++ b/tests/sites_ingress_mode.test.js
@@ -132,7 +132,7 @@ test('site modal always loads deployment capabilities for create and edit flows'
   const end = source.indexOf('// Global actions', start);
   const modalSource = source.slice(start, end);
 
-  assert.match(modalSource, /normalizeSiteCapabilities\(await API\.ingressCapabilities\(\)\)/);
+  assert.match(modalSource, /API\.ingressCapabilities\(\)\.then\(normalizeSiteCapabilities\)/);
   assert.doesNotMatch(modalSource, /if \(!isEdit\)[\s\S]{0,200}ingressCapabilities/);
 	assert.doesNotMatch(modalSource, /id="m-port"[^>]*\srequired(?:\s|>)/);
 	assert.match(modalSource, /portInput\.required = state\.requireListenPort/);

--- a/tests/sites_redirect_discovery.test.js
+++ b/tests/sites_redirect_discovery.test.js
@@ -442,8 +442,8 @@ test('site modal presents proxy and direct main-video choices without discovery 
   assert.match(body, /主视频流策略/);
   assert.match(body, /反代/);
   assert.match(body, /直连/);
-  assert.match(body, /网盘或 CDN 的 302/);
-  assert.match(body, /面板、API、PlaybackInfo、HLS \/ DASH、字幕、图片和必要静态资源/);
+  assert.match(body, /直连仅适用于主视频文件/);
+  assert.match(body, /面板、API、HLS\/DASH 等仍由 Meridian 代理/);
   assert.equal(document.getElementById('m-main-video-mode').value, 'proxy');
   assert.doesNotMatch(body, /播放回源/);
   assert.equal(document.getElementById('m-dynamic-enabled'), null);

--- a/tests/sites_redirect_discovery.test.js
+++ b/tests/sites_redirect_discovery.test.js
@@ -374,11 +374,7 @@ test('structured-discovery status reports delivered sources and only unavailable
 
   assert.match(status, /自动发现/);
   assert.match(status, /默认处理 HTTP 30x 和 PlaybackInfo/);
-  assert.match(status, /高级选项中开启 HLS、DASH/);
-  assert.match(status, /Extreme 扩展兼容模式/);
-  assert.match(status, /DYNAMIC_ROUTE_KEY：已配置/);
-  assert.ok(!status.includes('raw-secret-must-not-render'));
-  assert.ok(!status.includes('target-must-not-render'));
+  assert.doesNotMatch(status, /raw-secret-must-not-render|target-must-not-render/);
 });
 
 test('profile risk notices and transition confirmations match the approved product gates', () => {
@@ -434,7 +430,7 @@ test('profile risk notices and transition confirmations match the approved produ
   assert.equal(unchangedExtreme.requirement, 'none');
 });
 
-test('site modal presents proxy and direct main-video choices without discovery or security controls', async () => {
+test('site modal presents proxy, direct main-video, and automatic discovery controls', async () => {
   const { sandbox, document } = loadModalHarness();
   await sandbox.showSiteModal(null);
   const body = document.getElementById('modal-body').innerHTML;
@@ -445,13 +441,13 @@ test('site modal presents proxy and direct main-video choices without discovery 
   assert.match(body, /直连仅适用于主视频文件/);
   assert.match(body, /面板、API、HLS\/DASH 等仍由 Meridian 代理/);
   assert.equal(document.getElementById('m-main-video-mode').value, 'proxy');
+  assert.ok(document.getElementById('m-dynamic-enabled'));
+  assert.ok(document.getElementById('m-dynamic-profile'));
+  assert.ok(document.getElementById('m-dynamic-source-hls'));
+  assert.ok(document.getElementById('m-dynamic-source-dash'));
+  assert.match(body, /自动发现/);
+  assert.match(body, /Compatible|兼容/);
   assert.doesNotMatch(body, /播放回源/);
-  assert.equal(document.getElementById('m-dynamic-enabled'), null);
-  assert.equal(document.getElementById('m-dynamic-profile'), null);
-  assert.equal(document.getElementById('m-dynamic-source-hls'), null);
-  assert.equal(document.getElementById('m-dynamic-source-dash'), null);
-  assert.equal(document.getElementById('m-playback-list'), null);
-  assert.doesNotMatch(body, /Safe|Compatible|Extreme|高级选项/);
 });
 
 test('new site submission enables every automatic proxy source without manual playback origins', async () => {
@@ -750,7 +746,7 @@ test('dynamic rendering escapes values and never renders sensitive observation d
   }
 });
 
-test('edit modal hides legacy dynamic observations and configuration controls', async () => {
+test('edit modal exposes discovery policy and observation controls', async () => {
   const { sandbox, document, state } = loadModalHarness();
   const site = {
     id: 17,
@@ -775,10 +771,10 @@ test('edit modal hides legacy dynamic observations and configuration controls', 
 
   await sandbox.showSiteModal(site);
   assert.equal(state.opened, 1);
-  assert.equal(document.getElementById('m-refresh-dynamic-observations'), null);
-  assert.equal(document.getElementById('m-clear-dynamic-observations'), null);
-  assert.equal(document.getElementById('m-dynamic-observations'), null);
-  assert.deepEqual(state.observationGets, []);
+  assert.ok(document.getElementById('m-refresh-dynamic-observations'));
+  assert.ok(document.getElementById('m-clear-dynamic-observations'));
+  assert.ok(document.getElementById('m-dynamic-observations'));
+  assert.deepEqual(state.observationGets, [17]);
   assert.deepEqual(state.observationDeletes, []);
   assert.deepEqual(state.confirmations, []);
   assert.deepEqual(state.errors, []);

--- a/tests/sites_ua_mode.test.js
+++ b/tests/sites_ua_mode.test.js
@@ -131,7 +131,7 @@ test('site management exposes latency tests and safe asset cache controls', () =
   assert.match(source, /asset_cache_rules:/);
   assert.match(source, /\*\/file\/\*/);
   assert.match(source, /\*\/emby\/Items\/\*\/Images\/\*/);
-  assert.match(source, /视频、音频、HLS、DASH、Range 请求/);
+  assert.match(source, /视频、音频、HLS\/DASH、Range/);
 });
 
 test('upstream header payload keeps configured rows write-only', () => {

--- a/tests/sites_ua_mode.test.js
+++ b/tests/sites_ua_mode.test.js
@@ -75,6 +75,14 @@ test('hidden semantics override display utilities for the custom identity group'
   assert.match(source, /input\.required = state\.required/);
 });
 
+test('asset cache rules stay optional and follow the asset cache switch', () => {
+  const source = fs.readFileSync(path.join(STATIC_JS, 'pages', 'sites.js'), 'utf8');
+  const css = fs.readFileSync(STYLE_CSS, 'utf8');
+  assert.match(source, /id="m-cache-rules-group"/);
+  assert.match(source, /自定义缓存规则（可选）/);
+  assert.match(source, /cacheRulesGroup\.hidden = !enabled/);
+  assert.match(css, /\.site-cache-rules-group\[hidden\]\s*\{\s*display:\s*none\s*!important;/);
+});
 test('custom UA payload trims custom values and preset payload clears them', () => {
   const { buildCustomUAPayload } = loadSiteHelpers();
   const custom = buildCustomUAPayload('custom', ' UA ', ' Client ', ' 1.2.3 ');

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -510,7 +510,9 @@ test('dashboard trends use pointer interaction and dashed crosshairs', () => {
   const source = readScript('pages/dashboard.js');
   const css = readScript('../css/style.css');
   assert.match(source, /addEventListener\('pointermove'/);
-  assert.match(source, /addEventListener\('pointerdown'/);
+  assert.match(source, /addEventListener\('pointerup'/);
+  assert.match(source, /const clearHover = \(\) =>/);
+  assert.match(source, /pointercancel', clearHover/);
   assert.match(source, /setLineDash\(\[5, 4\]\)/);
   assert.match(source, /const ticks = 6/);
   assert.match(source, /dashboardRoundRect/);

--- a/tests/ui_polish.test.js
+++ b/tests/ui_polish.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.join(__dirname, '..');
+const indexSource = fs.readFileSync(path.join(ROOT, 'web/static/index.html'), 'utf8');
+const appSource = fs.readFileSync(path.join(ROOT, 'web/static/js/app.js'), 'utf8');
+const dashboardSource = fs.readFileSync(path.join(ROOT, 'web/static/js/pages/dashboard.js'), 'utf8');
+const cssSource = fs.readFileSync(path.join(ROOT, 'web/static/css/style.css'), 'utf8');
+
+test('GitHub project link points to the official repository', () => {
+  assert.match(indexSource, /class="github-project-link" href="https:\/\/github\.com\/snnabb\/Meridian"/);
+  assert.doesNotMatch(indexSource, /github\.com\/chanhui800\/Meridian/);
+});
+
+test('site modal resets overlay and content scroll on every open', () => {
+  assert.match(appSource, /function resetModalScroll\(\)/);
+  assert.match(appSource, /overlay\.scrollTop = 0/);
+  assert.match(appSource, /body\.scrollTop = 0/);
+  assert.match(appSource, /requestAnimationFrame\(resetModalScroll\)/);
+});
+
+test('dashboard trends trace smooth curves instead of only straight segments', () => {
+  assert.match(dashboardSource, /function dashboardTraceSmoothLine\(ctx, points\)/);
+  assert.match(dashboardSource, /ctx\.bezierCurveTo\(/);
+  assert.match(dashboardSource, /dashboardTraceSmoothLine\(ctx, pointsOnCanvas\)/);
+});
+
+test('upstream header rows do not inherit the browser fieldset frame', () => {
+  assert.match(cssSource, /\.form-list-row\.upstream-header-row[\s\S]*?border: 0;/);
+  assert.match(cssSource, /\.site-config-modal \.upstream-line-labels,[\s\S]*?grid-template-columns: 76px minmax\(150px, \.8fr\)/);
+});

--- a/tests/ui_polish.test.js
+++ b/tests/ui_polish.test.js
@@ -29,6 +29,10 @@ test('dashboard trends trace smooth curves instead of only straight segments', (
   assert.match(dashboardSource, /dashboardTraceSmoothLine\(ctx, pointsOnCanvas\)/);
 });
 
+test('mobile navigation keeps the header and drawer available', () => {
+  assert.match(cssSource, /@media \(max-width: 768px\)[\s\S]*?\.app-header \{[\s\S]*?display: flex;[\s\S]*?\.sidebar \{[\s\S]*?display: flex;/);
+  assert.match(cssSource, /#app-shell\.sidebar-expanded \.sidebar \{ transform: translateX\(0\); \}/);
+});
 test('upstream header rows do not inherit the browser fieldset frame', () => {
   assert.match(cssSource, /\.form-list-row\.upstream-header-row[\s\S]*?border: 0;/);
   assert.match(cssSource, /\.site-config-modal \.upstream-line-labels,[\s\S]*?grid-template-columns: 76px minmax\(150px, \.8fr\)/);

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5832,4 +5832,76 @@ html[data-theme="light"] .request-log-table-card { background: rgba(255,255,255,
   .request-log-filter-row { align-items: flex-start; flex-direction: column; gap: 6px; }
   .request-log-filter-label { flex-basis: auto; }
   .request-log-filter-select { width: 100%; }
+
+  .request-log-search-row {
+    grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
+    gap: 8px;
+  }
+  .request-log-date-field,
+  .request-log-date-field input,
+  .request-log-search-field,
+  .request-log-search-field input {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+  .request-log-date-field input { padding-inline: 8px; font-size: 13px; }
+  .request-log-search-field { grid-column: 1 / -1; }
+
+  .site-config-modal .upstream-line {
+    grid-template-columns: minmax(0, 1fr) 96px;
+  }
+  .site-config-modal .upstream-line-name { grid-column: 1; grid-row: 2; }
+  .site-config-modal .upstream-line-address { grid-column: 1 / -1; grid-row: 3; }
+  .site-config-modal .upstream-line-port { grid-column: 2; grid-row: 2; min-width: 0; width: 100%; }
+  .site-config-modal .upstream-line-latency { grid-column: 1; grid-row: 4; }
+  .site-config-modal .upstream-line-actions { grid-column: 2; grid-row: 4; }
+  .site-config-modal .upstream-line-actions.primary-actions { grid-column: 2; grid-row: 4; justify-self: end; }
+
+  .telegram-field input[type="time"] {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+    padding-inline: 10px;
+    font-size: 14px;
+  }
+}
+
+/* Final mobile polish: keep major surfaces comfortably rounded without making
+   compact controls pill-shaped. */
+:root,
+html[data-theme="light"] {
+  --radius-lg: 28px;
+  --ui-radius: 24px;
+}
+
+.site-cache-rules-group {
+  grid-area: cache-rules;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+  overflow: hidden;
+}
+.site-cache-rules-group > summary {
+  padding: 11px 13px;
+  color: var(--white-60);
+  font-size: .78rem;
+  cursor: pointer;
+  list-style: none;
+}
+.site-cache-rules-group > summary::-webkit-details-marker { display: none; }
+.site-cache-rules-group > summary::after { content: '⌄'; float: right; color: var(--white-38); }
+.site-cache-rules-group[open] > summary { border-bottom: 1px solid var(--glass-border); color: var(--white-87); }
+.site-cache-rules-group[open] > summary::after { content: '⌃'; }
+.site-cache-rules-body { padding: 11px 13px 13px; }
+.site-cache-rules-body .form-help { margin-top: 6px; font-size: .72rem; line-height: 1.45; }
+.site-cache-rules-group[hidden] { display: none !important; }
+
+@media (max-width: 768px) {
+  .site-cache-rules-group { margin-bottom: 16px; }
+  .site-cache-rules-body { padding: 10px; }
+  .site-cache-rules-body textarea { min-height: 88px; }
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6147,13 +6147,23 @@ body.modal-open { overflow-y: hidden !important; }
   .site-config-modal .upstream-line-port { width: 100%; min-width: 0; }
 }
 
+.dashboard-trend-controls .form-select {
+  width: 220px !important;
+  min-width: 220px !important;
+  padding-right: 52px;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
 @media (max-width: 600px) {
-  .dashboard-trend-controls {
-    grid-template-columns: minmax(0, 1fr);
+  .dashboard-trend-controls .form-select {
+    width: 100% !important;
+    min-width: 0 !important;
   }
 }
 
-@media (max-width: 768px) {
+
   /* Keep the mobile editor's line-list surface and every line field visible. */
   .site-config-modal .upstream-lines-card {
     display: block !important;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5779,8 +5779,41 @@ html[data-theme="light"] .request-log-table-card { background: rgba(255,255,255,
 }
 
 @media (max-width: 768px) {
-  .sidebar { display: none; }
-  .main { margin-left: 0; padding: 24px 18px 110px; }
+  #app-shell.active {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: 64px minmax(0, 1fr);
+  }
+  .app-header {
+    display: flex;
+    grid-column: 1;
+    min-height: 64px;
+    padding: 0 12px;
+    border-bottom: 1px solid var(--glass-border);
+    background: var(--glass);
+    backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
+  }
+  .sidebar {
+    display: flex;
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 1200;
+    width: 236px;
+    min-width: 236px;
+    padding: 10px;
+    overflow: hidden;
+    transform: translateX(-100%);
+    transition: transform .22s cubic-bezier(.22, 1, .36, 1);
+    box-shadow: 18px 0 42px rgba(0,0,0,.22);
+  }
+  #app-shell.sidebar-expanded .sidebar { transform: translateX(0); }
+  .sidebar-toggle { display: grid; place-items: center; }
+  .main {
+    grid-column: 1;
+    margin: 0;
+    padding: 24px 18px 110px;
+  }
   .site-config-modal .modal-body { display: block; padding: 16px; }
   .site-config-modal .upstream-line-labels { display: none; }
   .site-config-modal .upstream-line { grid-template-columns: minmax(0, 1fr) auto; gap: 10px; padding: 12px; }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6161,6 +6161,30 @@ body.modal-open { overflow-y: hidden !important; }
     width: 100% !important;
     min-width: 0 !important;
   }
+}@media (max-width: 768px) {
+  .dashboard-trend-controls {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+  .dashboard-trend-controls .form-select {
+    width: 100% !important;
+    min-width: 0 !important;
+    max-width: none !important;
+  }
+  .site-card .site-upstream-row {
+    display: block;
+  }
+  .site-card .site-upstream-row > .site-row-label {
+    display: block;
+    margin-bottom: 6px;
+  }
+  .site-card .site-upstream-row > .mono {
+    display: block;
+    width: 100%;
+    max-width: 100% !important;
+    overflow-wrap: anywhere;
+    text-align: left;
+    white-space: normal;
+  }
 }
 
 

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6171,11 +6171,15 @@ body.modal-open { overflow-y: hidden !important; }
 .site-cache-options .cache-limit-grid .form-input { width: 100%; min-width: 0; }
 
 .dashboard-trend-controls .form-select {
-  width: 184px;
-  min-width: 184px;
+  width: 220px;
+  min-width: 220px;
   max-width: 100%;
-  padding-right: 38px;
+  padding-right: 40px;
+  font-size: .95rem;
+  line-height: 1.3;
   white-space: nowrap;
+  text-overflow: clip;
+  overflow: visible;
 }
 
 @media (max-width: 768px) {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -4642,6 +4642,138 @@ html {
 }
 
 :root { --ui-radius: 10px; }
+
+/* UI polish: keep dense configuration rows aligned and avoid browser-default
+   fieldset framing around the fixed-header editor. */
+.form-list-row.upstream-header-row,
+.upstream-header-row {
+  min-inline-size: 0;
+  margin: 0 0 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.site-config-modal .upstream-line-labels,
+.site-config-modal .upstream-line {
+  grid-template-columns: 76px minmax(150px, .8fr) minmax(280px, 1.7fr) 90px 70px 112px;
+  column-gap: 12px;
+}
+
+.site-config-modal .upstream-line-labels {
+  padding: 0 12px 7px;
+  letter-spacing: .01em;
+}
+
+.site-config-modal .upstream-line-labels span,
+.site-config-modal .upstream-line > * {
+  min-width: 0;
+}
+
+.site-config-modal .upstream-line-labels span:nth-child(2),
+.site-config-modal .upstream-line-labels span:nth-child(3) {
+  padding-left: 0;
+}
+
+.site-config-modal .upstream-line-labels span:nth-child(4),
+.site-config-modal .upstream-line-labels span:nth-child(5) {
+  text-align: center;
+}
+
+.site-config-modal .upstream-line {
+  padding: 10px 12px;
+  border-radius: 10px;
+}
+
+.site-config-modal .upstream-line .form-input {
+  width: 100%;
+  font-size: .82rem;
+}
+
+.site-card .site-row:not(.site-access-row) > .site-row-label {
+  flex: 0 0 96px;
+}
+
+.site-card .site-row:not(.site-access-row) > span:not(.site-row-label) {
+  min-width: 0;
+  max-width: calc(100% - 108px);
+  overflow: hidden;
+  color: var(--white-87);
+  font-size: .82rem;
+  font-weight: 600;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.site-form-columns {
+  column-gap: 20px;
+  row-gap: 18px;
+}
+
+.site-form-columns > .form-group {
+  display: flex;
+  min-height: 108px;
+  flex-direction: column;
+}
+
+.site-form-columns > .form-group > .form-help {
+  min-height: 2.9em;
+  margin-top: 6px;
+  font-size: .72rem;
+  line-height: 1.45;
+}
+
+.site-form-columns > .form-group:has(> #m-main-video-mode) > .form-help {
+  min-height: 0;
+}
+
+.site-advanced-body {
+  padding: 18px 20px 20px;
+}
+
+.dashboard-trend-help {
+  max-width: 560px;
+  line-height: 1.45;
+}
+
+.dashboard-trend-grid .dashboard-trend-card {
+  padding: 18px;
+}
+
+@media (max-width: 768px) {
+  .site-config-modal .upstream-line {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 14px;
+  }
+
+  .site-config-modal .upstream-line-enabled {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .site-config-modal .upstream-line-name,
+  .site-config-modal .upstream-line-address,
+  .site-config-modal .upstream-line-port {
+    grid-column: 1 / -1;
+  }
+
+  .site-config-modal .upstream-line-name { grid-row: 2; }
+  .site-config-modal .upstream-line-address { grid-row: 3; }
+  .site-config-modal .upstream-line-port { grid-row: 4; }
+  .site-config-modal .upstream-line-latency { grid-column: 1; grid-row: 5; }
+  .site-config-modal .upstream-line-actions { grid-column: 2; grid-row: 5; }
+
+  .site-form-columns > .form-group {
+    min-height: 0;
+  }
+
+  .site-form-columns > .form-group > .form-help {
+    min-height: 0;
+  }
+}
+
 .stat-card, .glass-card, .site-card, .chart-wrap, .total-card, .request-log-controls, .request-log-table-card, .diag-card { border-radius: var(--ui-radius); }
 .sidebar-drawer-close { display: none; }
 .global-settings-link { margin-top: auto; border-top: 1px solid var(--panel-border) !important; border-radius: 0 !important; padding-top: 12px !important; }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5907,14 +5907,49 @@ html[data-theme="light"] {
 .site-cache-rules-group[hidden] { display: none !important; }
 
 @media (min-width: 769px) {
+  .site-config-modal .site-form-columns {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    grid-template-areas: none !important;
+    align-items: start;
+  }
+  .site-config-modal .site-form-columns > .form-group {
+    display: block !important;
+    width: auto !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+  }
+  .site-config-modal .site-form-columns > .form-group > label {
+    display: block !important;
+    width: auto !important;
+    max-width: none !important;
+    writing-mode: horizontal-tb !important;
+    word-break: keep-all !important;
+    white-space: normal !important;
+  }
+  .site-config-modal .site-form-columns > .form-group > .form-help {
+    width: auto !important;
+    max-width: none !important;
+    writing-mode: horizontal-tb !important;
+    word-break: normal !important;
+    white-space: normal !important;
+  }
+}
+
+@media (min-width: 769px) {
   .site-config-modal .upstream-lines-card { overflow-x: auto; }
   .site-config-modal .upstream-line-labels,
   .site-config-modal .upstream-line {
-    min-width: 780px;
-    grid-template-columns: 54px minmax(150px, 1fr) minmax(280px, 2fr) 88px 72px 124px;
+    min-width: 860px;
+    grid-template-columns: 54px 150px minmax(300px, 1fr) 96px 96px 170px;
     gap: 10px;
   }
-  .site-config-modal .upstream-line-labels { white-space: nowrap; }
+  .site-config-modal .upstream-line-labels {
+    white-space: nowrap;
+    word-break: keep-all;
+  }
+  .site-config-modal .upstream-line > input[type="hidden"] { display: none !important; }
+  .site-config-modal .upstream-line-actions { min-width: 0; white-space: nowrap; }
 }
 
 .telegram-report-card,
@@ -5936,6 +5971,10 @@ html[data-theme="light"] {
 }
 
 @media (max-width: 768px) {
+  .site-config-modal .upstream-line-port { width: 100%; min-width: 0; }
+  .site-config-modal .upstream-line {
+    grid-template-columns: minmax(0, 1fr) 120px;
+  }
   .site-config-modal .upstream-lines-card { overflow-x: visible; }
   .site-config-modal .upstream-line { min-width: 0; }
   .site-config-modal .upstream-line-labels { min-width: 0; }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6154,3 +6154,33 @@ body.modal-open { overflow-y: hidden !important; }
   ::-webkit-scrollbar-thumb { background: rgba(255,255,255,.18); border-radius: 999px; }
   ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,.28); }
 }
+
+[hidden] { display: none !important; }
+.site-cache-options {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+.site-cache-options[hidden] { display: none !important; }
+.site-cache-options .cache-limit-grid {
+  min-width: 0;
+  align-items: center;
+  gap: 8px 12px;
+}
+.site-cache-options .cache-limit-grid label { margin: 0; color: var(--white-60); font-size: .75rem; }
+.site-cache-options .cache-limit-grid .form-input { width: 100%; min-width: 0; }
+
+.dashboard-trend-controls .form-select {
+  width: 184px;
+  min-width: 184px;
+  max-width: 100%;
+  padding-right: 38px;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .dashboard-trend-controls .form-select {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5532,3 +5532,271 @@ body.is-site-dragging * {
     gap: 7px;
   }
 }
+
+/* Meridian legacy Apple visual language: preserve the original neutral glass
+   palette and spacious labeled navigation while keeping newer controls. */
+:root {
+  --black: #000;
+  --surface: rgba(255,255,255,.06);
+  --surface-hover: rgba(255,255,255,.10);
+  --surface-active: rgba(255,255,255,.14);
+  --glass: rgba(30,30,30,.72);
+  --glass-border: rgba(255,255,255,.08);
+  --white: #fff;
+  --white-87: rgba(255,255,255,.87);
+  --white-60: rgba(255,255,255,.60);
+  --white-38: rgba(255,255,255,.38);
+  --white-12: rgba(255,255,255,.12);
+  --blue: #0a84ff;
+  --blue-glow: rgba(10,132,255,.35);
+  --green: #30d158;
+  --green-dim: rgba(48,209,88,.15);
+  --red: #ff453a;
+  --red-dim: rgba(255,69,58,.15);
+  --orange: #ff9f0a;
+  --orange-dim: rgba(255,159,10,.15);
+  --teal: #64d2ff;
+  --teal-dim: rgba(100,210,255,.15);
+  --purple: #bf5af2;
+  --radius-xs: 8px;
+  --radius-sm: 12px;
+  --radius: 16px;
+  --radius-lg: 22px;
+  --radius-xl: 28px;
+  --sidebar-w: 260px;
+  --panel: rgba(30,30,30,.72);
+  --blue-dim: rgba(10,132,255,.15);
+  --panel-soft: rgba(255,255,255,.045);
+  --panel-raised: rgba(255,255,255,.08);
+  --panel-border: rgba(255,255,255,.08);
+  --page-shadow: 0 12px 35px rgba(0,0,0,.12);
+  --ui-radius: 16px;
+}
+
+html[data-theme="light"] {
+  --black: #f4f6f8;
+  --surface: rgba(15,23,42,.055);
+  --surface-hover: rgba(15,23,42,.09);
+  --surface-active: rgba(15,23,42,.14);
+  --glass: rgba(255,255,255,.82);
+  --glass-border: rgba(15,23,42,.12);
+  --white: #111827;
+  --white-87: rgba(15,23,42,.87);
+  --white-60: rgba(15,23,42,.64);
+  --white-38: rgba(15,23,42,.48);
+  --white-12: rgba(15,23,42,.12);
+  --blue: #0071e3;
+  --blue-glow: rgba(0,113,227,.22);
+  --green: #16853b;
+  --green-dim: rgba(22,133,59,.12);
+  --red: #d92d20;
+  --red-dim: rgba(217,45,32,.11);
+  --orange: #b45309;
+  --orange-dim: rgba(180,83,9,.11);
+  --teal: #087ea4;
+  --teal-dim: rgba(8,126,164,.11);
+  --purple: #8744b8;
+  --panel: rgba(255,255,255,.82);
+  --blue-dim: rgba(0,113,227,.12);
+  --panel-soft: rgba(15,23,42,.035);
+  --panel-raised: #fff;
+  --panel-border: rgba(15,23,42,.12);
+  --page-shadow: 0 12px 35px rgba(15,23,42,.07);
+}
+
+body { background: var(--black); color: var(--white); overflow-x: hidden; overflow-y: auto; }
+#app-shell.active { display: block; min-height: 100vh; height: auto; overflow: visible; }
+.app-header { display: none; }
+.sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: 260px;
+  min-width: 260px;
+  height: 100vh;
+  padding: 22px 18px 18px;
+  background: var(--glass);
+  border-right: 1px solid var(--glass-border);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  box-shadow: none;
+}
+.sidebar-brand {
+  min-height: 62px;
+  margin: 0 0 20px;
+  padding: 0 10px 22px;
+  flex-direction: row;
+  justify-content: flex-start;
+  gap: 12px;
+  border-bottom: 1px solid var(--glass-border);
+}
+.sidebar-logo { width: 44px; height: 44px; filter: none; }
+.sidebar-brand-name { position: static; width: auto; height: auto; overflow: visible; clip: auto; font-size: 1.22rem; font-weight: 720; }
+.sidebar-version { margin-left: auto; padding: 6px 8px; border: 0; border-radius: 8px; background: var(--blue-dim); color: var(--blue); font-size: .68rem; }
+.sidebar-nav { gap: 6px; align-items: stretch; }
+.sidebar .topnav-link {
+  position: static;
+  width: auto;
+  min-height: 52px;
+  padding: 0 16px;
+  justify-content: flex-start;
+  gap: 14px;
+  border: 0;
+  border-radius: 14px;
+  color: var(--white-60);
+}
+.sidebar .topnav-link svg { width: 22px; height: 22px; }
+.sidebar .topnav-link > span { position: static; width: auto; max-width: none; padding: 0; border: 0; background: transparent; color: inherit; box-shadow: none; font-size: .92rem; opacity: 1; pointer-events: auto; transform: none; }
+.sidebar .topnav-link:hover { color: var(--white-87); border: 0; background: var(--surface); }
+.sidebar .topnav-link.active { color: var(--white); border: 0; background: var(--surface-hover); box-shadow: none; }
+.sidebar .topnav-link[data-page="diagnostics"] { margin-top: 0; }
+.sidebar .topnav-link[data-page="diagnostics"]::before { display: none; }
+.sidebar-account { width: 100%; min-height: 0; margin: auto 0 0; padding: 11px; justify-content: flex-start; border: 1px solid var(--glass-border); border-radius: 15px; background: transparent; }
+.sidebar-account-copy, .sidebar-account > svg { display: block; }
+.sidebar-account > svg { margin-left: auto; }
+.main { margin: 0 0 0 260px; padding: 48px 48px 72px; max-width: 1700px; }
+
+.form-group label { color: var(--white-38); font-size: .75rem; font-weight: 500; letter-spacing: .06em; text-transform: uppercase; }
+.form-input,
+.form-select {
+  min-height: 44px;
+  padding: 13px 16px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--white);
+  font-size: .9rem;
+  font-weight: 400;
+  box-shadow: none;
+}
+.form-input:focus,
+.form-select:focus { border-color: rgba(10,132,255,.5); background: var(--surface-hover); box-shadow: 0 0 0 4px rgba(10,132,255,.1); }
+.form-select option { background: #1a1a1a; color: var(--white); }
+html[data-theme="light"] .form-select option { background: #fff; color: var(--white); }
+
+.modal.site-config-modal,
+html[data-theme="light"] .modal.site-config-modal { width: min(1120px, 94vw); max-width: none; max-height: min(920px, calc(100dvh - 48px)); background: #1a1a1a; border-color: var(--glass-border); border-radius: var(--radius-lg); }
+html[data-theme="light"] .modal.site-config-modal { background: #fff; }
+.site-config-modal .modal-body { display: block; padding: 24px 28px; }
+.site-config-modal .modal-body > .form-group,
+.site-config-modal .site-advanced-card { margin-bottom: 18px; }
+.site-config-modal .upstream-lines-card,
+.site-config-modal .site-form-wide { padding: 16px; border: 1px solid var(--glass-border); border-radius: var(--radius-sm); background: var(--surface); }
+.site-config-modal .upstream-line-labels,
+.site-config-modal .upstream-line { grid-template-columns: 58px minmax(120px, .7fr) minmax(260px, 1.65fr) 86px 70px 120px; gap: 10px; }
+.site-config-modal .upstream-line-labels { padding: 0 10px 7px; }
+.site-config-modal .upstream-line-labels span { padding-left: 0 !important; text-align: left !important; }
+.site-config-modal .upstream-line-labels span:nth-child(4),
+.site-config-modal .upstream-line-labels span:nth-child(5),
+.site-config-modal .upstream-line-labels span:nth-child(6) { text-align: center !important; }
+.site-config-modal .upstream-line { padding: 8px 10px; border-color: var(--glass-border); border-radius: var(--radius-xs); background: var(--panel); }
+.site-config-modal .upstream-line .form-input { min-height: 38px; padding: 9px 11px; font-size: .82rem; }
+.site-config-modal .upstream-line-actions { justify-content: center; }
+.site-config-modal .upstream-line-latency { text-align: center; }
+.site-config-modal .upstream-header-row { border: 0; margin: 0 0 8px; padding: 0; background: transparent; }
+.site-config-modal .upstream-header-row .form-input { min-height: 40px; }
+.site-dynamic-card { display: block; }
+.site-feature-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+.site-feature-heading label { margin-bottom: 4px; }
+.site-feature-badge { padding: 4px 9px; border-radius: 999px; background: var(--blue-glow); color: var(--blue); font-size: .7rem; white-space: nowrap; }
+.site-dynamic-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
+.site-dynamic-toggle, .site-dynamic-check { display: inline-flex; align-items: center; gap: 8px; color: var(--white-87); font-size: .85rem; }
+.site-dynamic-toggle input, .site-dynamic-check input { width: 16px; height: 16px; accent-color: var(--blue); }
+.site-dynamic-profile { display: flex; align-items: center; gap: 8px; margin: 0; color: var(--white-60); font-size: .8rem; }
+.site-dynamic-profile .form-select { width: 220px; min-height: 40px; padding: 9px 12px; }
+.site-dynamic-sources { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 14px; margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--glass-border); }
+.site-dynamic-sources[hidden] { display: none; }
+.site-dynamic-sources > label { display: inline-flex; align-items: center; gap: 6px; color: var(--white-60); font-size: .78rem; }
+.site-dynamic-label { color: var(--white-38); font-size: .72rem; }
+.site-dynamic-help { margin-top: 10px; color: var(--white-38); font-size: .76rem; line-height: 1.45; }
+.site-dynamic-advanced { margin-top: 12px; border-top: 1px solid var(--glass-border); }
+.site-dynamic-advanced summary { padding-top: 12px; color: var(--white-60); font-size: .78rem; cursor: pointer; }
+.site-dynamic-advanced-body { padding-top: 12px; }
+.site-dynamic-extreme { margin-top: 12px; padding: 10px 12px; border: 1px solid var(--orange); border-radius: var(--radius-xs); background: var(--orange-dim); }
+.site-dynamic-extreme[hidden] { display: none; }
+.site-dynamic-extreme .form-input { margin-top: 8px; }
+.site-dynamic-rules-head { display: flex; align-items: center; justify-content: space-between; margin-top: 14px; color: var(--white-60); font-size: .78rem; }
+.site-dynamic-rules-head .btn-ghost { min-height: 32px; padding: 6px 10px; font-size: .72rem; }
+.site-dynamic-advanced-body .m-dynamic-rule-row { margin-top: 8px !important; }
+.site-dynamic-advanced-body .m-dynamic-rule-row .form-input,
+.site-dynamic-advanced-body .m-dynamic-rule-row .form-select { min-height: 36px; padding: 8px 10px; font-size: .78rem; }
+.site-advanced-card { background: var(--surface); border-color: var(--glass-border); }
+.site-advanced-summary { min-height: 52px; padding: 0 18px; color: var(--white-87); font-size: .88rem; }
+.site-advanced-body { padding: 18px; border-top-color: var(--glass-border); }
+.site-form-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); grid-template-areas: none; gap: 18px 20px; }
+.site-form-columns > .form-group { display: block; min-height: 0; }
+.site-form-columns > .form-group > .form-help { min-height: 0; margin-top: 6px; font-size: .72rem; line-height: 1.45; }
+.site-form-columns > .form-group:has(> #m-ua),
+.site-form-columns > .form-group:has(> #m-client-ip-mode),
+.site-form-columns > .form-group:has(> #m-main-video-mode),
+.site-form-columns > .form-group:has(> #m-asset-cache),
+.site-form-columns > .form-group:has(> #m-cache-rules),
+.site-form-columns > .cache-limit-group,
+.site-form-columns > .form-group:has(> #m-quota),
+.site-form-columns > .form-group:has(> #m-speed) { grid-area: auto; }
+
+.settings-layout { grid-template-columns: 220px minmax(0, 1fr); gap: 24px; }
+.settings-section-nav { top: 24px; padding: 14px; border-color: var(--glass-border); border-radius: var(--radius); background: var(--glass); box-shadow: none; }
+.settings-section-nav > span { font-size: .68rem; letter-spacing: .12em; }
+.settings-section-nav > strong { padding: 4px 4px 12px; font-size: 1rem; }
+.settings-nav-item { min-height: 42px; justify-content: flex-start; padding: 0 12px; border: 0; border-radius: var(--radius-xs); color: var(--white-60); font-size: .82rem; font-weight: 500; }
+.settings-nav-item:hover, .settings-nav-item.active { border: 0; background: var(--surface-hover); color: var(--white); }
+.settings-content { gap: 16px; }
+.settings-panel { padding: 22px; border-color: var(--glass-border); border-radius: var(--radius); background: var(--glass); box-shadow: none; }
+.settings-panel header { padding-bottom: 12px; margin-bottom: 16px; border-bottom-color: var(--glass-border); }
+.settings-panel header h2 { font-size: 1.15rem; letter-spacing: -.02em; }
+.settings-panel header b { padding: 5px 9px; border-color: var(--glass-border); font-size: .7rem; font-weight: 500; }
+.settings-panel p, .settings-panel small { font-size: .78rem; line-height: 1.5; }
+.settings-grid, .settings-two-column { gap: 16px; }
+.settings-field { gap: 6px; font-size: .78rem; font-weight: 500; }
+.settings-field input, .settings-field select { min-height: 42px; padding: 10px 12px; font-size: .85rem; }
+.settings-check-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 14px; }
+.settings-check { min-height: 36px; gap: 8px; padding: 6px 0; border: 0; background: transparent; }
+.settings-check-copy strong { font-size: .8rem; font-weight: 500; }
+.settings-check-copy small { display: none; }
+.settings-more { margin-top: 12px; border-top: 1px solid var(--glass-border); }
+.settings-more summary { padding-top: 10px; color: var(--white-60); font-size: .76rem; cursor: pointer; }
+
+.request-log-controls, .request-log-table-card { border-color: var(--glass-border); border-radius: var(--radius); background: var(--glass); box-shadow: none; }
+.request-log-controls { padding: 22px; }
+.request-log-filter-row { display: flex; align-items: center; gap: 12px; padding-top: 12px; border-top-color: var(--glass-border); }
+.request-log-filter-label { flex: 0 0 72px; color: var(--white-38); font-size: .74rem; }
+.request-log-filter-select { width: min(260px, 100%); min-height: 40px; padding: 9px 12px; }
+.request-log-pills { display: none; }
+.request-log-actions { border-top-color: var(--glass-border); }
+.request-log-table thead { background: var(--surface); }
+.request-log-table th { color: var(--white-38); }
+
+html[data-theme="light"] .sidebar { background: rgba(255,255,255,.94); }
+html[data-theme="light"] .modal.site-config-modal { background: #fff; }
+html[data-theme="light"] .settings-section-nav,
+html[data-theme="light"] .settings-panel,
+html[data-theme="light"] .request-log-controls,
+html[data-theme="light"] .request-log-table-card { background: rgba(255,255,255,.82); }
+
+@media (max-width: 1180px) {
+  .sidebar { width: 220px; min-width: 220px; }
+  .main { margin-left: 220px; padding-left: 28px; padding-right: 28px; }
+}
+
+@media (max-width: 768px) {
+  .sidebar { display: none; }
+  .main { margin-left: 0; padding: 24px 18px 110px; }
+  .site-config-modal .modal-body { display: block; padding: 16px; }
+  .site-config-modal .upstream-line-labels { display: none; }
+  .site-config-modal .upstream-line { grid-template-columns: minmax(0, 1fr) auto; gap: 10px; padding: 12px; }
+  .site-config-modal .upstream-line-enabled { grid-column: 1 / -1; }
+  .site-config-modal .upstream-line-name,
+  .site-config-modal .upstream-line-address,
+  .site-config-modal .upstream-line-port { grid-column: 1 / -1; }
+  .site-config-modal .upstream-line-latency { grid-column: 1; text-align: left; }
+  .site-config-modal .upstream-line-actions { grid-column: 2; }
+  .site-form-columns { display: block; }
+  .site-form-columns > .form-group { margin-bottom: 16px; }
+  .settings-layout { display: block; }
+  .settings-section-nav { position: static; margin-bottom: 16px; }
+  .settings-nav-item { display: inline-flex; margin: 2px; }
+  .settings-check-grid { grid-template-columns: 1fr; }
+  .request-log-filter-row { align-items: flex-start; flex-direction: column; gap: 6px; }
+  .request-log-filter-label { flex-basis: auto; }
+  .request-log-filter-select { width: 100%; }
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5871,13 +5871,19 @@ html[data-theme="light"] .request-log-table-card { background: rgba(255,255,255,
    compact controls pill-shaped. */
 :root,
 html[data-theme="light"] {
+  --radius: 24px;
   --radius-lg: 28px;
   --ui-radius: 24px;
 }
 
+/* HTML's hidden attribute must win over the dense form display rules below. */
+[hidden] { display: none !important; }
+
 .site-cache-rules-group {
+  display: block !important;
   grid-area: cache-rules;
   min-width: 0;
+  min-height: 0 !important;
   margin: 0;
   padding: 0;
   border: 1px solid var(--glass-border);
@@ -5900,7 +5906,39 @@ html[data-theme="light"] {
 .site-cache-rules-body .form-help { margin-top: 6px; font-size: .72rem; line-height: 1.45; }
 .site-cache-rules-group[hidden] { display: none !important; }
 
+@media (min-width: 769px) {
+  .site-config-modal .upstream-lines-card { overflow-x: auto; }
+  .site-config-modal .upstream-line-labels,
+  .site-config-modal .upstream-line {
+    min-width: 780px;
+    grid-template-columns: 54px minmax(150px, 1fr) minmax(280px, 2fr) 88px 72px 124px;
+    gap: 10px;
+  }
+  .site-config-modal .upstream-line-labels { white-space: nowrap; }
+}
+
+.telegram-report-card,
+.telegram-report-form-grid,
+.telegram-field,
+.telegram-field input,
+.telegram-field select {
+  min-width: 0;
+  max-width: 100%;
+}
+.telegram-field input[type="time"] {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0 !important;
+  max-width: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
 @media (max-width: 768px) {
+  .site-config-modal .upstream-lines-card { overflow-x: visible; }
+  .site-config-modal .upstream-line { min-width: 0; }
+  .site-config-modal .upstream-line-labels { min-width: 0; }
   .site-cache-rules-group { margin-bottom: 16px; }
   .site-cache-rules-body { padding: 10px; }
   .site-cache-rules-body textarea { min-height: 88px; }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6147,15 +6147,41 @@ body.modal-open { overflow-y: hidden !important; }
   .site-config-modal .upstream-line-port { width: 100%; min-width: 0; }
 }
 
-@media (min-width: 769px) {
-  html { scrollbar-width: auto; }
-  ::-webkit-scrollbar { width: 10px; height: 10px; }
-  ::-webkit-scrollbar-track { background: rgba(255,255,255,.03); }
-  ::-webkit-scrollbar-thumb { background: rgba(255,255,255,.18); border-radius: 999px; }
-  ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,.28); }
+@media (max-width: 600px) {
+  .dashboard-trend-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
-[hidden],
+@media (max-width: 768px) {
+  /* Keep the mobile editor's line-list surface and every line field visible. */
+  .site-config-modal .upstream-lines-card {
+    display: block !important;
+    width: 100%;
+    visibility: visible !important;
+  }
+  .site-config-modal .upstream-lines-head {
+    display: flex !important;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+  .site-config-modal .upstream-lines-buttons {
+    display: grid !important;
+    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .site-config-modal .upstream-lines-buttons > button {
+    min-width: 0;
+    width: 100%;
+  }
+  .site-config-modal .upstream-line-field,
+  .site-config-modal .upstream-line-address {
+    display: flex !important;
+    visibility: visible !important;
+  }
+}
+
 .site-settings-grid > .form-group[hidden],
 .site-settings-grid > [hidden] { display: none !important; }
 .site-cache-options {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -6155,7 +6155,9 @@ body.modal-open { overflow-y: hidden !important; }
   ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,.28); }
 }
 
-[hidden] { display: none !important; }
+[hidden],
+.site-settings-grid > .form-group[hidden],
+.site-settings-grid > [hidden] { display: none !important; }
 .site-cache-options {
   display: grid;
   gap: 14px;
@@ -6182,6 +6184,28 @@ body.modal-open { overflow-y: hidden !important; }
   overflow: visible;
 }
 
+
+/* Restore the desktop application header after the compact shell reset. */
+@media (min-width: 1181px) {
+  .app-header {
+    display: flex !important;
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    min-height: 64px;
+    margin-left: 260px;
+  }
+}
+@media (min-width: 769px) and (max-width: 1180px) {
+  .app-header {
+    display: flex !important;
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    min-height: 64px;
+    margin-left: 220px;
+  }
+}
 @media (max-width: 768px) {
   .dashboard-trend-controls .form-select {
     width: 100%;

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -5982,3 +5982,175 @@ html[data-theme="light"] {
   .site-cache-rules-body { padding: 10px; }
   .site-cache-rules-body textarea { min-height: 88px; }
 }
+
+/* Rebuilt site advanced-settings layout: each cache control owns one stable
+   card instead of participating in the legacy area-based form grid. */
+.site-settings-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px 20px;
+  align-items: start;
+  min-width: 0;
+}
+.site-settings-grid > .form-group {
+  display: block !important;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+}
+.site-settings-grid > .form-group > label,
+.site-settings-grid > .form-group > .form-help {
+  writing-mode: horizontal-tb;
+  word-break: normal;
+  white-space: normal;
+}
+.site-settings-grid > .cache-limit-group {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+.site-cache-panel-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 190px);
+  gap: 18px;
+  align-items: start;
+  min-width: 0;
+}
+.site-cache-panel-heading h3 { margin: 0 0 4px; color: var(--white-87); font-size: .92rem; font-weight: 650; }
+.site-cache-panel-heading p { margin: 0; color: var(--white-60); font-size: .76rem; line-height: 1.5; }
+.site-cache-panel-heading .form-select { width: 100%; min-width: 0; }
+.site-cache-rules-group {
+  display: block !important;
+  min-width: 0;
+  margin: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--panel-soft);
+}
+.site-cache-rules-group[hidden] { display: none !important; }
+.site-cache-rules-group > summary { padding: 11px 13px; }
+.site-cache-rules-body { min-width: 0; padding: 12px 13px 13px; }
+.site-cache-rules-body textarea { display: block; width: 100%; min-width: 0; min-height: 92px; resize: vertical; }
+.site-cache-limits {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px 12px;
+  align-items: center;
+  min-width: 0;
+}
+.site-cache-limits label { margin: 0; color: var(--white-60); font-size: .75rem; }
+.site-cache-limits .form-input { min-width: 0; width: 100%; }
+
+/* Rebuilt upstream rows: labels live inside each cell, so a header can never
+   wrap independently from the data row. */
+.site-config-modal .upstream-line-labels { display: none !important; }
+.site-config-modal .upstream-lines {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+.site-config-modal #m-failover-lines { display: contents; }
+.site-config-modal .upstream-line {
+  display: grid;
+  grid-template-columns: 54px minmax(145px, .85fr) minmax(260px, 1.65fr) 96px 88px 156px;
+  grid-template-areas: "enabled name address port latency actions";
+  gap: 10px;
+  align-items: end;
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--panel);
+}
+.site-config-modal .upstream-line-enabled { grid-area: enabled; align-self: end; }
+.site-config-modal .upstream-line-field { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.site-config-modal .upstream-line-field:nth-child(2) { grid-area: name; }
+.site-config-modal .upstream-line-field:nth-child(3) { grid-area: address; }
+.site-config-modal .upstream-line-field:nth-child(4) { grid-area: port; }
+.site-config-modal .upstream-line-field::before,
+.site-config-modal .upstream-line-latency::before,
+.site-config-modal .upstream-line-actions::before {
+  content: attr(data-label);
+  display: block;
+  min-height: 1.1em;
+  color: var(--white-38);
+  font-size: .68rem;
+  font-weight: 600;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+.site-config-modal .upstream-line-field .form-input { width: 100%; min-width: 0; }
+.site-config-modal .upstream-line-latency {
+  grid-area: latency;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 4px;
+  color: var(--white-60);
+  font-size: .78rem;
+  text-align: left;
+  white-space: nowrap;
+}
+.site-config-modal .upstream-line-actions {
+  grid-area: actions;
+  display: grid;
+  grid-template-columns: repeat(3, 34px);
+  grid-template-rows: auto 34px;
+  justify-content: end;
+  gap: 4px;
+  min-width: 0;
+}
+.site-config-modal .upstream-line-actions::before { grid-column: 1 / -1; }
+.site-config-modal .upstream-line-actions.primary-actions { grid-template-columns: 1fr; grid-template-rows: auto 34px; justify-items: end; }
+.site-config-modal .upstream-line-actions.primary-actions::before { justify-self: stretch; }
+.site-config-modal .upstream-line-actions .icon-button { width: 34px; height: 34px; }
+.site-config-modal .upstream-line-primary-note { align-self: center; color: var(--white-60); font-size: .78rem; }
+
+/* Keep page scrolling available on desktop; only an active modal locks the
+   document, while its own overlay/body remain independently scrollable. */
+html, body { min-height: 100%; overflow-y: auto !important; }
+body.modal-open { overflow-y: hidden !important; }
+#app-shell.active { min-height: 100vh; height: auto; overflow: visible !important; }
+.main { min-height: calc(100vh - 72px); overflow: visible; }
+
+@media (max-width: 768px) {
+  .site-settings-grid { display: block; }
+  .site-settings-grid > .form-group { margin-bottom: 16px; }
+  .site-settings-grid > .cache-limit-group { margin-bottom: 16px; padding: 13px; }
+  .site-cache-panel-heading { grid-template-columns: minmax(0, 1fr) 128px; gap: 10px; }
+  .site-cache-panel-heading h3 { font-size: .86rem; }
+  .site-cache-panel-heading p { font-size: .72rem; }
+  .site-cache-limits { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+  .site-config-modal .upstream-line {
+    grid-template-columns: minmax(0, 1fr) 132px;
+    grid-template-areas:
+      "enabled enabled"
+      "name port"
+      "address address"
+      "latency actions";
+    align-items: end;
+    padding: 13px;
+  }
+  .site-config-modal .upstream-line-enabled { grid-area: enabled; }
+  .site-config-modal .upstream-line-field:nth-child(2) { grid-area: name; }
+  .site-config-modal .upstream-line-field:nth-child(3) { grid-area: address; }
+  .site-config-modal .upstream-line-field:nth-child(4) { grid-area: port; }
+  .site-config-modal .upstream-line-latency { grid-area: latency; }
+  .site-config-modal .upstream-line-actions { grid-area: actions; }
+  .site-config-modal .upstream-line-actions.primary-actions { grid-template-columns: 1fr; }
+  .site-config-modal .upstream-line-port { width: 100%; min-width: 0; }
+}
+
+@media (min-width: 769px) {
+  html { scrollbar-width: auto; }
+  ::-webkit-scrollbar { width: 10px; height: 10px; }
+  ::-webkit-scrollbar-track { background: rgba(255,255,255,.03); }
+  ::-webkit-scrollbar-thumb { background: rgba(255,255,255,.18); border-radius: 999px; }
+  ::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,.28); }
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui14">
-<script src="/js/theme.js?v=1.9.3-ui14"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui14">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui15">
+<script src="/js/theme.js?v=1.9.3-ui15"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui15">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui14"></script>
-<script src="/js/toast.js?v=1.9.3-ui14"></script>
-<script src="/js/router.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui14"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui14"></script>
-<script src="/js/app.js?v=1.9.3-ui14"></script>
+<script src="/js/api.js?v=1.9.3-ui15"></script>
+<script src="/js/toast.js?v=1.9.3-ui15"></script>
+<script src="/js/router.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui15"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui15"></script>
+<script src="/js/app.js?v=1.9.3-ui15"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui4">
-<script src="/js/theme.js?v=1.9.3-ui4"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui4">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui5">
+<script src="/js/theme.js?v=1.9.3-ui5"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui5">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui4"></script>
-<script src="/js/toast.js?v=1.9.3-ui4"></script>
-<script src="/js/router.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui4"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui4"></script>
-<script src="/js/app.js?v=1.9.3-ui4"></script>
+<script src="/js/api.js?v=1.9.3-ui5"></script>
+<script src="/js/toast.js?v=1.9.3-ui5"></script>
+<script src="/js/router.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui5"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui5"></script>
+<script src="/js/app.js?v=1.9.3-ui5"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3">
-<script src="/js/theme.js?v=1.9.3"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui1">
+<script src="/js/theme.js?v=1.9.3-ui1"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui1">
 </head>
 <body class="auth-checking">
 
@@ -103,7 +103,7 @@
       </div>
     </div>
     <div class="app-header-actions">
-      <a class="github-project-link" href="https://github.com/chanhui800/Meridian" target="_blank" rel="noopener noreferrer" aria-label="打开 Meridian GitHub 项目" title="GitHub 项目">
+      <a class="github-project-link" href="https://github.com/snnabb/Meridian" target="_blank" rel="noopener noreferrer" aria-label="打开 Meridian GitHub 项目" title="GitHub 项目">
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2a10 10 0 0 0-3.16 19.49c.5.09.68-.22.68-.48v-1.86c-2.78.6-3.37-1.18-3.37-1.18-.45-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.61.07-.61 1 .07 1.53 1.03 1.53 1.03.9 1.53 2.34 1.09 2.91.83.09-.65.35-1.09.64-1.34-2.22-.25-4.56-1.11-4.56-4.94 0-1.09.39-1.98 1.03-2.68-.1-.25-.45-1.27.1-2.64 0 0 .84-.27 2.75 1.02A9.58 9.58 0 0 1 12 6.84a9.6 9.6 0 0 1 2.5.34c1.9-1.29 2.74-1.02 2.74-1.02.55 1.37.2 2.39.1 2.64.64.7 1.03 1.59 1.03 2.68 0 3.84-2.34 4.68-4.57 4.93.36.31.68.92.68 1.86v2.75c0 .27.18.58.69.48A10 10 0 0 0 12 2z"/></svg>
       </a>
       <button class="theme-toggle theme-toggle-header" id="theme-toggle" type="button" aria-label="切换到白色背景" aria-pressed="false" title="切换到白色背景">
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3"></script>
-<script src="/js/toast.js?v=1.9.3"></script>
-<script src="/js/router.js?v=1.9.3"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3"></script>
-<script src="/js/pages/sites.js?v=1.9.3"></script>
-<script src="/js/pages/diag.js?v=1.9.3"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3"></script>
-<script src="/js/pages/account.js?v=1.9.3"></script>
-<script src="/js/app.js?v=1.9.3"></script>
+<script src="/js/api.js?v=1.9.3-ui1"></script>
+<script src="/js/toast.js?v=1.9.3-ui1"></script>
+<script src="/js/router.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui1"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui1"></script>
+<script src="/js/app.js?v=1.9.3-ui1"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui6">
-<script src="/js/theme.js?v=1.9.3-ui6"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui6">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui7">
+<script src="/js/theme.js?v=1.9.3-ui7"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui7">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui6"></script>
-<script src="/js/toast.js?v=1.9.3-ui6"></script>
-<script src="/js/router.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui6"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui6"></script>
-<script src="/js/app.js?v=1.9.3-ui6"></script>
+<script src="/js/api.js?v=1.9.3-ui7"></script>
+<script src="/js/toast.js?v=1.9.3-ui7"></script>
+<script src="/js/router.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui7"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui7"></script>
+<script src="/js/app.js?v=1.9.3-ui7"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui5">
-<script src="/js/theme.js?v=1.9.3-ui5"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui5">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui6">
+<script src="/js/theme.js?v=1.9.3-ui6"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui6">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui5"></script>
-<script src="/js/toast.js?v=1.9.3-ui5"></script>
-<script src="/js/router.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui5"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui5"></script>
-<script src="/js/app.js?v=1.9.3-ui5"></script>
+<script src="/js/api.js?v=1.9.3-ui6"></script>
+<script src="/js/toast.js?v=1.9.3-ui6"></script>
+<script src="/js/router.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui6"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui6"></script>
+<script src="/js/app.js?v=1.9.3-ui6"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui1">
-<script src="/js/theme.js?v=1.9.3-ui1"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui1">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui2">
+<script src="/js/theme.js?v=1.9.3-ui2"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui2">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui1"></script>
-<script src="/js/toast.js?v=1.9.3-ui1"></script>
-<script src="/js/router.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui1"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui1"></script>
-<script src="/js/app.js?v=1.9.3-ui1"></script>
+<script src="/js/api.js?v=1.9.3-ui2"></script>
+<script src="/js/toast.js?v=1.9.3-ui2"></script>
+<script src="/js/router.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui2"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui2"></script>
+<script src="/js/app.js?v=1.9.3-ui2"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui8">
-<script src="/js/theme.js?v=1.9.3-ui8"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui8">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui9">
+<script src="/js/theme.js?v=1.9.3-ui9"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui9">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui8"></script>
-<script src="/js/toast.js?v=1.9.3-ui8"></script>
-<script src="/js/router.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui8"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui8"></script>
-<script src="/js/app.js?v=1.9.3-ui8"></script>
+<script src="/js/api.js?v=1.9.3-ui9"></script>
+<script src="/js/toast.js?v=1.9.3-ui9"></script>
+<script src="/js/router.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui9"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui9"></script>
+<script src="/js/app.js?v=1.9.3-ui9"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui3">
-<script src="/js/theme.js?v=1.9.3-ui3"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui3">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui4">
+<script src="/js/theme.js?v=1.9.3-ui4"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui4">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui3"></script>
-<script src="/js/toast.js?v=1.9.3-ui3"></script>
-<script src="/js/router.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui3"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui3"></script>
-<script src="/js/app.js?v=1.9.3-ui3"></script>
+<script src="/js/api.js?v=1.9.3-ui4"></script>
+<script src="/js/toast.js?v=1.9.3-ui4"></script>
+<script src="/js/router.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui4"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui4"></script>
+<script src="/js/app.js?v=1.9.3-ui4"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui2">
-<script src="/js/theme.js?v=1.9.3-ui2"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui2">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui3">
+<script src="/js/theme.js?v=1.9.3-ui3"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui3">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui2"></script>
-<script src="/js/toast.js?v=1.9.3-ui2"></script>
-<script src="/js/router.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui2"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui2"></script>
-<script src="/js/app.js?v=1.9.3-ui2"></script>
+<script src="/js/api.js?v=1.9.3-ui3"></script>
+<script src="/js/toast.js?v=1.9.3-ui3"></script>
+<script src="/js/router.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui3"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui3"></script>
+<script src="/js/app.js?v=1.9.3-ui3"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui9">
-<script src="/js/theme.js?v=1.9.3-ui9"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui9">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui10">
+<script src="/js/theme.js?v=1.9.3-ui10"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui10">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui9"></script>
-<script src="/js/toast.js?v=1.9.3-ui9"></script>
-<script src="/js/router.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui9"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui9"></script>
-<script src="/js/app.js?v=1.9.3-ui9"></script>
+<script src="/js/api.js?v=1.9.3-ui10"></script>
+<script src="/js/toast.js?v=1.9.3-ui10"></script>
+<script src="/js/router.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui10"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui10"></script>
+<script src="/js/app.js?v=1.9.3-ui10"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui7">
-<script src="/js/theme.js?v=1.9.3-ui7"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui7">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui8">
+<script src="/js/theme.js?v=1.9.3-ui8"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui8">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui7"></script>
-<script src="/js/toast.js?v=1.9.3-ui7"></script>
-<script src="/js/router.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui7"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui7"></script>
-<script src="/js/app.js?v=1.9.3-ui7"></script>
+<script src="/js/api.js?v=1.9.3-ui8"></script>
+<script src="/js/toast.js?v=1.9.3-ui8"></script>
+<script src="/js/router.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui8"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui8"></script>
+<script src="/js/app.js?v=1.9.3-ui8"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui12">
-<script src="/js/theme.js?v=1.9.3-ui12"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui12">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui13">
+<script src="/js/theme.js?v=1.9.3-ui13"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui13">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui12"></script>
-<script src="/js/toast.js?v=1.9.3-ui12"></script>
-<script src="/js/router.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui12"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui12"></script>
-<script src="/js/app.js?v=1.9.3-ui12"></script>
+<script src="/js/api.js?v=1.9.3-ui13"></script>
+<script src="/js/toast.js?v=1.9.3-ui13"></script>
+<script src="/js/router.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui13"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui13"></script>
+<script src="/js/app.js?v=1.9.3-ui13"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui10">
-<script src="/js/theme.js?v=1.9.3-ui10"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui10">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui12">
+<script src="/js/theme.js?v=1.9.3-ui12"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui12">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui10"></script>
-<script src="/js/toast.js?v=1.9.3-ui10"></script>
-<script src="/js/router.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui10"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui10"></script>
-<script src="/js/app.js?v=1.9.3-ui10"></script>
+<script src="/js/api.js?v=1.9.3-ui12"></script>
+<script src="/js/toast.js?v=1.9.3-ui12"></script>
+<script src="/js/router.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui12"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui12"></script>
+<script src="/js/app.js?v=1.9.3-ui12"></script>
 </body>
 </html>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
-<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui13">
-<script src="/js/theme.js?v=1.9.3-ui13"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui13">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.9.3-ui14">
+<script src="/js/theme.js?v=1.9.3-ui14"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.9.3-ui14">
 </head>
 <body class="auth-checking">
 
@@ -143,16 +143,16 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.9.3-ui13"></script>
-<script src="/js/toast.js?v=1.9.3-ui13"></script>
-<script src="/js/router.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/dashboard.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/sites.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/diag.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/request-logs.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/telegram-report.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/global-settings.js?v=1.9.3-ui13"></script>
-<script src="/js/pages/account.js?v=1.9.3-ui13"></script>
-<script src="/js/app.js?v=1.9.3-ui13"></script>
+<script src="/js/api.js?v=1.9.3-ui14"></script>
+<script src="/js/toast.js?v=1.9.3-ui14"></script>
+<script src="/js/router.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/dashboard.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/sites.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/diag.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/request-logs.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/telegram-report.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/global-settings.js?v=1.9.3-ui14"></script>
+<script src="/js/pages/account.js?v=1.9.3-ui14"></script>
+<script src="/js/app.js?v=1.9.3-ui14"></script>
 </body>
 </html>

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -31,14 +31,28 @@
     setup_token_required: false,
   };
 
+  function resetModalScroll() {
+    const overlay = document.getElementById('modal-overlay');
+    const modal = document.getElementById('modal');
+    const body = document.getElementById('modal-body');
+    if (overlay) overlay.scrollTop = 0;
+    if (modal) modal.scrollTop = 0;
+    if (body) body.scrollTop = 0;
+    document.getElementById('modal-body').scrollTop = 0;
+  }
+
   window.openModal = function(options) {
     modalBackdropClosable = !!(options && options.closeOnBackdrop);
     modalPreviousFocus = document.activeElement;
     const overlay = document.getElementById('modal-overlay');
-    document.getElementById('modal-body').scrollTop = 0;
+    resetModalScroll();
     overlay.classList.add('active');
     overlay.setAttribute('aria-hidden', 'false');
     document.body.classList.add('modal-open');
+    // Reset after layout as well: replacing modal content can restore the
+    // previous scroll position in some browsers after the overlay is shown.
+    if (typeof window.requestAnimationFrame === 'function') window.requestAnimationFrame(resetModalScroll);
+    if (typeof window.setTimeout === 'function') window.setTimeout(resetModalScroll, 0);
   };
 
   window.closeModal = function() {

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -161,7 +161,12 @@
     if (loginFooterEl) loginFooterEl.hidden = true;
   }
 
+  function revealAuthScreen() {
+    if (document.body && document.body.classList) document.body.classList.remove('auth-checking');
+  }
+
   function showAuthCheckError() {
+    revealAuthScreen();
     authMode = 'error';
     loginFormEl.setAttribute('aria-busy', 'false');
     loginButtonEl.disabled = true;
@@ -219,6 +224,7 @@
   }
 
   function showSetupMode() {
+    revealAuthScreen();
     authMode = 'setup';
     loginFormEl.setAttribute('aria-busy', 'false');
     if (authCheckStatusEl) authCheckStatusEl.hidden = true;
@@ -239,6 +245,7 @@
   }
 
   function showLoginMode() {
+    revealAuthScreen();
     authMode = 'login';
     loginFormEl.setAttribute('aria-busy', 'false');
     if (authCheckStatusEl) authCheckStatusEl.hidden = true;

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -525,6 +525,14 @@ function setupDashboardTrendControls() {
     const tooltip = canvas.parentElement.querySelector('.dashboard-chart-tooltip');
     const chart = { canvas, tooltip, hoverIndex: -1, hoverX: null, hoverY: null, pointerActive: false, geometry: null };
     dashboardTrendCharts.set(metric, chart);
+    const clearHover = () => {
+      chart.pointerActive = false;
+      chart.hoverIndex = -1;
+      chart.hoverX = null;
+      chart.hoverY = null;
+      if (tooltip) tooltip.hidden = true;
+      drawDashboardTrendChart(metric);
+    };
     const updateHover = event => {
       const points = dashboardTrendPoints();
       if (!points.length) return;
@@ -563,10 +571,10 @@ function setupDashboardTrendControls() {
       if (event.pointerType === 'mouse' || chart.pointerActive) updateHover(event);
     });
     canvas.addEventListener('pointerup', event => {
-      chart.pointerActive = false;
       if (canvas.releasePointerCapture && canvas.hasPointerCapture?.(event.pointerId)) canvas.releasePointerCapture(event.pointerId);
+      clearHover();
     });
-    canvas.addEventListener('pointercancel', () => { chart.pointerActive = false; });
+    canvas.addEventListener('pointercancel', clearHover);
     canvas.addEventListener('pointerleave', event => {
       if (event.pointerType !== 'mouse') return;
       chart.hoverIndex = -1; chart.hoverX = null; chart.hoverY = null;

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -311,6 +311,27 @@ function dashboardRoundRect(ctx, x, y, width, height, radius) {
   ctx.closePath();
 }
 
+function dashboardTraceSmoothLine(ctx, points) {
+  if (!points.length) return;
+  if (points.length === 1) {
+    ctx.moveTo(points[0].x, points[0].y);
+    return;
+  }
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let index = 0; index < points.length - 1; index++) {
+    const previous = points[index - 1] || points[index];
+    const current = points[index];
+    const next = points[index + 1];
+    const following = points[index + 2] || next;
+    const tension = 1 / 6;
+    const control1X = current.x + (next.x - previous.x) * tension;
+    const control1Y = current.y + (next.y - previous.y) * tension;
+    const control2X = next.x - (following.x - current.x) * tension;
+    const control2Y = next.y - (following.y - current.y) * tension;
+    ctx.bezierCurveTo(control1X, control1Y, control2X, control2Y, next.x, next.y);
+  }
+}
+
 function drawDashboardTrendChart(metric) {
   const chart = dashboardTrendCharts.get(metric);
   const points = dashboardTrendPoints();
@@ -354,12 +375,12 @@ function drawDashboardTrendChart(metric) {
   canvasSeries.forEach(item => {
     const pointsOnCanvas = item.points;
     ctx.beginPath();
-    pointsOnCanvas.forEach((point, index) => index ? ctx.lineTo(point.x, point.y) : ctx.moveTo(point.x, point.y));
+    dashboardTraceSmoothLine(ctx, pointsOnCanvas);
     if (metric !== 'speed') {
       ctx.lineTo(pointsOnCanvas[pointsOnCanvas.length - 1].x, top + plotH); ctx.lineTo(pointsOnCanvas[0].x, top + plotH); ctx.closePath();
       ctx.globalAlpha = .12; ctx.fillStyle = item.color; ctx.fill(); ctx.globalAlpha = 1;
       ctx.beginPath();
-      pointsOnCanvas.forEach((point, index) => index ? ctx.lineTo(point.x, point.y) : ctx.moveTo(point.x, point.y));
+      dashboardTraceSmoothLine(ctx, pointsOnCanvas);
     }
     ctx.strokeStyle = item.color; ctx.lineWidth = 2.5; ctx.lineJoin = 'round'; ctx.lineCap = 'round'; ctx.stroke();
   });

--- a/web/static/js/pages/global-settings.js
+++ b/web/static/js/pages/global-settings.js
@@ -24,7 +24,7 @@ function globalSettingsNav(active) {
   const button = (id, label) => `<button type="button" class="settings-nav-item ${active === id ? 'active' : ''}" data-settings-section="${id}">${label}</button>`;
   return `<aside class="settings-section-nav">
     <span>SETTINGS</span><strong>全局设置导航</strong>
-    ${button('system-ui', '系统 UI')}${button('logs', '日志设置')}
+    ${button('system-ui', '系统设置')}${button('logs', '日志设置')}
     <a href="#settings-tls" class="settings-nav-item ${active === 'tls' ? 'active' : ''}">TLS 设置</a>
     <a href="#telegram-report" class="settings-nav-item ${active === 'telegram' ? 'active' : ''}">Telegram 通知</a>
     <a href="#diagnostics" class="settings-nav-item ${active === 'diagnostics' ? 'active' : ''}">故障诊断</a>
@@ -196,7 +196,7 @@ function paintGlobalSettings(page = document.getElementById('page-global-setting
 }
 
 function renderSystemUIForm(s) {
-  return `<section class="settings-panel"><header><span>TRAFFIC</span><h2>流量计费模式</h2><b>全局统计与额度</b></header>
+  return `<section class="settings-panel"><header><span>SYSTEM</span><h2>系统设置</h2><b>全局运行参数</b></header>
     <p class="settings-panel-help">单向仅计 VPS 发给客户端的出站流量；双向同时计源站回到 VPS 的入站与 VPS 发给客户端的出站流量。</p>
     <span class="settings-label">计费方向</span><div class="settings-choice" id="traffic-billing-mode-choice"><button data-setting-choice="outbound" class="${s.traffic_billing_mode === 'outbound' ? 'active' : ''}">单向（仅下载）</button><button data-setting-choice="bidirectional" class="${s.traffic_billing_mode !== 'outbound' ? 'active' : ''}">双向（下载 + 上传）</button></div>
   </section>
@@ -226,16 +226,28 @@ function renderLogSettingsForm(s) {
     ${settingsNumber('setting-log-retries', '写入重试次数', s.log_retry_count, 0, 10, '次')}${settingsNumber('setting-log-backoff', '重试退避', s.log_retry_backoff_ms, 0, 5000, 'ms')}
     ${settingsNumber('setting-log-lease', '定时任务租约时长', s.log_task_lease_ms, 1000, 900000, 'ms')}
   </div></section>
-  <section class="settings-panel"><header><span>RESOURCE CATEGORIES</span><h2>资源类别写入</h2><b>默认按需写入</b></header><p class="settings-panel-help">图片海报与媒体元数据默认不写入。勾选后，后续命中的请求才会写入日志，并自然出现在日志页中。</p><div class="settings-grid">
-    ${settingsCheck('setting-write-playback', '播放信息与状态同步', s.log_write_playback !== false, 'PlaybackInfo，以及 Sessions/Playing、Progress、Stopped、Ping 等播放状态同步请求。')}${settingsCheck('setting-write-video', '视频流', s.log_write_video !== false, '主视频或音频流、HLS/DASH 清单与媒体分片。')}
-    ${settingsCheck('setting-write-image', '图片海报', s.log_write_image === true, 'Images、Icons、Branding、封面与常见图片文件。')}${settingsCheck('setting-write-metadata', '媒体元数据', s.log_write_metadata === true, 'Items、Shows、Movies 与 Users 等媒体资料请求。')}
-    ${settingsCheck('setting-write-api', '常规 API', s.log_write_api !== false, '不属于其他明确类别的普通 API 与状态查询请求。')}${settingsCheck('setting-write-auth', '用户认证', s.log_write_auth !== false, 'Authenticate 与 QuickConnect 等登录认证请求。')}
-    ${settingsCheck('setting-write-subtitle', '字幕', s.log_write_subtitle !== false, '字幕路径以及 SRT、ASS、VTT 等字幕文件。')}${settingsCheck('setting-write-asset', '静态资源', s.log_write_asset !== false, 'JavaScript、CSS、字体、Source Map 与 Web Manifest。')}
-    ${settingsCheck('setting-write-websocket', 'WebSocket', s.log_write_websocket !== false, '带 Upgrade 意图的实时连接请求。')}
-  </div></section>
-  <div class="settings-two-column"><section class="settings-panel"><header><span>WRITE</span><h2>日志字段写入</h2><b>仅影响后续新日志</b></header><p class="settings-panel-help">关闭后，新写入日志会直接省略对应字段；旧日志不会被回收或改写。</p>${settingsCheck('setting-write-node', '写入节点', s.log_write_node !== false, '保存请求命中的站点节点名称。')}${settingsCheck('setting-write-category', '写入资源类别', s.log_write_category !== false, '保存媒体元数据、视频流、图片海报、API 或认证类别。')}${settingsCheck('setting-write-status', '写入状态', s.log_write_status !== false, '保存请求返回的 HTTP 状态码。')}${settingsCheck('setting-write-ip', '写入客户端 IP', s.log_write_client_ip !== false, '保存访问来源 IP，便于区分客户端。')}${settingsCheck('setting-write-ua', '写入客户端 UA', s.log_write_ua !== false, '保存客户端发给 Meridian 的原始 UA，用于识别实际播放客户端。')}${settingsCheck('setting-write-upstream-ua', '写入上游 UA', s.log_write_upstream_ua !== false, '保存 Meridian 最终发给 Emby 或 Jellyfin 后端的 UA；透传模式下与客户端 UA 相同。')}${settingsCheck('setting-write-backend-address', '写入后端地址', s.log_write_backend_address !== false, '保存该请求实际连接的推流后端 authority，不写入路径、查询参数或令牌。')}${settingsCheck('setting-write-timeline', '写入时间线', s.log_write_timeline !== false, '保存日志页展示的请求发生时间；内部清理与统计时间不受影响。')}</section>
-  <section class="settings-panel"><header><span>DISPLAY</span><h2>日志字段展示</h2><b>仅影响日志页</b></header><p class="settings-panel-help">关闭后，字段仍可按写入设置保留在新日志里，但日志表格会隐藏对应列。</p>${settingsCheck('setting-display-node', '展示节点', s.log_display_node !== false, '在日志表格中显示节点名称。')}${settingsCheck('setting-display-category', '展示资源类别', s.log_display_category !== false, '在日志表格中显示资源类别。')}${settingsCheck('setting-display-status', '展示状态', s.log_display_status !== false, '在日志表格中显示 HTTP 状态码。')}${settingsCheck('setting-display-ip', '展示客户端 IP', s.log_display_client_ip !== false, '在日志表格中显示客户端 IP 列。')}${settingsCheck('setting-display-ua', '展示客户端 UA', s.log_display_ua !== false, '在日志表格中显示客户端传入的原始 UA。')}${settingsCheck('setting-display-upstream-ua', '展示上游 UA', s.log_display_upstream_ua !== false, '在日志表格中显示 Meridian 实际发给后端的 UA。')}${settingsCheck('setting-display-backend-address', '展示后端地址', s.log_display_backend_address !== false, '在日志表格中显示该请求最终使用的推流后端。')}${settingsCheck('setting-display-timeline', '展示时间线', s.log_display_timeline !== false, '在日志表格中显示请求相对时间。')}</section></div>
-  <section class="settings-panel"><header><span>SEARCH</span><h2>日志搜索模式</h2><b>LIKE / FTS</b></header><div class="settings-choice" id="log-search-choice"><button data-setting-choice="like" class="${s.log_search_mode === 'like' ? 'active' : ''}">LIKE 模糊匹配</button><button data-setting-choice="fts" class="${s.log_search_mode === 'fts' ? 'active' : ''}">FTS 分词查询</button></div></section>${settingsSaveBar()}`;
+  <section class="settings-panel"><header><span>RESOURCE CATEGORIES</span><h2>记录哪些请求</h2><b>按需写入</b></header><p class="settings-panel-help">只开启排查时需要的类别，减少日志噪音。</p><div class="settings-check-grid">
+    ${settingsCheck('setting-write-playback', '播放信息', s.log_write_playback !== false)}${settingsCheck('setting-write-video', '视频与流媒体', s.log_write_video !== false)}
+    ${settingsCheck('setting-write-api', '常规 API', s.log_write_api !== false)}${settingsCheck('setting-write-auth', '用户认证', s.log_write_auth !== false)}
+    ${settingsCheck('setting-write-asset', '静态资源', s.log_write_asset !== false)}
+  </div><details class="settings-more"><summary>更多类别</summary><div class="settings-check-grid">
+    ${settingsCheck('setting-write-image', '图片海报', s.log_write_image === true)}${settingsCheck('setting-write-metadata', '媒体元数据', s.log_write_metadata === true)}
+    ${settingsCheck('setting-write-subtitle', '字幕', s.log_write_subtitle !== false)}${settingsCheck('setting-write-websocket', 'WebSocket', s.log_write_websocket !== false)}
+  </div></details></section>
+  <div class="settings-two-column"><section class="settings-panel"><header><span>WRITE</span><h2>日志字段写入</h2><b>仅影响新日志</b></header><p class="settings-panel-help">关闭不需要的字段可减少存储和页面噪音。</p><div class="settings-check-grid">
+    ${settingsCheck('setting-write-node', '节点', s.log_write_node !== false)}${settingsCheck('setting-write-status', '状态码', s.log_write_status !== false)}
+    ${settingsCheck('setting-write-ip', '客户端 IP', s.log_write_client_ip !== false)}${settingsCheck('setting-write-ua', '客户端 UA', s.log_write_ua !== false)}
+    ${settingsCheck('setting-write-backend-address', '后端地址', s.log_write_backend_address !== false)}
+  </div><details class="settings-more"><summary>更多字段</summary><div class="settings-check-grid">
+    ${settingsCheck('setting-write-category', '资源类别', s.log_write_category !== false)}${settingsCheck('setting-write-upstream-ua', '上游 UA', s.log_write_upstream_ua !== false)}${settingsCheck('setting-write-timeline', '时间线', s.log_write_timeline !== false)}
+  </div></details></section>
+  <section class="settings-panel"><header><span>DISPLAY</span><h2>日志字段展示</h2><b>仅影响日志页</b></header><p class="settings-panel-help">只保留排查时真正需要的列，其他字段可在“更多字段”中打开。</p><div class="settings-check-grid">
+    ${settingsCheck('setting-display-node', '节点', s.log_display_node !== false)}${settingsCheck('setting-display-status', '状态码', s.log_display_status !== false)}
+    ${settingsCheck('setting-display-ip', '客户端 IP', s.log_display_client_ip !== false)}${settingsCheck('setting-display-ua', '客户端 UA', s.log_display_ua !== false)}
+    ${settingsCheck('setting-display-backend-address', '后端地址', s.log_display_backend_address !== false)}
+  </div><details class="settings-more"><summary>更多字段</summary><div class="settings-check-grid">
+    ${settingsCheck('setting-display-category', '资源类别', s.log_display_category !== false)}${settingsCheck('setting-display-upstream-ua', '上游 UA', s.log_display_upstream_ua !== false)}${settingsCheck('setting-display-timeline', '时间线', s.log_display_timeline !== false)}
+  </div></details></section></div>${settingsSaveBar()}`;
 }
 
 function settingsSaveBar() { return '<div class="settings-save-bar"><button class="telegram-btn primary" type="button" id="settings-save">保存设置</button></div>'; }
@@ -301,7 +313,7 @@ async function saveGlobalSettings() {
     s.log_display_category = checkedSetting('setting-display-category', true);
     s.log_display_status = checkedSetting('setting-display-status', true);
     s.log_display_timeline = checkedSetting('setting-display-timeline', true);
-    s.log_search_mode = activeSettingChoice('log-search-choice', s.log_search_mode);
+    // Search mode is intentionally kept at its server default; the log page uses one simple search box.
   }
   const button = document.getElementById('settings-save');
   button.disabled = true;

--- a/web/static/js/pages/request-logs.js
+++ b/web/static/js/pages/request-logs.js
@@ -168,31 +168,28 @@ function renderRequestLogs() {
       </div>
 
       <div class="request-log-filter-row">
-        <span class="request-log-filter-label">筛选模式</span>
-        <div class="request-log-pills" id="request-log-category-pills">
-          <button type="button" class="request-log-pill active" data-category="all">全部</button>
-          <button type="button" class="request-log-pill" data-category="playback">播放信息</button>
-          <button type="button" class="request-log-pill" data-category="playback_sync">播放状态同步</button>
-          <button type="button" class="request-log-pill" data-category="stream">主视频流</button>
-          <button type="button" class="request-log-pill" data-category="manifest">播放清单</button>
-          <button type="button" class="request-log-pill" data-category="segment">媒体分片</button>
-          <button type="button" class="request-log-pill" data-category="image">图片海报</button>
-          <button type="button" class="request-log-pill" data-category="metadata">媒体元数据</button>
-          <button type="button" class="request-log-pill" data-category="subtitle">字幕</button>
-          <button type="button" class="request-log-pill" data-category="asset">静态资源</button>
-          <button type="button" class="request-log-pill" data-category="websocket">WebSocket</button>
-          <button type="button" class="request-log-pill" data-category="api">常规 API</button>
-          <button type="button" class="request-log-pill" data-category="auth">用户认证</button>
-        </div>
+        <label class="request-log-filter-label" for="request-log-category">资源类别</label>
+        <select class="form-select request-log-filter-select" id="request-log-category">
+          <option value="all">全部资源</option>
+          <option value="playback">播放信息</option>
+          <option value="playback_sync">播放状态同步</option>
+          <option value="video">视频与流媒体</option>
+          <option value="image">图片海报</option>
+          <option value="asset">静态资源</option>
+          <option value="api">常规 API</option>
+          <option value="auth">用户认证</option>
+        </select>
       </div>
 
       <div class="request-log-filter-row">
-        <span class="request-log-filter-label">状态筛选</span>
-        <div class="request-log-pills" id="request-log-status-pills">
-          <button type="button" class="request-log-pill active" data-status="all">全部状态</button>
-          <button type="button" class="request-log-pill" data-status="4xx">只看 4XX</button>
-          <button type="button" class="request-log-pill" data-status="5xx">只看 5XX</button>
-        </div>
+        <label class="request-log-filter-label" for="request-log-status">状态</label>
+        <select class="form-select request-log-filter-select" id="request-log-status">
+          <option value="all">全部状态</option>
+          <option value="2xx">正常 2xx</option>
+          <option value="3xx">正常 3xx</option>
+          <option value="4xx">客户端错误 4xx</option>
+          <option value="5xx">服务端错误 5xx</option>
+        </select>
       </div>
 
       <div class="request-log-ua-width-control">
@@ -237,20 +234,16 @@ function renderRequestLogs() {
   `;
   requestLogApplyUAWidth();
 
-  document.querySelectorAll('#request-log-category-pills .request-log-pill').forEach(button => {
-    button.onclick = () => {
-      requestLogCategoryFilter = button.dataset.category;
-      setRequestLogActivePill('request-log-category-pills', button);
-      loadRequestLogs();
-    };
-  });
-  document.querySelectorAll('#request-log-status-pills .request-log-pill').forEach(button => {
-    button.onclick = () => {
-      requestLogStatusFilter = button.dataset.status;
-      setRequestLogActivePill('request-log-status-pills', button);
-      loadRequestLogs();
-    };
-  });
+  const categorySelect = document.getElementById('request-log-category');
+  if (categorySelect) categorySelect.onchange = event => {
+    requestLogCategoryFilter = event.target.value;
+    loadRequestLogs();
+  };
+  const statusSelect = document.getElementById('request-log-status');
+  if (statusSelect) statusSelect.onchange = event => {
+    requestLogStatusFilter = event.target.value;
+    loadRequestLogs();
+  };
   document.getElementById('request-log-from').onchange = loadRequestLogs;
   document.getElementById('request-log-to').onchange = loadRequestLogs;
   document.getElementById('request-log-search').oninput = () => {

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1330,7 +1330,7 @@ async function showSiteModal(site) {
 	</div>
 	<div class="form-group upstream-lines-card">
 	  <div class="upstream-lines-head">
-	    <div><label>线路列表</label><div class="form-help">主线路失败时按顺序切换，恢复后自动回切。备用线路沿用主线路的反代、自动发现和请求策略。</div></div>
+	    <div><label>线路列表</label><div class="form-help">主线路失败时按顺序切换，恢复后自动回切。</div></div>
 	    <div class="upstream-lines-buttons">
 	      <button type="button" class="btn-ghost upstream-test-all" id="m-test-all-lines">线路测速</button>
 	      <button type="button" class="btn-add upstream-add-line" id="m-add-failover-line">+ 添加线路</button>
@@ -1349,13 +1349,13 @@ async function showSiteModal(site) {
 	    </div>
 	    <div id="m-failover-lines"></div>
 	  </div>
-	  <div class="form-help">域名栏可包含协议和 Base URL 路径；端口单独填写。443 默认 HTTPS，其他端口默认 HTTP。最多添加 7 条备用线路；禁用线路会保留配置但不参与故障转移。</div>
+	  <div class="form-help">域名可包含协议和 Base URL 路径；端口单独填写。最多 7 条备用线路。</div>
 	</div>
 		<div class="form-group site-form-wide">
 		  <label>主回源固定请求头（可选）</label>
 		  <div id="m-upstream-headers"></div>
 		  <button type="button" class="btn-ghost upstream-header-add" id="m-add-upstream-header" ${upstreamHeadersAvailable ? '' : 'disabled'}>+ 添加请求头</button>
-		  <div class="form-help">值使用 UPSTREAM_HEADER_KEY 加密保存且不会回显，只发送给主回源的精确协议、域名和端口；更换主回源的协议、域名或端口后必须重新输入这些值。</div>
+		  <div class="form-help">使用 UPSTREAM_HEADER_KEY 加密保存，不会回显；仅发送到主回源。</div>
 		  ${upstreamHeadersAvailable ? '' : '<div class="form-help" style="color:var(--orange)">当前部署未配置 UPSTREAM_HEADER_KEY，不能新增、重命名或修改 Header 值；仍可删除旧配置。配置密钥并重启后可恢复编辑。</div>'}
 		</div>
     <details class="site-advanced-card site-form-wide" open>
@@ -1380,7 +1380,7 @@ async function showSiteModal(site) {
       <input type="text" class="form-input" id="m-custom-ua" placeholder="User-Agent" maxlength="1024" autocapitalize="none" autocorrect="off" spellcheck="false">
       <input type="text" class="form-input" id="m-custom-client" placeholder="Emby Client" maxlength="128" autocapitalize="none" autocorrect="off" spellcheck="false" style="margin-top:8px">
       <input type="text" class="form-input" id="m-custom-version" placeholder="Emby Version" maxlength="64" autocapitalize="none" autocorrect="off" spellcheck="false" style="margin-top:8px">
-      <div class="form-help">仅改写 User-Agent、Client 和 Version；Device 与 DeviceId 保持原样。</div>
+      <div class="form-help">只改写 User-Agent、Client、Version；Device 与 DeviceId 保持不变。</div>
     </div>
     <div class="form-group">
       <label>真实客户端 IP 透传</label>
@@ -1389,7 +1389,7 @@ async function showSiteModal(site) {
         <option value="real_ip" ${isEdit && site.client_ip_mode === 'real_ip' ? 'selected' : ''}>仅保留 X-Real-IP</option>
         <option value="none" ${isEdit && site.client_ip_mode === 'none' ? 'selected' : ''}>强制不透传（慎用）</option>
       </select>
-      <div class="form-help">仅控制发送给回源的 X-Real-IP 与 X-Forwarded-For；客户端来源仍按可信代理规则识别，日志中的客户端 IP 不受影响。</div>
+      <div class="form-help">仅影响发往回源的 X-Real-IP 与 X-Forwarded-For。</div>
     </div>
     <div class="form-group">
       <label>主视频流策略</label>
@@ -1397,8 +1397,8 @@ async function showSiteModal(site) {
         <option value="proxy" ${!isEdit || site.main_video_stream_mode !== 'direct' ? 'selected' : ''}>反代</option>
         <option value="direct" ${isEdit && site.main_video_stream_mode === 'direct' ? 'selected' : ''}>直连</option>
       </select>
-      <div class="form-help">反代沿用当前策略。直连会校验网盘或 CDN 的 302 等最终公网地址，再将 MP4、MKV、MOV、AVI、WebM 及 /Videos/.../stream、original、download、file 等主视频体通过 307 交给播放器；面板、API、PlaybackInfo、HLS / DASH、字幕、图片和必要静态资源仍由 Meridian 反代。</div>
-      <div class="form-help">自动发现保持启用；localhost、私网、链路本地及回环目标始终拒绝。</div>
+      <div class="form-help">直连仅适用于主视频文件；面板、API、HLS/DASH 等仍由 Meridian 代理。</div>
+      <div class="form-help">自动发现保持启用；私网、回环和链路本地目标始终拒绝。</div>
     </div>
     <div class="form-group">
       <label for="m-asset-cache">缓存图片与静态资源</label>
@@ -1406,7 +1406,7 @@ async function showSiteModal(site) {
         <option value="off" ${!isEdit || !site.asset_cache_enabled ? 'selected' : ''}>关闭</option>
         <option value="on" ${isEdit && site.asset_cache_enabled ? 'selected' : ''}>开启</option>
       </select>
-      <div class="form-help">仅缓存图片、CSS、JS、字体和 WASM；视频、音频、HLS、DASH、Range 请求、私有响应及带 Set-Cookie 的响应永不缓存。</div>
+      <div class="form-help">仅缓存图片与静态资源；视频、音频、HLS/DASH、Range 和私有响应不缓存。</div>
     </div>
     <div class="form-group">
       <label>缓存规则（每行一条，支持 * 通配）</label>
@@ -1431,7 +1431,7 @@ async function showSiteModal(site) {
     <div class="form-group">
       <label>单连接限速 (Mbps, 0=不限)</label>
       <input type="number" class="form-input" id="m-speed" value="${isEdit ? (site.speed_limit || 0) : 0}" placeholder="0" min="0" max="1000000" step="1" inputmode="numeric">
-      <div class="form-help">限制单个 HTTP 响应和 WebSocket 下行连接的速度；上传方向不受此项影响。</div>
+      <div class="form-help">限制单个连接的下行速度，上传不受影响。</div>
       </div>
       </div>
     </details>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -672,9 +672,8 @@ function buildDynamicPolicyPayload(policy, capabilities) {
 function renderDynamicProfileOptions(capabilities, selectedProfile) {
 	const dynamicCapabilities = normalizeDynamicProfiles(capabilities);
 	const normalizedSelected = normalizeDynamicProfile(selectedProfile);
-	const selected = normalizedSelected === 'extreme' ? 'extreme' : 'compatible';
-	return dynamicCapabilities.profiles.filter(profile => profile.id !== 'safe').map(profile => `
-		<option value="${esc(profile.id)}" ${profile.id === selected ? 'selected' : ''}>${esc(profile.label)}${profile.recommended ? '（推荐）' : ''}</option>
+	return dynamicCapabilities.profiles.map(profile => `
+		<option value="${esc(profile.id)}" ${profile.id === normalizedSelected ? 'selected' : ''}>${esc(profile.label)}${profile.recommended ? '（推荐）' : ''}</option>
 	`).join('');
 }
 
@@ -715,16 +714,9 @@ function renderDynamicRuleRows(rules) {
 
 function renderDynamicStatus(capabilities) {
 	const dynamicCapabilities = normalizeDynamicProfiles(capabilities);
-	const contractWarning = dynamicCapabilities.recognized
-		? ''
-		: '<div class="form-help" style="color:var(--orange)">动态能力数据缺失、格式异常或版本过旧，已按不可用处理。</div>';
 	const keyStatus = !dynamicCapabilities.recognized ? '未知' : dynamicCapabilities.key_configured ? '已配置' : '未配置';
-	return `
-		<div class="form-help"><strong>自动发现</strong>默认处理 HTTP 30x 和 PlaybackInfo，无需手工维护额外地址。</div>
-		${contractWarning}
-		<div class="form-help">播放失败时，可在高级选项中开启 HLS、DASH，或切换到 Extreme 扩展兼容模式。</div>
-		<div class="form-help">部署状态：${dynamicCapabilities.available ? '可用' : '不可用'}；DYNAMIC_ROUTE_KEY：${keyStatus}</div>
-	`;
+	if (!dynamicCapabilities.recognized) return '<span class="form-help">自动发现能力不可用，请检查后端版本。</span>';
+	return `<span class="form-help">自动发现：${dynamicCapabilities.available ? '已可用' : '未启用'} · DYNAMIC_ROUTE_KEY：${keyStatus} · 默认处理 HTTP 30x 和 PlaybackInfo</span>`;
 }
 
 function dynamicProfileRiskNotice(profile) {
@@ -787,10 +779,7 @@ function renderDynamicEnableControl(capabilities, policy) {
 	const dynamicPolicy = normalizeDynamicSitePolicy(policy);
 	const enableEditable = dynamicCapabilities.recognized && (dynamicCapabilities.available || dynamicPolicy.dynamic_discovery_enabled);
 	return `
-		<label style="display:flex;gap:8px;align-items:center;margin-top:10px">
-          <input type="checkbox" id="m-dynamic-enabled" ${dynamicPolicy.dynamic_discovery_enabled ? 'checked' : ''} ${enableEditable ? '' : 'disabled'}>
-		  启用自动发现（推荐）
-		</label>
+		<label class="site-dynamic-toggle"><input type="checkbox" id="m-dynamic-enabled" ${dynamicPolicy.dynamic_discovery_enabled ? 'checked' : ''} ${enableEditable ? '' : 'disabled'}><span>启用自动发现</span></label>
 	`;
 }
 
@@ -1245,12 +1234,17 @@ async function showSiteModal(site) {
   const isEdit = !!site;
   const title = isEdit ? '编辑站点' : '添加站点';
 	let siteCapabilities;
+	let dynamicCapabilities;
 	try {
-		siteCapabilities = normalizeSiteCapabilities(await API.ingressCapabilities());
+		[siteCapabilities, dynamicCapabilities] = await Promise.all([
+			API.ingressCapabilities().then(normalizeSiteCapabilities),
+			loadDynamicProfiles(),
+		]);
 	} catch (error) {
 		Toast.error(`无法读取站点能力：${error.message}`);
 		return;
 	}
+	dynamicCapabilities = normalizeDynamicProfiles(dynamicCapabilities);
 	const hostOnlyAvailable = siteCapabilities.host_only_available;
 	const upstreamHeadersAvailable = siteCapabilities.upstream_headers_available;
 	const domainPrefixAvailable = siteCapabilities.domain_prefix_available === true;
@@ -1295,6 +1289,14 @@ async function showSiteModal(site) {
 			: !panelTLSReady
 				? '请先在 TLS 页配置面板域名、泛域名并申请证书，完成后才能启用域名前缀。'
 				: '';
+	const dynamicPolicy = normalizeDynamicSitePolicy(isEdit ? site : {
+		dynamic_discovery_enabled: true,
+		dynamic_profile: 'compatible',
+		dynamic_discovery_sources: [...DEFAULT_DYNAMIC_SOURCE_IDS, ...ADVANCED_DYNAMIC_SOURCE_IDS],
+		dynamic_domain_rules: [],
+		dynamic_allow_https_downgrade: true,
+	});
+	let dynamicRules = [...dynamicPolicy.dynamic_domain_rules];
   document.getElementById('modal-title').textContent = title;
   document.getElementById('modal-body').innerHTML = `
     <div class="form-group">
@@ -1358,7 +1360,33 @@ async function showSiteModal(site) {
 		  <div class="form-help">使用 UPSTREAM_HEADER_KEY 加密保存，不会回显；仅发送到主回源。</div>
 		  ${upstreamHeadersAvailable ? '' : '<div class="form-help" style="color:var(--orange)">当前部署未配置 UPSTREAM_HEADER_KEY，不能新增、重命名或修改 Header 值；仍可删除旧配置。配置密钥并重启后可恢复编辑。</div>'}
 		</div>
-    <details class="site-advanced-card site-form-wide" open>
+		<div class="form-group site-form-wide site-dynamic-card">
+		  <div class="site-feature-heading"><div><label>自动发现</label>${renderDynamicStatus(dynamicCapabilities)}</div><span class="site-feature-badge">播放兼容</span></div>
+		  <div class="site-dynamic-row">
+		    ${renderDynamicEnableControl(dynamicCapabilities, dynamicPolicy)}
+		    <label class="site-dynamic-profile"><span>模式</span><select class="form-select modal-select" id="m-dynamic-profile" ${dynamicCapabilities.recognized ? '' : 'disabled'}>${renderDynamicProfileOptions(dynamicCapabilities, dynamicPolicy.dynamic_profile)}</select></label>
+		  </div>
+		  <div class="site-dynamic-sources" id="m-dynamic-sources" ${dynamicCapabilities.recognized ? '' : 'hidden'}>
+		    <span class="site-dynamic-label">处理来源</span>
+		    ${DYNAMIC_SOURCE_IDS.map(source => `<label><input type="checkbox" id="m-dynamic-source-${source}" data-dynamic-source="${source}" ${dynamicPolicy.dynamic_discovery_sources.includes(source) ? 'checked' : ''}>${DYNAMIC_SOURCE_LABELS[source]}</label>`).join('')}
+		  </div>
+		  <div class="site-dynamic-help" id="m-dynamic-help">兼容模式默认处理 HTTP 30x、PlaybackInfo、HLS 和 DASH；仍拒绝私网与回环目标。</div>
+		  <div class="site-dynamic-extreme" id="m-dynamic-extreme-confirm" hidden>
+		    <label class="site-dynamic-check"><input type="checkbox" id="m-dynamic-extreme-ack"><span>我了解 Extreme 会放宽动态兼容范围</span></label>
+		    <input type="text" class="form-input" id="m-dynamic-extreme-name" placeholder="输入站点名称确认" autocomplete="off">
+		  </div>
+		  <details class="site-dynamic-advanced">
+		    <summary>安全规则与观察记录</summary>
+		    <div class="site-dynamic-advanced-body">
+		      <label class="site-dynamic-check"><input type="checkbox" id="m-dynamic-downgrade" ${dynamicPolicy.dynamic_allow_https_downgrade ? 'checked' : ''}><span>允许 HTTPS 回源降级到 HTTP</span></label>
+		      <div class="form-help">仅兼容模式生效；Safe 模式始终禁止。</div>
+		      <div class="site-dynamic-rules-head"><span>Safe 域名规则</span><button type="button" class="btn-ghost" id="m-add-dynamic-rule">添加规则</button></div>
+		      <div id="m-dynamic-rules"></div>
+		      ${isEdit ? renderDynamicObservationsPanel(dynamicCapabilities.recognized && dynamicCapabilities.available) : ''}
+		    </div>
+		  </details>
+		</div>
+	    <details class="site-advanced-card site-form-wide" open>
       <summary class="site-advanced-summary">
         <span>高级设置</span>
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
@@ -1607,6 +1635,69 @@ async function showSiteModal(site) {
   toggleCustomUAFields();
   uaSelect.addEventListener('change', toggleCustomUAFields);
 
+  const dynamicEnabledInput = document.getElementById('m-dynamic-enabled');
+  const dynamicProfileSelect = document.getElementById('m-dynamic-profile');
+  const dynamicSourcesContainer = document.getElementById('m-dynamic-sources');
+  const dynamicHelp = document.getElementById('m-dynamic-help');
+  const dynamicDowngradeInput = document.getElementById('m-dynamic-downgrade');
+  const dynamicRulesContainer = document.getElementById('m-dynamic-rules');
+  const dynamicRulesButton = document.getElementById('m-add-dynamic-rule');
+  const dynamicInitialPolicy = { ...dynamicPolicy };
+  const renderDynamicRules = () => {
+    if (!dynamicRulesContainer) return;
+    dynamicRulesContainer.innerHTML = renderDynamicRuleRows(dynamicRules);
+    dynamicRulesContainer.querySelectorAll('.m-dynamic-rule-type').forEach(input => {
+      input.onchange = () => { dynamicRules[Number(input.dataset.idx)].type = input.value; };
+    });
+    dynamicRulesContainer.querySelectorAll('.m-dynamic-rule-value').forEach(input => {
+      input.oninput = () => { dynamicRules[Number(input.dataset.idx)].value = input.value; };
+    });
+    dynamicRulesContainer.querySelectorAll('.m-dynamic-rule-remove').forEach(button => {
+      button.onclick = () => { dynamicRules.splice(Number(button.dataset.idx), 1); renderDynamicRules(); };
+    });
+  };
+  const syncDynamicControls = () => {
+    const profile = normalizeDynamicProfile(dynamicProfileSelect?.value || dynamicPolicy.dynamic_profile);
+    const allowed = new Set(dynamicSourcesForProfile(profile));
+    if (dynamicSourcesContainer) dynamicSourcesContainer.querySelectorAll('[data-dynamic-source]').forEach(input => {
+      const available = dynamicCapabilities.recognized && allowed.has(input.dataset.dynamicSource);
+      input.disabled = !available || dynamicEnabledInput?.checked !== true;
+      if (!allowed.has(input.dataset.dynamicSource)) input.checked = false;
+    });
+    if (dynamicSourcesContainer) dynamicSourcesContainer.hidden = !dynamicCapabilities.recognized || dynamicEnabledInput?.checked !== true;
+    const extremeConfirm = document.getElementById('m-dynamic-extreme-confirm');
+    if (extremeConfirm) extremeConfirm.hidden = profile !== 'extreme' || dynamicEnabledInput?.checked !== true;
+    if (dynamicDowngradeInput) dynamicDowngradeInput.disabled = profile === 'safe' || dynamicEnabledInput?.checked !== true;
+    if (dynamicHelp) dynamicHelp.textContent = profile === 'safe'
+      ? 'Safe 仅允许 HTTPS:443，并要求命中明确的域名规则。'
+      : profile === 'extreme'
+        ? 'Extreme 提供更宽的兼容范围；只建议在普通模式无法播放时使用。'
+        : '兼容模式默认处理 HTTP 30x、PlaybackInfo、HLS 和 DASH；仍拒绝私网与回环目标。';
+  };
+  if (dynamicRulesButton) dynamicRulesButton.onclick = () => {
+    dynamicRules.push({ type: 'exact', value: '' });
+    renderDynamicRules();
+    const last = dynamicRulesContainer?.querySelector('.m-dynamic-rule-value:last-child');
+    if (last) last.focus();
+  };
+  if (dynamicProfileSelect) dynamicProfileSelect.onchange = syncDynamicControls;
+  if (dynamicEnabledInput) dynamicEnabledInput.onchange = syncDynamicControls;
+  renderDynamicRules();
+  syncDynamicControls();
+  if (isEdit && dynamicCapabilities.recognized && dynamicCapabilities.available) {
+    const refreshObservations = async () => {
+      const target = document.getElementById('m-dynamic-observations');
+      if (!target || !API.getDynamicObservations) return;
+      target.innerHTML = '<div class="form-help">正在读取观察记录…</div>';
+      try { target.innerHTML = renderDynamicObservations(await API.getDynamicObservations(site.id)); } catch (error) { target.innerHTML = `<div class="form-help" style="color:var(--red)">${esc(error.message)}</div>`; }
+    };
+    document.getElementById('m-refresh-dynamic-observations')?.addEventListener('click', refreshObservations);
+    document.getElementById('m-clear-dynamic-observations')?.addEventListener('click', async () => {
+      try { await API.deleteDynamicObservations(site.id); await refreshObservations(); Toast.success('观察记录已清空'); } catch (error) { Toast.error(error.message); }
+    });
+    refreshObservations();
+  }
+
   const upstreamHeadersContainer = document.getElementById('m-upstream-headers');
   let upstreamHeaders = isEdit && Array.isArray(site.upstream_headers) && site.upstream_headers.length
     ? site.upstream_headers.map(header => ({ name: header.name || '', value: '', configured: !!header.configured }))
@@ -1665,7 +1756,25 @@ async function showSiteModal(site) {
 			document.getElementById('m-target-address').value,
 			document.getElementById('m-target-port').value,
 		);
-		document.getElementById('m-target').value = primaryTargetURL;
+		const nextDynamicPolicy = {
+			dynamic_discovery_enabled: dynamicEnabledInput?.checked === true,
+			dynamic_profile: normalizeDynamicProfile(dynamicProfileSelect?.value || dynamicPolicy.dynamic_profile),
+			dynamic_discovery_sources: DYNAMIC_SOURCE_IDS.filter(source => document.getElementById(`m-dynamic-source-${source}`)?.checked === true),
+			dynamic_domain_rules: dynamicRules,
+			dynamic_allow_https_downgrade: dynamicDowngradeInput?.checked === true,
+		};
+		const dynamicConfirmation = confirmDynamicProfileChange(
+			dynamicInitialPolicy,
+			nextDynamicPolicy,
+			document.getElementById('m-name').value.trim(),
+			document.getElementById('m-dynamic-extreme-ack')?.checked === true,
+			document.getElementById('m-dynamic-extreme-name')?.value.trim() || '',
+		);
+		if (!dynamicConfirmation.ok) {
+			if (dynamicConfirmation.error) Toast.error(dynamicConfirmation.error);
+			return;
+		}
+		const dynamicPayload = buildDynamicPolicyPayload(nextDynamicPolicy, dynamicCapabilities);
 		const data = {
 	      name: document.getElementById('m-name').value.trim(),
 	      target_url: primaryTargetURL,
@@ -1685,11 +1794,7 @@ async function showSiteModal(site) {
       ua_mode: uaMode,
       client_ip_mode: clientIPModeSelect.value,
       ...customUAPayload,
-		dynamic_discovery_enabled: true,
-		dynamic_profile: 'compatible',
-		dynamic_discovery_sources: [...DEFAULT_DYNAMIC_SOURCE_IDS, ...ADVANCED_DYNAMIC_SOURCE_IDS],
-		dynamic_domain_rules: [],
-		dynamic_allow_https_downgrade: true,
+		...dynamicPayload,
       asset_cache_enabled: document.getElementById('m-asset-cache').value === 'on',
       asset_cache_ttl_sec: parseInt(document.getElementById('m-cache-ttl').value || 24) * 3600,
       asset_cache_max_bytes: parseInt(document.getElementById('m-cache-max').value || 512) * 1048576,

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -65,7 +65,7 @@ async function loadSites() {
 		    <span class="site-row-label">访问地址</span>
 		    <span class="site-access-value"><span class="mono site-access-address is-hidden" data-access-address="${esc(accessAddress)}">********</span><button type="button" class="icon-button site-access-toggle" data-site-action="access" data-site-id="${s.id}" aria-label="显示访问地址" title="显示访问地址">◉</button><button type="button" class="icon-button site-access-copy" data-site-action="copy" data-site-id="${s.id}" aria-label="复制访问地址" title="复制访问地址"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="10" height="10" rx="2"></rect><path d="M6 15H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v1"></path></svg></button></span>
 		  </div>
-          <div class="site-row">
+          <div class="site-row site-upstream-row">
             <span class="site-row-label">主回源地址</span>
             <span class="mono">${esc(s.target_url)}</span>
           </div>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1436,10 +1436,13 @@ async function showSiteModal(site) {
       </select>
       <div class="form-help">仅缓存图片与静态资源；视频、音频、HLS/DASH、Range 和私有响应不缓存。</div>
     </div>
-    <div class="form-group">
-      <label>缓存规则（每行一条，支持 * 通配）</label>
-      <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
-    </div>
+    <details class="form-group site-cache-rules-group" id="m-cache-rules-group">
+      <summary>自定义缓存规则（可选）</summary>
+      <div class="site-cache-rules-body">
+        <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
+        <div class="form-help">仅在需要覆盖默认的图片和静态资源路径时修改；每行一条，支持 * 通配。</div>
+      </div>
+    </details>
     <div class="form-group cache-limit-group">
       <div class="cache-limit-grid">
         <div>
@@ -1611,6 +1614,8 @@ async function showSiteModal(site) {
 	const uaSelect = document.getElementById('m-ua');
   const clientIPModeSelect = document.getElementById('m-client-ip-mode');
   const mainVideoModeSelect = document.getElementById('m-main-video-mode');
+  const assetCacheSelect = document.getElementById('m-asset-cache');
+  const cacheRulesGroup = document.getElementById('m-cache-rules-group');
   const customUAGroup = document.getElementById('m-custom-ua-group');
   const customUAInputs = [
     document.getElementById('m-custom-ua'),
@@ -1624,6 +1629,16 @@ async function showSiteModal(site) {
   customUAInputs[0].value = initialUAState.customUserAgent;
   customUAInputs[1].value = initialUAState.customClient;
   customUAInputs[2].value = initialUAState.customVersion;
+
+  const syncAssetCacheFields = () => {
+    const enabled = assetCacheSelect?.value === 'on';
+    if (cacheRulesGroup) {
+      cacheRulesGroup.hidden = !enabled;
+      if (!enabled) cacheRulesGroup.open = false;
+    }
+  };
+  syncAssetCacheFields();
+  assetCacheSelect?.addEventListener('change', syncAssetCacheFields);
 
   function toggleCustomUAFields() {
     const state = customUAFormState(uaSelect.value);

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1399,7 +1399,7 @@ async function showSiteModal(site) {
         <option value="infuse" ${isEdit && site.ua_mode === 'infuse' ? 'selected' : ''}>Infuse</option>
         <option value="web" ${isEdit && site.ua_mode === 'web' ? 'selected' : ''}>Web</option>
         <option value="client" ${isEdit && site.ua_mode === 'client' ? 'selected' : ''}>客户端</option>
-        <option value="custom">自定义</option>
+        <option value="custom">自定义客户端</option>
       </select>
     </div>
     <div class="form-group" id="m-custom-ua-group" hidden>
@@ -1644,8 +1644,18 @@ async function showSiteModal(site) {
   function toggleCustomUAFields() {
     const state = customUAFormState(uaSelect.value);
     customUAGroup.hidden = !state.visible;
+    if (state.visible) {
+      if (typeof customUAGroup.style?.removeProperty === 'function') customUAGroup.style.removeProperty('display');
+      else if (customUAGroup.style) customUAGroup.style.display = '';
+    } else if (typeof customUAGroup.style?.setProperty === 'function') {
+      customUAGroup.style.setProperty('display', 'none', 'important');
+    } else if (customUAGroup.style) {
+      customUAGroup.style.display = 'none';
+    }
+    if (typeof customUAGroup.setAttribute === 'function') customUAGroup.setAttribute('aria-hidden', state.visible ? 'false' : 'true');
     customUAInputs.forEach(input => {
       input.required = state.required;
+      if (!state.visible) input.value = '';
     });
   }
   toggleCustomUAFields();

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1416,7 +1416,7 @@ async function showSiteModal(site) {
         <option value="real_ip" ${isEdit && site.client_ip_mode === 'real_ip' ? 'selected' : ''}>仅保留 X-Real-IP</option>
         <option value="none" ${isEdit && site.client_ip_mode === 'none' ? 'selected' : ''}>强制不透传（慎用）</option>
       </select>
-      <div class="form-help">仅影响发往回源的 X-Real-IP 与 X-Forwarded-For。</div>
+      <div class="form-help">与 UA 模式独立；仅影响发往回源的 X-Real-IP 与 X-Forwarded-For。</div>
     </div>
     <div class="form-group">
       <label>主视频流策略</label>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1338,15 +1338,14 @@ async function showSiteModal(site) {
 	      <button type="button" class="btn-add upstream-add-line" id="m-add-failover-line">+ 添加线路</button>
 	    </div>
 	  </div>
-	  <div class="upstream-line-labels" aria-hidden="true"><span>启用</span><span>线路名称</span><span>协议与域名 / 路径</span><span>端口</span><span>延迟</span><span>排序 / 删除</span></div>
 	  <div class="upstream-lines" id="m-upstream-lines">
 	    <div class="upstream-line is-primary" data-line="primary">
 	      <label class="upstream-line-enabled"><input type="checkbox" checked disabled><span>主</span></label>
-	      <input type="text" class="form-input upstream-line-name" id="m-primary-line-name" value="${esc(isEdit ? (site.primary_line_name || '主线路') : '主线路')}" maxlength="100" aria-label="主线路名称">
-	      <input type="text" class="form-input upstream-line-address" id="m-target-address" value="${esc(primaryTargetParts.address)}" placeholder="https://emby.example.com" inputmode="url" autocapitalize="none" autocorrect="off" spellcheck="false" maxlength="2048" required aria-label="主回源域名或地址">
-	      <input type="number" class="form-input upstream-line-port" id="m-target-port" value="${esc(primaryTargetParts.port)}" placeholder="443" min="1" max="65535" inputmode="numeric" required aria-label="主回源端口">
-	      <span class="upstream-line-latency">--</span>
-	      <div class="upstream-line-actions primary-actions"><span class="upstream-line-primary-note">主线路</span></div>
+	      <div class="upstream-line-field" data-label="线路名称"><input type="text" class="form-input upstream-line-name" id="m-primary-line-name" value="${esc(isEdit ? (site.primary_line_name || '主线路') : '主线路')}" maxlength="100" aria-label="主线路名称"></div>
+	      <div class="upstream-line-field" data-label="协议与域名 / 路径"><input type="text" class="form-input upstream-line-address" id="m-target-address" value="${esc(primaryTargetParts.address)}" placeholder="https://emby.example.com" inputmode="url" autocapitalize="none" autocorrect="off" spellcheck="false" maxlength="2048" required aria-label="主回源域名或地址"></div>
+	      <div class="upstream-line-field" data-label="端口"><input type="number" class="form-input upstream-line-port" id="m-target-port" value="${esc(primaryTargetParts.port)}" placeholder="443" min="1" max="65535" inputmode="numeric" required aria-label="主回源端口"></div>
+	      <span class="upstream-line-latency" data-label="延迟">--</span>
+	      <div class="upstream-line-actions primary-actions" data-label="线路状态"><span class="upstream-line-primary-note">主线路</span></div>
 	      <input type="hidden" id="m-target">
 	    </div>
 	    <div id="m-failover-lines"></div>
@@ -1392,7 +1391,7 @@ async function showSiteModal(site) {
         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
       </summary>
       <div class="site-advanced-body">
-      <div class="site-form-columns">
+      <div class="site-settings-grid">
     <div class="form-group">
       <label>UA 模式</label>
       <select class="form-select modal-select" id="m-ua">
@@ -1428,33 +1427,31 @@ async function showSiteModal(site) {
       <div class="form-help">直连仅适用于主视频文件；面板、API、HLS/DASH 等仍由 Meridian 代理。</div>
       <div class="form-help">自动发现保持启用；私网、回环和链路本地目标始终拒绝。</div>
     </div>
-    <div class="form-group">
-      <label for="m-asset-cache">缓存图片与静态资源</label>
-      <select class="form-select modal-select" id="m-asset-cache">
-        <option value="off" ${!isEdit || !site.asset_cache_enabled ? 'selected' : ''}>关闭</option>
-        <option value="on" ${isEdit && site.asset_cache_enabled ? 'selected' : ''}>开启</option>
-      </select>
-      <div class="form-help">仅缓存图片与静态资源；视频、音频、HLS/DASH、Range 和私有响应不缓存。</div>
-    </div>
-    <details class="form-group site-cache-rules-group" id="m-cache-rules-group">
-      <summary>自定义缓存规则（可选）</summary>
-      <div class="site-cache-rules-body">
-        <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
-        <div class="form-help">仅在需要覆盖默认的图片和静态资源路径时修改；每行一条，支持 * 通配。</div>
+    <section class="form-group cache-limit-group" data-cache-panel aria-labelledby="m-cache-panel-title">
+      <div class="site-cache-panel-heading">
+        <div>
+          <h3 id="m-cache-panel-title">缓存图片与静态资源</h3>
+          <p>仅缓存图片与静态资源；视频、音频、HLS/DASH、Range 和私有响应不缓存。</p>
+        </div>
+        <select class="form-select modal-select" id="m-asset-cache" aria-label="缓存图片与静态资源">
+          <option value="off" ${!isEdit || !site.asset_cache_enabled ? 'selected' : ''}>关闭</option>
+          <option value="on" ${isEdit && site.asset_cache_enabled ? 'selected' : ''}>开启</option>
+        </select>
       </div>
-    </details>
-    <div class="form-group cache-limit-group">
+      <details class="site-cache-rules-group" id="m-cache-rules-group">
+        <summary>自定义缓存规则（可选）</summary>
+        <div class="site-cache-rules-body">
+          <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
+          <div class="form-help">仅在需要覆盖默认的图片和静态资源路径时修改；每行一条，支持 * 通配。</div>
+        </div>
+      </details>
       <div class="cache-limit-grid">
-        <div>
-          <label for="m-cache-ttl">缓存时间（小时）</label>
-          <input type="number" class="form-input" id="m-cache-ttl" min="1" max="720" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_ttl_sec || 86400) / 3600)) : 24}">
-        </div>
-        <div>
-          <label for="m-cache-max">容量上限（MB）</label>
-          <input type="number" class="form-input" id="m-cache-max" min="1" max="20480" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_max_bytes || 536870912) / 1048576)) : 512}">
-        </div>
+        <label for="m-cache-ttl">缓存时间（小时）</label>
+        <input type="number" class="form-input" id="m-cache-ttl" min="1" max="720" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_ttl_sec || 86400) / 3600)) : 24}">
+        <label for="m-cache-max">容量上限（MB）</label>
+        <input type="number" class="form-input" id="m-cache-max" min="1" max="20480" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_max_bytes || 536870912) / 1048576)) : 512}">
       </div>
-    </div>
+    </section>
     <div class="form-group">
       <label>流量额度 (GB, 0=不限)</label>
       <input type="number" class="form-input" id="m-quota" value="${isEdit ? Math.round((site.traffic_quota || 0) / 1073741824) : 0}" placeholder="0" min="0" inputmode="numeric">
@@ -1493,11 +1490,11 @@ async function showSiteModal(site) {
 		failoverLinesContainer.innerHTML = failoverLines.map((line, index) => `
 		  <div class="upstream-line" data-line-index="${index}">
 		    <label class="upstream-line-enabled"><input type="checkbox" class="upstream-line-toggle" ${line.enabled ? 'checked' : ''}><span>${line.enabled ? '开' : '关'}</span></label>
-		    <input type="text" class="form-input upstream-line-name" value="${esc(line.name)}" placeholder="线路${index + 2}" maxlength="100" aria-label="备用线路名称">
-		    <input type="text" class="form-input upstream-line-address" value="${esc(line.address)}" placeholder="https://backup.example.com" maxlength="2048" inputmode="url" autocapitalize="none" autocorrect="off" spellcheck="false" aria-label="备用线路域名或地址">
-		    <input type="number" class="form-input upstream-line-port" value="${esc(line.port)}" placeholder="443" min="1" max="65535" inputmode="numeric" aria-label="备用线路端口">
-		    <span class="upstream-line-latency">--</span>
-		    <div class="upstream-line-actions">
+		    <div class="upstream-line-field" data-label="线路名称"><input type="text" class="form-input upstream-line-name" value="${esc(line.name)}" placeholder="线路${index + 2}" maxlength="100" aria-label="备用线路名称"></div>
+		    <div class="upstream-line-field" data-label="协议与域名 / 路径"><input type="text" class="form-input upstream-line-address" value="${esc(line.address)}" placeholder="https://backup.example.com" maxlength="2048" inputmode="url" autocapitalize="none" autocorrect="off" spellcheck="false" aria-label="备用线路域名或地址"></div>
+		    <div class="upstream-line-field" data-label="端口"><input type="number" class="form-input upstream-line-port" value="${esc(line.port)}" placeholder="443" min="1" max="65535" inputmode="numeric" aria-label="备用线路端口"></div>
+		    <span class="upstream-line-latency" data-label="延迟">--</span>
+		    <div class="upstream-line-actions" data-label="排序 / 删除">
 		      <button type="button" class="icon-button upstream-line-move-up" title="上移" aria-label="上移" ${index === 0 ? 'disabled' : ''}>${lineActionIcon('up')}</button>
 		      <button type="button" class="icon-button upstream-line-move-down" title="下移" aria-label="下移" ${index === failoverLines.length - 1 ? 'disabled' : ''}>${lineActionIcon('down')}</button>
 		      <button type="button" class="icon-button upstream-line-remove" title="删除线路" aria-label="删除线路">${lineActionIcon('remove')}</button>

--- a/web/static/js/pages/sites.js
+++ b/web/static/js/pages/sites.js
@@ -1438,18 +1438,20 @@ async function showSiteModal(site) {
           <option value="on" ${isEdit && site.asset_cache_enabled ? 'selected' : ''}>开启</option>
         </select>
       </div>
-      <details class="site-cache-rules-group" id="m-cache-rules-group">
-        <summary>自定义缓存规则（可选）</summary>
-        <div class="site-cache-rules-body">
-          <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
-          <div class="form-help">仅在需要覆盖默认的图片和静态资源路径时修改；每行一条，支持 * 通配。</div>
+      <div class="site-cache-options" id="m-cache-options" hidden>
+        <details class="site-cache-rules-group" id="m-cache-rules-group">
+          <summary>自定义缓存规则（可选）</summary>
+          <div class="site-cache-rules-body">
+            <textarea class="form-input" id="m-cache-rules" rows="3" maxlength="4096" spellcheck="false">${esc(isEdit ? (site.asset_cache_rules || '*/file/*\n*/emby/Items/*/Images/*') : '*/file/*\n*/emby/Items/*/Images/*')}</textarea>
+            <div class="form-help">仅在需要覆盖默认的图片和静态资源路径时修改；每行一条，支持 * 通配。</div>
+          </div>
+        </details>
+        <div class="cache-limit-grid">
+          <label for="m-cache-ttl">缓存时间（小时）</label>
+          <input type="number" class="form-input" id="m-cache-ttl" min="1" max="720" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_ttl_sec || 86400) / 3600)) : 24}">
+          <label for="m-cache-max">容量上限（MB）</label>
+          <input type="number" class="form-input" id="m-cache-max" min="1" max="20480" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_max_bytes || 536870912) / 1048576)) : 512}">
         </div>
-      </details>
-      <div class="cache-limit-grid">
-        <label for="m-cache-ttl">缓存时间（小时）</label>
-        <input type="number" class="form-input" id="m-cache-ttl" min="1" max="720" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_ttl_sec || 86400) / 3600)) : 24}">
-        <label for="m-cache-max">容量上限（MB）</label>
-        <input type="number" class="form-input" id="m-cache-max" min="1" max="20480" value="${isEdit ? Math.max(1, Math.round((site.asset_cache_max_bytes || 536870912) / 1048576)) : 512}">
       </div>
     </section>
     <div class="form-group">
@@ -1612,6 +1614,7 @@ async function showSiteModal(site) {
   const clientIPModeSelect = document.getElementById('m-client-ip-mode');
   const mainVideoModeSelect = document.getElementById('m-main-video-mode');
   const assetCacheSelect = document.getElementById('m-asset-cache');
+  const cacheOptionsGroup = document.getElementById('m-cache-options');
   const cacheRulesGroup = document.getElementById('m-cache-rules-group');
   const customUAGroup = document.getElementById('m-custom-ua-group');
   const customUAInputs = [
@@ -1629,6 +1632,7 @@ async function showSiteModal(site) {
 
   const syncAssetCacheFields = () => {
     const enabled = assetCacheSelect?.value === 'on';
+    if (cacheOptionsGroup) cacheOptionsGroup.hidden = !enabled;
     if (cacheRulesGroup) {
       cacheRulesGroup.hidden = !enabled;
       if (!enabled) cacheRulesGroup.open = false;

--- a/web/static/js/pages/telegram-report.js
+++ b/web/static/js/pages/telegram-report.js
@@ -56,7 +56,7 @@ function renderTelegramReport() {
           <label class="telegram-field">
             <span>发送时间</span>
             <input class="form-input" type="time" id="telegram-schedule-time" value="20:00">
-            <small>默认使用北京时间（UTC+8），可在“全局设置 → 系统 UI”中调整调度时区。</small>
+            <small>默认使用北京时间（UTC+8），可在“全局设置 → 系统设置”中调整调度时区。</small>
           </label>
         </div>
 


### PR DESCRIPTION
## Summary

- Point the header GitHub link to `snnabb/Meridian`.
- Make site editor upstream lines use a stable six-column layout with consistent sizing and alignment.
- Remove the browser-default rectangular `fieldset` frame around fixed upstream headers.
- Shorten advanced-setting explanations and normalize field spacing for easier scanning.
- Reset modal, modal body, and overlay scroll positions every time a modal opens.
- Restore smooth Bezier curves for dashboard trend lines and area fills.
- Add a static cache-buster for the UI assets.

## Validation

- `node --check web/static/js/app.js`
- `node --check web/static/js/pages/dashboard.js`
- `node --check web/static/js/pages/sites.js`
- `node --test tests/*.test.js` (120 passed)
- `git diff --check`

This is a first UI polish pass; it does not change proxy, authentication, storage, or routing behavior.
