### PR TITLE
Add post-#50 trend, route, and bidirectional billing fixes

### DIFF
--- a/dashboard_trends_test.go
+++ b/dashboard_trends_test.go
@@ -44,16 +44,16 @@ func TestDashboardTrendsAggregateAllAndSingleSite(t *testing.T) {
 		t.Fatalf("all metadata = %+v", all)
 	}
 	traffic, requests := sumDashboardTrend(all.Points)
-	if traffic != 430 || requests != 6 {
-		t.Fatalf("all totals = traffic %d requests %d, want 430/6", traffic, requests)
+	if traffic != 860 || requests != 6 {
+		t.Fatalf("all totals = traffic %d requests %d, want 860/6", traffic, requests)
 	}
 	if len(all.SiteSeries) != 2 || all.SiteSeries[0].SiteName != "first" || all.SiteSeries[1].SiteName != "second" {
 		t.Fatalf("all site series = %+v, want both named sites", all.SiteSeries)
 	}
 	firstTraffic, firstRequests := sumDashboardTrend(all.SiteSeries[0].Points)
 	secondTraffic, secondRequests := sumDashboardTrend(all.SiteSeries[1].Points)
-	if firstTraffic != 330 || firstRequests != 4 || secondTraffic != 100 || secondRequests != 2 {
-		t.Fatalf("all site series totals = first %d/%d second %d/%d, want 330/4 and 100/2", firstTraffic, firstRequests, secondTraffic, secondRequests)
+	if firstTraffic != 660 || firstRequests != 4 || secondTraffic != 200 || secondRequests != 2 {
+		t.Fatalf("all site series totals = first %d/%d second %d/%d, want 660/4 and 200/2", firstTraffic, firstRequests, secondTraffic, secondRequests)
 	}
 
 	single, err := app.pm.dashboardTrends(&first.ID, "hour")
@@ -61,11 +61,11 @@ func TestDashboardTrendsAggregateAllAndSingleSite(t *testing.T) {
 		t.Fatalf("dashboardTrends single: %v", err)
 	}
 	traffic, requests = sumDashboardTrend(single.Points)
-	if traffic != 330 || requests != 4 {
-		t.Fatalf("single totals = traffic %d requests %d, want 330/4", traffic, requests)
+	if traffic != 660 || requests != 4 {
+		t.Fatalf("single totals = traffic %d requests %d, want 660/4", traffic, requests)
 	}
 	last := single.Points[len(single.Points)-1]
-	if last.Traffic < 30 || last.Requests < 1 {
+	if last.Traffic < 60 || last.Requests < 1 {
 		t.Fatalf("current bucket = %+v, want pending traffic and request", last)
 	}
 	if len(single.SiteSeries) != 1 || single.SiteSeries[0].SiteID != first.ID || single.SiteSeries[0].SiteName != "first" {
@@ -124,11 +124,11 @@ func TestDashboardTrendRangesAndMonthlyTraffic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TrafficSnapshot: %v", err)
 	}
-	if snapshot.MonthlyTraffic != 120 || snapshot.TotalTraffic != 120 {
-		t.Fatalf("snapshot traffic = monthly %d total %d, want 120/120", snapshot.MonthlyTraffic, snapshot.TotalTraffic)
+	if snapshot.MonthlyTraffic != 240 || snapshot.TotalTraffic != 240 {
+		t.Fatalf("snapshot traffic = monthly %d total %d, want 240/240", snapshot.MonthlyTraffic, snapshot.TotalTraffic)
 	}
-	if len(snapshot.LiveSites) != 1 || snapshot.LiveSites[0].MonthlyTraffic != 120 {
-		t.Fatalf("site monthly traffic = %+v, want 120", snapshot.LiveSites)
+	if len(snapshot.LiveSites) != 1 || snapshot.LiveSites[0].MonthlyTraffic != 240 {
+		t.Fatalf("site monthly traffic = %+v, want 240", snapshot.LiveSites)
 	}
 }
 
@@ -156,8 +156,8 @@ func TestDashboardTrendCustomWindowUsesMinutePrecisionAndAggregates(t *testing.T
 		t.Fatalf("custom bounds = %d/%d, want %d/%d", trend.StartMS, trend.EndMS, start.UnixMilli(), end.UnixMilli())
 	}
 	traffic, requests := sumDashboardTrend(trend.Points)
-	if traffic != 140 || requests != 3 {
-		t.Fatalf("custom totals = traffic %d requests %d, want 140/3", traffic, requests)
+	if traffic != 280 || requests != 3 {
+		t.Fatalf("custom totals = traffic %d requests %d, want 280/3", traffic, requests)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -3817,7 +3817,7 @@ func findLiveSite(t *testing.T, snap *TrafficSnapshot, id int64) SiteTraffic {
 }
 
 // Pending bytes and requests are flushed to the DB exactly once, the authoritative total
-// traffic_used = persisted + pending is conserved across flushes, and the
+// traffic_used = billable persisted + billable pending is conserved across flushes, and the
 // current-minute log bucket aggregates without double counting.
 func TestFlushPersistsPendingExactlyOnceAndConservesTotals(t *testing.T) {
 	app := newTestApp(t)
@@ -3841,8 +3841,8 @@ func TestFlushPersistsPendingExactlyOnceAndConservesTotals(t *testing.T) {
 		t.Fatalf("TrafficSnapshot: %v", err)
 	}
 	live := findLiveSite(t, snap, site.ID)
-	if live.TrafficUsed != 200 || live.PersistedTraffic != 0 || live.BytesIn != 120 || live.BytesOut != 80 || live.CumulativeBytesIn != 120 || live.CumulativeBytesOut != 80 {
-		t.Fatalf("pre-flush live state = %+v, want used=200 persisted=0 in=120 out=80", live)
+	if live.TrafficUsed != 400 || live.PersistedTraffic != 0 || live.BytesIn != 120 || live.BytesOut != 80 || live.CumulativeBytesIn != 120 || live.CumulativeBytesOut != 80 {
+		t.Fatalf("pre-flush live state = %+v, want billed used=400 persisted=0 in=120 out=80", live)
 	}
 
 	app.pm.FlushTraffic()
@@ -3902,8 +3902,8 @@ func TestFlushPersistsPendingExactlyOnceAndConservesTotals(t *testing.T) {
 		t.Fatalf("TrafficSnapshot: %v", err)
 	}
 	live = findLiveSite(t, snap, site.ID)
-	if live.TrafficUsed != 240 || snap.TotalTraffic != 240 || live.Requests != 8 || snap.TotalRequests != 8 {
-		t.Fatalf("post-flush totals = site:%d snapshot:%d requests:%d/%d, want 240/240 and 8/8", live.TrafficUsed, snap.TotalTraffic, live.Requests, snap.TotalRequests)
+	if live.TrafficUsed != 480 || snap.TotalTraffic != 480 || live.Requests != 8 || snap.TotalRequests != 8 {
+		t.Fatalf("post-flush totals = site:%d snapshot:%d requests:%d/%d, want billed 480/480 and 8/8", live.TrafficUsed, snap.TotalTraffic, live.Requests, snap.TotalRequests)
 	}
 }
 
@@ -4017,8 +4017,8 @@ func TestSiteTrafficHistoryMergesPendingIntoCurrentMinuteBucket(t *testing.T) {
 	if current.ID != 0 || current.BytesIn != 30 || current.BytesOut != 20 || current.Requests != 4 || !(sameTrafficMinute(current.RecordedAt, minuteBefore) || sameTrafficMinute(current.RecordedAt, minuteAfter)) {
 		t.Fatalf("synthetic current bucket = %+v, want ID=0 30/20 and 4 requests at the current minute", current)
 	}
-	if !history.Snapshot.Running || history.Snapshot.PersistedTraffic != 150 || history.Snapshot.BytesIn != 30 || history.Snapshot.BytesOut != 20 || history.Snapshot.TrafficUsed != 200 || history.Snapshot.Requests != 9 {
-		t.Fatalf("snapshot = %+v, want running persisted=150 in=30 out=20 used=200 requests=9", history.Snapshot)
+	if !history.Snapshot.Running || history.Snapshot.PersistedTraffic != 300 || history.Snapshot.BytesIn != 30 || history.Snapshot.BytesOut != 20 || history.Snapshot.TrafficUsed != 400 || history.Snapshot.Requests != 9 {
+		t.Fatalf("snapshot = %+v, want running billed persisted=300 in=30 out=20 used=400 requests=9", history.Snapshot)
 	}
 
 	// All pending values at zero is a no-op: no synthetic bucket is appended.
@@ -4264,16 +4264,16 @@ func TestTrafficSnapshotUnifiedPayloadAndTotals(t *testing.T) {
 	if snap.TotalSites != 2 || snap.OnlineSites != 2 || snap.RunningSites != 1 {
 		t.Fatalf("counts = total:%d online:%d running:%d, want 2/2/1", snap.TotalSites, snap.OnlineSites, snap.RunningSites)
 	}
-	if snap.TotalTraffic != 190 {
-		t.Fatalf("total_traffic = %d, want 190 (100+30+20 persisted+pending + 40 DB)", snap.TotalTraffic)
+	if snap.TotalTraffic != 380 {
+		t.Fatalf("total_traffic = %d, want billed 380", snap.TotalTraffic)
 	}
 	a := findLiveSite(t, snap, siteA.ID)
-	if !a.Running || a.TrafficQuota != 1024 || a.PersistedTraffic != 100 || a.BytesIn != 30 || a.BytesOut != 20 || a.TrafficUsed != 150 {
-		t.Fatalf("running site entry = %+v, want running quota=1024 persisted=100 in=30 out=20 used=150", a)
+	if !a.Running || a.TrafficQuota != 1024 || a.PersistedTraffic != 200 || a.BytesIn != 30 || a.BytesOut != 20 || a.TrafficUsed != 300 {
+		t.Fatalf("running site entry = %+v, want running quota=1024 billed persisted=200 in=30 out=20 used=300", a)
 	}
 	b := findLiveSite(t, snap, siteB.ID)
-	if b.Running || b.PersistedTraffic != 40 || b.BytesIn != 0 || b.BytesOut != 0 || b.TrafficUsed != 40 {
-		t.Fatalf("idle site entry = %+v, want not running persisted=40 used=40", b)
+	if b.Running || b.PersistedTraffic != 80 || b.BytesIn != 0 || b.BytesOut != 0 || b.TrafficUsed != 80 {
+		t.Fatalf("idle site entry = %+v, want not running billed persisted=80 used=80", b)
 	}
 }
 
@@ -4317,8 +4317,8 @@ func TestHandleTrafficLegacyArrayAndSnapshotEnvelope(t *testing.T) {
 	}
 	body := decodeBody(t, rr)
 	snap := mustMapValue(t, body, "snapshot")
-	if mustNumberValue(t, snap, "traffic_used") != 50 || mustNumberValue(t, snap, "persisted_traffic") != 0 || mustNumberValue(t, snap, "bytes_in") != 40 || mustNumberValue(t, snap, "bytes_out") != 10 || mustNumberValue(t, snap, "requests") != 6 {
-		t.Fatalf("envelope snapshot = %v, want used=50 persisted=0 in=40 out=10 requests=6", snap)
+	if mustNumberValue(t, snap, "traffic_used") != 100 || mustNumberValue(t, snap, "persisted_traffic") != 0 || mustNumberValue(t, snap, "bytes_in") != 40 || mustNumberValue(t, snap, "bytes_out") != 10 || mustNumberValue(t, snap, "requests") != 6 {
+		t.Fatalf("envelope snapshot = %v, want billed used=100 persisted=0 in=40 out=10 requests=6", snap)
 	}
 	if !mustBoolValue(t, snap, "running") {
 		t.Fatal("envelope snapshot must report the site as running")
@@ -4558,7 +4558,7 @@ func TestConcurrentFlushSnapshotAndHistoryStayConsistent(t *testing.T) {
 				return
 			}
 			for _, st := range snap.LiveSites {
-				if st.ID == site.ID && st.TrafficUsed != st.PersistedTraffic+st.BytesIn+st.BytesOut {
+				if st.ID == site.ID && st.TrafficUsed != st.PersistedTraffic+trafficBillableBytes(trafficBillingModeBidirectional, st.BytesIn, st.BytesOut) {
 					t.Errorf("torn snapshot view: used=%d persisted=%d in=%d out=%d", st.TrafficUsed, st.PersistedTraffic, st.BytesIn, st.BytesOut)
 					return
 				}
@@ -4582,7 +4582,7 @@ func TestConcurrentFlushSnapshotAndHistoryStayConsistent(t *testing.T) {
 				t.Errorf("SiteTrafficHistory: %v", err)
 				return
 			}
-			if h.Snapshot.TrafficUsed != h.Snapshot.PersistedTraffic+h.Snapshot.BytesIn+h.Snapshot.BytesOut {
+			if h.Snapshot.TrafficUsed != h.Snapshot.PersistedTraffic+trafficBillableBytes(trafficBillingModeBidirectional, h.Snapshot.BytesIn, h.Snapshot.BytesOut) {
 				t.Errorf("torn history view: used=%d persisted=%d in=%d out=%d", h.Snapshot.TrafficUsed, h.Snapshot.PersistedTraffic, h.Snapshot.BytesIn, h.Snapshot.BytesOut)
 				return
 			}
@@ -4643,8 +4643,8 @@ func TestTrafficReadsDoNotWriteDatabase(t *testing.T) {
 	}
 	body := decodeBody(t, rr)
 	snap := mustMapValue(t, body, "snapshot")
-	if mustNumberValue(t, snap, "bytes_in") != 11 || mustNumberValue(t, snap, "traffic_used") != 20 {
-		t.Fatalf("read-only envelope snapshot = %v, want in=11 used=20", snap)
+	if mustNumberValue(t, snap, "bytes_in") != 11 || mustNumberValue(t, snap, "traffic_used") != 40 {
+		t.Fatalf("read-only envelope snapshot = %v, want in=11 billed used=40", snap)
 	}
 
 	// Dashboard and overview share the unified snapshot payload.
@@ -4655,8 +4655,8 @@ func TestTrafficReadsDoNotWriteDatabase(t *testing.T) {
 		t.Fatalf("dashboard status = %d body=%s", rr.Code, rr.Body.String())
 	}
 	body = decodeBody(t, rr)
-	if mustNumberValue(t, body, "total_traffic") != 20 || mustNumberValue(t, body, "running_sites") != 1 {
-		t.Fatalf("dashboard payload = %v, want total_traffic=20 running_sites=1", body)
+	if mustNumberValue(t, body, "total_traffic") != 40 || mustNumberValue(t, body, "running_sites") != 1 {
+		t.Fatalf("dashboard payload = %v, want billed total_traffic=40 running_sites=1", body)
 	}
 
 	rr = httptest.NewRecorder()
@@ -4666,8 +4666,8 @@ func TestTrafficReadsDoNotWriteDatabase(t *testing.T) {
 		t.Fatalf("overview status = %d body=%s", rr.Code, rr.Body.String())
 	}
 	body = decodeBody(t, rr)
-	if mustNumberValue(t, body, "total_traffic") != 20 {
-		t.Fatalf("overview payload = %v, want total_traffic=20", body)
+	if mustNumberValue(t, body, "total_traffic") != 40 {
+		t.Fatalf("overview payload = %v, want billed total_traffic=40", body)
 	}
 
 	// SSE event frame.
@@ -4675,8 +4675,8 @@ func TestTrafficReadsDoNotWriteDatabase(t *testing.T) {
 	if err := app.sendSSEEvent(rr, rr); err != nil {
 		t.Fatalf("sendSSEEvent against a read-only DB: %v", err)
 	}
-	if !strings.HasPrefix(rr.Body.String(), "data: ") || !strings.Contains(rr.Body.String(), "\"total_traffic\":20") {
-		t.Fatalf("SSE frame = %q, want data: frame with total_traffic 20", rr.Body.String())
+	if !strings.HasPrefix(rr.Body.String(), "data: ") || !strings.Contains(rr.Body.String(), "\"total_traffic\":40") {
+		t.Fatalf("SSE frame = %q, want data: frame with billed total_traffic 40", rr.Body.String())
 	}
 
 	// And the DB really is untouched: no logs, no usage.
@@ -4916,8 +4916,8 @@ func TestHandleSitesGETOverlaysLiveTrafficWithoutDBWrite(t *testing.T) {
 	if liveRow == nil || stoppedRow == nil {
 		t.Fatalf("expected both sites in the response: %+v", rows)
 	}
-	if liveRow.TrafficUsed != 120 {
-		t.Fatalf("live traffic_used = %d, want 120 (100 persisted + 11 + 9 pending)", liveRow.TrafficUsed)
+	if liveRow.TrafficUsed != 240 {
+		t.Fatalf("live traffic_used = %d, want billed 240", liveRow.TrafficUsed)
 	}
 	if !liveRow.Running {
 		t.Fatal("running site must be flagged running")

--- a/main_test.go
+++ b/main_test.go
@@ -6715,7 +6715,13 @@ func TestReservedDynamicRouteReturnsNotFoundWithoutProxying(t *testing.T) {
 	if !configured || handler == nil {
 		t.Fatal("host handler not registered")
 	}
-	for _, requestPath := range []string{"/_meridian/d", "/_meridian/d/stale-token", "/emby/_meridian/d", "/emby/_meridian/d/stale-token"} {
+	for _, requestPath := range []string{
+		"/_meridian/d",
+		"/_meridian/d/stale-token",
+		"/emby/_meridian/d",
+		"/emby/_meridian/d/stale-token",
+		"/jellyfin/_meridian/d/stale-token",
+	} {
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, requestPath, nil))
 		if rr.Code != http.StatusNotFound {
@@ -6724,6 +6730,35 @@ func TestReservedDynamicRouteReturnsNotFoundWithoutProxying(t *testing.T) {
 	}
 	if got := upstreamCalls.Load(); got != 0 {
 		t.Fatalf("reserved dynamic route reached upstream %d times", got)
+	}
+}
+
+func TestNormalizeEmbeddedDynamicCapabilityRequestPath(t *testing.T) {
+	for _, test := range []struct {
+		path       string
+		wantPath   string
+		normalized bool
+	}{
+		{path: "/emby/_meridian/d/token", wantPath: "/_meridian/d/token", normalized: true},
+		{path: "/jellyfin/_meridian/d/token", wantPath: "/_meridian/d/token", normalized: true},
+		{path: "/EMBY/_meridian/d/token", wantPath: "/_meridian/d/token", normalized: true},
+		{path: "/emby/_meridian/d", wantPath: "/_meridian/d", normalized: true},
+		{path: "/emby/api/Items", wantPath: "/emby/api/Items", normalized: false},
+		{path: "/emby/_meridian/debug", wantPath: "/emby/_meridian/debug", normalized: false},
+		{path: "/other/emby/_meridian/d/token", wantPath: "/other/emby/_meridian/d/token", normalized: false},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			requestURL := &url.URL{Path: test.path, RawPath: test.path}
+			if got := normalizeEmbeddedDynamicCapabilityRequestPath(requestURL); got != test.normalized {
+				t.Fatalf("normalized=%v, want %v", got, test.normalized)
+			}
+			if requestURL.Path != test.wantPath {
+				t.Fatalf("path=%q, want %q", requestURL.Path, test.wantPath)
+			}
+			if test.normalized && requestURL.RawPath != "" {
+				t.Fatalf("normalized RawPath=%q, want empty", requestURL.RawPath)
+			}
+		})
 	}
 }
 

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -316,6 +316,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			return
 		}
 		defer inst.endHTTPRequest(requestController)
+		normalizeEmbeddedDynamicCapabilityRequestPath(r.URL)
 		clientRequestContext := r.Context()
 		requestLogWriter := &requestLogResponseWriter{ResponseWriter: w}
 		requestLogEntry := newRequestLogEvent(site, r, inst.trustedProxies, policy)

--- a/site_routing.go
+++ b/site_routing.go
@@ -530,6 +530,29 @@ func isReservedDynamicRoute(requestPath string) bool {
 	return normalizeDynamicCapabilityPath(requestPath) != ""
 }
 
+// normalizeEmbeddedDynamicCapabilityRequestPath accepts the reserved dynamic
+// route when an Emby/Jellyfin client prepends the server's application Base
+// URL. Some servers advertise /emby or /jellyfin even though Meridian's
+// capability route is rooted at /_meridian/d/. Only the reserved namespace is
+// normalized; ordinary application requests keep their original paths.
+func normalizeEmbeddedDynamicCapabilityRequestPath(requestURL *url.URL) bool {
+	if requestURL == nil || requestURL.Path == "" {
+		return false
+	}
+	for _, appBase := range []string{"/emby", "/jellyfin"} {
+		embeddedRoot := appBase + strings.TrimSuffix(dynamicRoutePrefix, "/")
+		embeddedPrefix := appBase + dynamicRoutePrefix
+		if !strings.EqualFold(requestURL.Path, embeddedRoot) &&
+			(len(requestURL.Path) < len(embeddedPrefix) || !strings.EqualFold(requestURL.Path[:len(embeddedPrefix)], embeddedPrefix)) {
+			continue
+		}
+		requestURL.Path = requestURL.Path[len(appBase):]
+		requestURL.RawPath = ""
+		return true
+	}
+	return false
+}
+
 func requestPublicHost(hostport string) string {
 	hostport = strings.TrimSpace(hostport)
 	if hostport == "" || strings.HasPrefix(hostport, "[") {

--- a/telegram_report.go
+++ b/telegram_report.go
@@ -317,6 +317,7 @@ func (d *DB) telegramReportSettingsView() (telegramReportSettingsView, telegramR
 func (d *DB) buildTelegramReportStats(now time.Time) (telegramReportStats, error) {
 	settings := d.currentSystemSettings()
 	location := timezoneLocationByName(settings.ScheduleTimezoneName, settings.ScheduleTimezone)
+	billingMode := settings.TrafficBillingMode
 	localNow := now.In(location)
 	todayStart := time.Date(localNow.Year(), localNow.Month(), localNow.Day(), 0, 0, 0, 0, location)
 	tomorrow := todayStart.AddDate(0, 0, 1)
@@ -334,12 +335,12 @@ func (d *DB) buildTelegramReportStats(now time.Time) (telegramReportStats, error
 		return stats, err
 	}
 	trafficSum := func(start time.Time) (int64, error) {
-		var value sql.NullInt64
-		err := d.db.QueryRow(`SELECT SUM(bytes_in + bytes_out) FROM traffic_logs WHERE recorded_at>=? AND recorded_at<?`, trafficMinuteBucket(start), trafficMinuteBucket(tomorrow)).Scan(&value)
-		if err != nil || !value.Valid {
+		var bytesIn, bytesOut sql.NullInt64
+		err := d.db.QueryRow(`SELECT SUM(bytes_in), SUM(bytes_out) FROM traffic_logs WHERE recorded_at>=? AND recorded_at<?`, trafficMinuteBucket(start), trafficMinuteBucket(tomorrow)).Scan(&bytesIn, &bytesOut)
+		if err != nil || !bytesIn.Valid || !bytesOut.Valid {
 			return 0, err
 		}
-		return value.Int64, nil
+		return trafficBillableBytes(billingMode, bytesIn.Int64, bytesOut.Int64), nil
 	}
 	var err error
 	if stats.TodayTraffic, err = trafficSum(todayStart); err != nil {
@@ -351,9 +352,11 @@ func (d *DB) buildTelegramReportStats(now time.Time) (telegramReportStats, error
 	if stats.ThirtyDayTraffic, err = trafficSum(todayStart.AddDate(0, 0, -29)); err != nil {
 		return stats, err
 	}
-	if err := d.db.QueryRow(`SELECT COALESCE(SUM(bytes_in + bytes_out),0) FROM traffic_logs`).Scan(&stats.HistoryTraffic); err != nil {
+	var historyIn, historyOut int64
+	if err := d.db.QueryRow(`SELECT COALESCE(SUM(bytes_in),0), COALESCE(SUM(bytes_out),0) FROM traffic_logs`).Scan(&historyIn, &historyOut); err != nil {
 		return stats, err
 	}
+	stats.HistoryTraffic = trafficBillableBytes(billingMode, historyIn, historyOut)
 
 	requestRows, err := d.db.Query(`SELECT site_id, site_name, COUNT(*) FROM request_logs WHERE recorded_at_ms>=? AND recorded_at_ms<? GROUP BY site_id, site_name`, todayStart.UnixMilli(), tomorrow.UnixMilli())
 	if err != nil {
@@ -374,17 +377,18 @@ func (d *DB) buildTelegramReportStats(now time.Time) (telegramReportStats, error
 		return stats, err
 	}
 	requestRows.Close()
-	trafficRows, err := d.db.Query(`SELECT traffic_logs.site_id, COALESCE(NULLIF(sites.name,''), '站点 ' || traffic_logs.site_id), COALESCE(SUM(traffic_logs.bytes_in + traffic_logs.bytes_out),0) FROM traffic_logs LEFT JOIN sites ON sites.id=traffic_logs.site_id WHERE traffic_logs.recorded_at>=? AND traffic_logs.recorded_at<? GROUP BY traffic_logs.site_id, sites.name`, trafficMinuteBucket(todayStart), trafficMinuteBucket(tomorrow))
+	trafficRows, err := d.db.Query(`SELECT traffic_logs.site_id, COALESCE(NULLIF(sites.name,''), '站点 ' || traffic_logs.site_id), COALESCE(SUM(traffic_logs.bytes_in),0), COALESCE(SUM(traffic_logs.bytes_out),0) FROM traffic_logs LEFT JOIN sites ON sites.id=traffic_logs.site_id WHERE traffic_logs.recorded_at>=? AND traffic_logs.recorded_at<? GROUP BY traffic_logs.site_id, sites.name`, trafficMinuteBucket(todayStart), trafficMinuteBucket(tomorrow))
 	if err != nil {
 		return stats, err
 	}
 	for trafficRows.Next() {
-		var id, traffic int64
+		var id, bytesIn, bytesOut int64
 		var name string
-		if err := trafficRows.Scan(&id, &name, &traffic); err != nil {
+		if err := trafficRows.Scan(&id, &name, &bytesIn, &bytesOut); err != nil {
 			trafficRows.Close()
 			return stats, err
 		}
+		traffic := trafficBillableBytes(billingMode, bytesIn, bytesOut)
 		if stat := requestBySite[id]; stat != nil {
 			stat.Traffic = traffic
 		} else {

--- a/telegram_report_test.go
+++ b/telegram_report_test.go
@@ -90,3 +90,36 @@ func TestTelegramReportScheduleChangeRearmsCurrentPeriod(t *testing.T) {
 		t.Fatalf("changed schedule kept last_sent_key: %q", stored.LastSentKey)
 	}
 }
+
+func TestTelegramReportTrafficUsesGlobalBillingMode(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("telegram-billing", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	now := time.Now()
+	if err := app.db.addTrafficWithRequestsAt(site.ID, 10, 90, 1, now); err != nil {
+		t.Fatalf("add traffic: %v", err)
+	}
+
+	dual, err := app.db.buildTelegramReportStats(now)
+	if err != nil {
+		t.Fatalf("build bidirectional stats: %v", err)
+	}
+	if dual.TodayTraffic != 200 || dual.HistoryTraffic != 200 || len(dual.TopTraffic) != 1 || dual.TopTraffic[0].Traffic != 200 {
+		t.Fatalf("bidirectional stats = %+v, want traffic 200", dual)
+	}
+
+	settings := app.db.currentSystemSettings()
+	settings.TrafficBillingMode = trafficBillingModeOutbound
+	if err := app.db.saveSystemSettings(settings); err != nil {
+		t.Fatalf("save outbound mode: %v", err)
+	}
+	outbound, err := app.db.buildTelegramReportStats(now)
+	if err != nil {
+		t.Fatalf("build outbound stats: %v", err)
+	}
+	if outbound.TodayTraffic != 90 || outbound.HistoryTraffic != 90 || len(outbound.TopTraffic) != 1 || outbound.TopTraffic[0].Traffic != 90 {
+		t.Fatalf("outbound stats = %+v, want traffic 90", outbound)
+	}
+}

--- a/tests/request_logs.test.js
+++ b/tests/request_logs.test.js
@@ -239,6 +239,15 @@ test('request log UA width slider stays compact', () => {
   assert.match(source, /\.request-log-ua-width-control input\[type="range"\]\s*\{[^}]*max-width:\s*220px;/s);
 });
 
+test('request log filter chips keep centered labels and balanced spacing', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'web', 'static', 'css', 'style.css'),
+    'utf8',
+  );
+  assert.match(source, /\.request-log-filter-row\s*\{[^}]*padding:\s*10px 0;/s);
+  assert.match(source, /\.request-log-pill\s*\{[^}]*display:\s*inline-flex;[^}]*align-items:\s*center;[^}]*justify-content:\s*center;[^}]*padding:\s*7px 16px;[^}]*text-align:\s*center;/s);
+});
+
 test('mobile request log table uses fixed readable columns without overlap', () => {
   const source = fs.readFileSync(
     path.join(__dirname, '..', 'web', 'static', 'css', 'style.css'),

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -467,6 +467,8 @@ test('dashboard live speed uses consecutive bidirectional SSE counters and rejec
   const html = elements['dash-table'].innerHTML;
   assert.ok(html.includes('↓ 512 KB/s'), html);
   assert.ok(html.includes('↑ 1 KB/s'), html);
+  const billedSample = vm.runInContext("dashboardRealtimeTrendSamples.get('all').at(-1).traffic_bytes", sandbox);
+  assert.equal(billedSample, 2 * (2048 + 1048576), 'bidirectional realtime traffic must count both VPS network legs');
 
   await vm.runInContext('loadDashboardTable()', sandbox);
   const refreshedHTML = elements['dash-table'].innerHTML;
@@ -554,7 +556,7 @@ test('dashboard trend touch pointers outside the canvas are treated as inactive'
   assert.equal(vm.runInContext('dashboardTrendPointerInside({ left: 100, top: 50, width: 300, height: 200 }, { clientX: 399, clientY: 249 })', sandbox), true);
   const source = readScript('pages/dashboard.js');
   assert.match(source, /event\.pointerType !== 'mouse' && !dashboardTrendPointerInside\(rect, event\)/);
-  assert.match(source, /pointerType !== 'mouse' && !dashboardTrendPointerInside\(canvas\.getBoundingClientRect\(\), event\)/);
+  assert.match(source, /canvas\.addEventListener\('pointerup',[\s\S]*?clearHover\(\);[\s\S]*?\}\);/);
   assert.match(source, /Touch pointer capture continues delivering pointermove events/);
 });
 

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -546,6 +546,18 @@ test('dashboard trend pointer coordinates use the plot bounds and keep the cross
   assert.equal(right.index, 6, 'the last sample should be selected at the plot end');
 });
 
+test('dashboard trend touch pointers outside the canvas are treated as inactive', () => {
+  const { sandbox } = makeTrafficHarness();
+  assert.equal(vm.runInContext('dashboardTrendPointerInside({ left: 100, top: 50, right: 400, bottom: 250 }, { clientX: 250, clientY: 150 })', sandbox), true);
+  assert.equal(vm.runInContext('dashboardTrendPointerInside({ left: 100, top: 50, right: 400, bottom: 250 }, { clientX: 401, clientY: 150 })', sandbox), false);
+  assert.equal(vm.runInContext('dashboardTrendPointerInside({ left: 100, top: 50, right: 400, bottom: 250 }, { clientX: 250, clientY: 251 })', sandbox), false);
+  assert.equal(vm.runInContext('dashboardTrendPointerInside({ left: 100, top: 50, width: 300, height: 200 }, { clientX: 399, clientY: 249 })', sandbox), true);
+  const source = readScript('pages/dashboard.js');
+  assert.match(source, /event\.pointerType !== 'mouse' && !dashboardTrendPointerInside\(rect, event\)/);
+  assert.match(source, /pointerType !== 'mouse' && !dashboardTrendPointerInside\(canvas\.getBoundingClientRect\(\), event\)/);
+  assert.match(source, /Touch pointer capture continues delivering pointermove events/);
+});
+
 test('dashboard trend tooltip avoids the pointer and flips at chart edges', () => {
   const { sandbox } = makeTrafficHarness();
   const rightEdge = vm.runInContext('dashboardTooltipPosition(270, 100, 300, 200, 100, 50)', sandbox);

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -557,6 +557,20 @@ test('dashboard trend tooltip avoids the pointer and flips at chart edges', () =
   const css = readScript('../css/style.css');
   assert.match(css, /\.dashboard-chart-tooltip[^\n]*transform:\s*none/);
   assert.match(css, /\.dashboard-chart-tooltip[^\n]*pointer-events:\s*none/);
+  assert.match(css, /\.dashboard-trend-card\s*\{[^}]*overflow:\s*visible/);
+  assert.match(css, /\.dashboard-trend-grid\s*\{[^}]*position:\s*relative[^}]*z-index:\s*3/);
+  assert.match(css, /\.dashboard-insights-grid,\s*\.dashboard-site-status\s*\{[^}]*position:\s*relative[^}]*z-index:\s*1/);
+});
+
+test('dashboard trend tooltip keeps long content outside the pointer without clipping', () => {
+  const { sandbox } = makeTrafficHarness();
+  const middle = vm.runInContext('dashboardTooltipPosition(150, 100, 300, 200, 360, 300)', sandbox);
+  assert.equal(middle.top, 114, 'a long tooltip should move below a middle pointer');
+  assert.equal(middle.maxHeight, undefined, 'the tooltip should not receive a height limit');
+  assert.ok(middle.top >= 100 + 14, 'the tooltip should keep a gap below the pointer');
+  const top = vm.runInContext('dashboardTooltipPosition(150, 20, 300, 200, 360, 300)', sandbox);
+  assert.equal(top.top, 34, 'a top-edge pointer should use the space below it');
+  assert.equal(top.maxHeight, undefined, 'the tooltip should remain fully visible instead of scrolling');
 });
 
 test('dashboard zero-value trend scales never render negative or invalid labels', () => {

--- a/traffic_accounting.go
+++ b/traffic_accounting.go
@@ -7,8 +7,11 @@ const (
 	trafficBillingModeOutbound      = "outbound"
 )
 
-// trafficBillableBytes translates raw proxy directions into the amount charged
-// by the selected VPS billing policy. BytesOut is the response sent to clients.
+// trafficBillableBytes translates the two logical proxy payload directions into
+// the amount charged by the selected VPS billing policy. Every payload byte
+// relayed by Meridian crosses two VPS network legs: it is received once and
+// sent once. Outbound mode intentionally keeps the existing product meaning of
+// counting only responses delivered to clients.
 func trafficBillableBytes(mode string, bytesIn, bytesOut int64) int64 {
 	if bytesIn < 0 {
 		bytesIn = 0
@@ -19,7 +22,15 @@ func trafficBillableBytes(mode string, bytesIn, bytesOut int64) int64 {
 	if mode == trafficBillingModeOutbound {
 		return bytesOut
 	}
-	return bytesIn + bytesOut
+	const maxInt64 = int64(^uint64(0) >> 1)
+	if bytesIn > maxInt64-bytesOut {
+		return maxInt64
+	}
+	total := bytesIn + bytesOut
+	if total > maxInt64/2 {
+		return maxInt64
+	}
+	return total * 2
 }
 
 func trafficBillingModeLabel(mode string) string {

--- a/traffic_billing_test.go
+++ b/traffic_billing_test.go
@@ -57,8 +57,8 @@ func TestTrafficCycleUsageRespectsSiteAndBillingMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("outbound cycle usage: %v", err)
 	}
-	if dual != 400 || outbound != 300 {
-		t.Fatalf("cycle usage = dual %d outbound %d, want 400/300", dual, outbound)
+	if dual != 800 || outbound != 300 {
+		t.Fatalf("cycle usage = dual %d outbound %d, want 800/300", dual, outbound)
 	}
 }
 
@@ -93,8 +93,8 @@ func TestDisabledTrafficResetUsesAllPersistedUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sum no-reset usage: %v", err)
 	}
-	if usage != 400 {
-		t.Fatalf("no-reset usage = %d, want all-time 400", usage)
+	if usage != 800 {
+		t.Fatalf("no-reset usage = %d, want all-time 800", usage)
 	}
 }
 
@@ -111,8 +111,8 @@ func TestTrafficBillingModeAppliesToAllTrafficSnapshots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dual snapshot: %v", err)
 	}
-	if dual.TotalTraffic != 400 || dual.BillingMode != trafficBillingModeBidirectional {
-		t.Fatalf("dual snapshot = %+v, want 400 bidirectional", dual)
+	if dual.TotalTraffic != 800 || dual.BillingMode != trafficBillingModeBidirectional {
+		t.Fatalf("dual snapshot = %+v, want 800 bidirectional", dual)
 	}
 
 	settings := app.db.currentSystemSettings()
@@ -165,8 +165,8 @@ func TestCurrentTrafficCycleUsageCachesPersistedAndTracksFlushes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("current usage: %v", err)
 	}
-	if usage != 330 {
-		t.Fatalf("current usage = %d, want 330", usage)
+	if usage != 660 {
+		t.Fatalf("current usage = %d, want 660", usage)
 	}
 	if err := app.pm.flushProxyTraffic(inst); err != nil {
 		t.Fatalf("flush traffic: %v", err)
@@ -175,8 +175,8 @@ func TestCurrentTrafficCycleUsageCachesPersistedAndTracksFlushes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("usage after flush: %v", err)
 	}
-	if usage != 330 {
-		t.Fatalf("usage after flush = %d, want 330 without double counting", usage)
+	if usage != 660 {
+		t.Fatalf("usage after flush = %d, want 660 without double counting", usage)
 	}
 
 	settings := app.db.currentSystemSettings()
@@ -190,5 +190,25 @@ func TestCurrentTrafficCycleUsageCachesPersistedAndTracksFlushes(t *testing.T) {
 	}
 	if usage != 220 {
 		t.Fatalf("outbound usage = %d, want 220", usage)
+	}
+}
+
+func TestTrafficBillableBytesCountsBothVPSNetworkLegs(t *testing.T) {
+	videoBytes := int64(784) * (1 << 30) / 100
+	if got := trafficBillableBytes(trafficBillingModeBidirectional, 0, videoBytes); got != videoBytes*2 {
+		t.Fatalf("bidirectional 7.84 GiB video = %d, want %d", got, videoBytes*2)
+	}
+	if got := trafficBillableBytes(trafficBillingModeOutbound, 0, videoBytes); got != videoBytes {
+		t.Fatalf("outbound 7.84 GiB video = %d, want %d", got, videoBytes)
+	}
+}
+
+func TestTrafficBillableBytesClampsInvalidAndOverflowingCounters(t *testing.T) {
+	if got := trafficBillableBytes(trafficBillingModeBidirectional, -10, 5); got != 10 {
+		t.Fatalf("negative input clamp = %d, want 10", got)
+	}
+	maxInt64 := int64(^uint64(0) >> 1)
+	if got := trafficBillableBytes(trafficBillingModeBidirectional, maxInt64, 1); got != maxInt64 {
+		t.Fatalf("overflow result = %d, want saturated %d", got, maxInt64)
 	}
 }

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -21,7 +21,7 @@ type TrafficLog struct {
 
 // SiteTraffic is the authoritative per-site traffic state: the persisted
 // baseline plus in-memory pending bytes. TrafficUsed is always
-// PersistedTraffic + BytesIn + BytesOut (pending, not yet flushed).
+// the configured billing projection of persisted and pending raw directions.
 type SiteTraffic struct {
 	ID                 int64  `json:"id"`
 	Name               string `json:"name"`
@@ -168,28 +168,20 @@ func (d *DB) GetTrafficLogs(siteID int64, hours int) ([]TrafficLog, error) {
 // wall-clock buckets for backwards compatibility, so the comparison uses the
 // same text format as trafficMinuteBucket instead of UTC serialization.
 func (d *DB) SumTrafficSince(start time.Time, billingMode string) (int64, error) {
-	var total int64
-	expression := "bytes_in + bytes_out"
-	if trafficBillingModeLabel(billingMode) == trafficBillingModeOutbound {
-		expression = "bytes_out"
-	}
+	var bytesIn, bytesOut int64
 	err := d.db.QueryRow(
-		"SELECT COALESCE(SUM("+expression+"), 0) FROM traffic_logs WHERE recorded_at >= ?",
+		"SELECT COALESCE(SUM(bytes_in), 0), COALESCE(SUM(bytes_out), 0) FROM traffic_logs WHERE recorded_at >= ?",
 		start.In(time.Local).Format("2006-01-02 15:04:05"),
-	).Scan(&total)
-	return total, err
+	).Scan(&bytesIn, &bytesOut)
+	return trafficBillableBytes(billingMode, bytesIn, bytesOut), err
 }
 
 // SumTrafficSinceBySite returns the same billing-mode projection as
 // SumTrafficSince, grouped by site so dashboards can show each node's current
 // month usage without issuing one query per site.
 func (d *DB) SumTrafficSinceBySite(start time.Time, billingMode string) (map[int64]int64, error) {
-	expression := "bytes_in + bytes_out"
-	if trafficBillingModeLabel(billingMode) == trafficBillingModeOutbound {
-		expression = "bytes_out"
-	}
 	rows, err := d.db.Query(
-		"SELECT site_id, COALESCE(SUM("+expression+"), 0) FROM traffic_logs WHERE recorded_at >= ? GROUP BY site_id",
+		"SELECT site_id, COALESCE(SUM(bytes_in), 0), COALESCE(SUM(bytes_out), 0) FROM traffic_logs WHERE recorded_at >= ? GROUP BY site_id",
 		start.In(time.Local).Format("2006-01-02 15:04:05"),
 	)
 	if err != nil {
@@ -198,11 +190,11 @@ func (d *DB) SumTrafficSinceBySite(start time.Time, billingMode string) (map[int
 	defer rows.Close()
 	result := make(map[int64]int64)
 	for rows.Next() {
-		var siteID, total int64
-		if err := rows.Scan(&siteID, &total); err != nil {
+		var siteID, bytesIn, bytesOut int64
+		if err := rows.Scan(&siteID, &bytesIn, &bytesOut); err != nil {
 			return nil, err
 		}
-		result[siteID] = total
+		result[siteID] = trafficBillableBytes(billingMode, bytesIn, bytesOut)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -214,16 +206,12 @@ func (d *DB) SumTrafficSinceBySite(start time.Time, billingMode string) (map[int
 // Directional columns remain raw so changing the billing mode never destroys
 // the information needed to recalculate the current cycle.
 func (d *DB) SumTrafficSinceForSite(siteID int64, start time.Time, billingMode string) (int64, error) {
-	expression := "bytes_in + bytes_out"
-	if trafficBillingModeLabel(billingMode) == trafficBillingModeOutbound {
-		expression = "bytes_out"
-	}
-	var total int64
+	var bytesIn, bytesOut int64
 	err := d.db.QueryRow(
-		"SELECT COALESCE(SUM("+expression+"), 0) FROM traffic_logs WHERE site_id=? AND recorded_at >= ?",
+		"SELECT COALESCE(SUM(bytes_in), 0), COALESCE(SUM(bytes_out), 0) FROM traffic_logs WHERE site_id=? AND recorded_at >= ?",
 		siteID, start.In(time.Local).Format("2006-01-02 15:04:05"),
-	).Scan(&total)
-	return total, err
+	).Scan(&bytesIn, &bytesOut)
+	return trafficBillableBytes(billingMode, bytesIn, bytesOut), err
 }
 
 // GetTrafficTrendLogs returns minute/hour buckets in the requested wall-clock

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -4841,7 +4841,7 @@ html {
 .dashboard-trend-apply { min-height: 42px; white-space: nowrap; }
 .dashboard-trend-custom-error { flex: 1 0 100%; margin: -4px 0 0; color: var(--red); font-size: 12px; text-align: right; }
 .dashboard-trend-custom[hidden], .dashboard-trend-custom-error[hidden] { display: none !important; }
-.dashboard-trend-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; margin-top: 14px; }
+.dashboard-trend-grid { position: relative; z-index: 3; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; margin-top: 14px; }
 .dashboard-trend-grid .dashboard-trend-card { min-width: 0; margin-top: 0; padding: 16px; }
 .dashboard-trend-grid .dashboard-trend-wrap { position: relative; height: clamp(210px, 22vw, 290px); min-height: 210px; }
 .dashboard-trend-grid canvas { display: block; width: 100%; height: 100%; max-width: 100%; cursor: default; touch-action: none; }
@@ -4850,6 +4850,7 @@ html {
 .dashboard-chart-tooltip-row + .dashboard-chart-tooltip-row { margin-top: 3px; padding-top: 3px; border-top: 1px solid var(--panel-border); }
 .dashboard-chart-tooltip-row strong { color: var(--white-87); font-weight: 700; }
 .dashboard-chart-tooltip-row span { color: var(--white-70); text-align: right; white-space: nowrap; }
+.dashboard-insights-grid, .dashboard-site-status { position: relative; z-index: 1; }
 .dashboard-site-status { margin-top: 18px; }
 @media (max-width: 768px) {
   .sidebar-drawer-close { position: absolute; top: 16px; right: 10px; z-index: 3; display: grid; place-items: center; width: 36px; height: 36px; border: 1px solid var(--panel-border); border-radius: 9px; background: var(--panel); color: var(--white-60); }
@@ -5278,7 +5279,7 @@ html { font-size: 15px; }
 .request-log-backend { white-space: normal; overflow-wrap: anywhere; line-height: 1.35; }
 .request-log-time { display: block; overflow: hidden; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
 
-.dashboard-trend-card { min-width: 0; overflow: hidden; }
+.dashboard-trend-card { min-width: 0; overflow: visible; }
 .dashboard-trend-wrap { width: 100%; height: clamp(210px, 28vw, 360px); min-height: 210px; max-height: 360px; }
 #dashboardRequestTrend { display: block; width: 100% !important; height: 100% !important; max-width: 100%; }
 .dashboard-trend-note { display: none; }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -4404,7 +4404,7 @@ html {
 .request-log-filter-row {
   gap: 12px;
   margin-top: 10px;
-  padding-top: 0;
+  padding: 10px 0;
 }
 
 .request-log-filter-label {
@@ -4416,10 +4416,15 @@ html {
 }
 
 .request-log-pill {
-  min-height: 34px;
-  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 7px 16px;
   border-radius: 8px;
   font-size: 14px;
+  line-height: 1.2;
+  text-align: center;
 }
 
 .request-log-actions {

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -187,13 +187,30 @@ function dashboardTooltipPosition(pointerX, pointerY, wrapWidth, wrapHeight, too
   const cardHeight = Math.max(1, Number(tooltipHeight) || 56);
   const gap = 14;
   const padding = 6;
-  let left = pointerX + gap;
-  if (left + cardWidth > width - padding) left = pointerX - cardWidth - gap;
-  left = Math.max(padding, Math.min(Math.max(padding, width - cardWidth - padding), left));
-  let top = pointerY - cardHeight - gap;
-  if (top < padding) top = pointerY + gap;
-  top = Math.max(padding, Math.min(Math.max(padding, height - cardHeight - padding), top));
-  return { left, top };
+  const rightSpace = width - pointerX - gap - padding;
+  const leftSpace = pointerX - gap - padding;
+  const clampLeft = left => Math.max(padding, Math.min(Math.max(padding, width - cardWidth - padding), left));
+
+  // Keep the tooltip beside the pointer whenever possible. This avoids
+  // covering the pointer even when the contents contain many site rows.
+  if (rightSpace >= cardWidth) {
+    let top = pointerY - cardHeight - gap;
+    if (top < padding) top = pointerY + gap;
+    return { left: clampLeft(pointerX + gap), top };
+  }
+  if (leftSpace >= cardWidth) {
+    let top = pointerY - cardHeight - gap;
+    if (top < padding) top = pointerY + gap;
+    return { left: clampLeft(pointerX - cardWidth - gap), top };
+  }
+
+  // If neither side has enough room, place the full card above or below the
+  // pointer. It is intentionally allowed to overflow the chart wrapper so
+  // long all-site tooltips keep all rows visible without covering the pointer.
+  const aboveSpace = Math.max(0, pointerY - gap - padding);
+  const belowSpace = Math.max(0, height - pointerY - gap - padding);
+  const below = belowSpace >= aboveSpace;
+  return { left: clampLeft(pointerX - cardWidth / 2), top: below ? pointerY + gap : pointerY - cardHeight - gap };
 }
 
 function dashboardTrendTimeLabel(timestamp, range) {

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -180,6 +180,18 @@ function dashboardTrendPointerState(rect, geometry, event, pointCount) {
   return { x, y, index };
 }
 
+function dashboardTrendPointerInside(rect, event) {
+  if (!rect || !event) return false;
+  const x = Number(event.clientX);
+  const y = Number(event.clientY);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+  const left = Number(rect.left) || 0;
+  const top = Number(rect.top) || 0;
+  const right = Number.isFinite(Number(rect.right)) ? Number(rect.right) : left + (Number(rect.width) || 0);
+  const bottom = Number.isFinite(Number(rect.bottom)) ? Number(rect.bottom) : top + (Number(rect.height) || 0);
+  return x >= left && x <= right && y >= top && y <= bottom;
+}
+
 function dashboardTooltipPosition(pointerX, pointerY, wrapWidth, wrapHeight, tooltipWidth, tooltipHeight) {
   const width = Math.max(1, Number(wrapWidth) || 1);
   const height = Math.max(1, Number(wrapHeight) || 1);
@@ -567,6 +579,13 @@ function setupDashboardTrendControls() {
       const points = dashboardTrendPoints();
       if (!points.length) return;
       const rect = canvas.getBoundingClientRect();
+      // Touch pointer capture continues delivering pointermove events after
+      // the finger leaves the canvas. Do not clamp those events to the edge:
+      // hide the tooltip until the finger comes back into the chart.
+      if (event.pointerType !== 'mouse' && !dashboardTrendPointerInside(rect, event)) {
+        clearHover();
+        return;
+      }
       const geometry = chart.geometry || { width: rect.width, height: rect.height, left: 0, top: 0, plotW: rect.width, plotH: rect.height };
       const pointer = dashboardTrendPointerState(rect, geometry, event, points.length);
       chart.hoverIndex = pointer.index;
@@ -607,9 +626,7 @@ function setupDashboardTrendControls() {
     canvas.addEventListener('pointercancel', clearHover);
     canvas.addEventListener('pointerleave', event => {
       if (event.pointerType !== 'mouse') return;
-      chart.hoverIndex = -1; chart.hoverX = null; chart.hoverY = null;
-      if (tooltip) tooltip.hidden = true;
-      drawDashboardTrendChart(metric);
+      clearHover();
     });
   });
 }

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -846,7 +846,7 @@ function updateDashboardSiteSpeeds(liveSites) {
       bytes_in: bytesIn,
       bytes_out: bytesOut,
       requests: dashboardSafeNonNegative(sample?.requests),
-      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound' ? bytesOut : bytesIn + bytesOut,
+      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound' ? bytesOut : 2 * (bytesIn + bytesOut),
     });
     // Keep the active dashboard session responsive without imposing a time
     // window; the X axis adapts to however many samples are available.
@@ -865,7 +865,9 @@ function updateDashboardSiteSpeeds(liveSites) {
       bytes_in: dashboardSafeNonNegative(delta.bytesIn),
       bytes_out: dashboardSafeNonNegative(delta.bytesOut),
       requests: dashboardSafeNonNegative(delta.requests),
-      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound' ? dashboardSafeNonNegative(delta.bytesOut) : dashboardSafeNonNegative(delta.bytesIn) + dashboardSafeNonNegative(delta.bytesOut),
+      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound'
+        ? dashboardSafeNonNegative(delta.bytesOut)
+        : 2 * (dashboardSafeNonNegative(delta.bytesIn) + dashboardSafeNonNegative(delta.bytesOut)),
     });
     dashboardRealtimeTrendSiteSamples.set(String(siteID), siteSamples.slice(-1800));
   }

--- a/web/static/js/pages/global-settings.js
+++ b/web/static/js/pages/global-settings.js
@@ -214,7 +214,7 @@ function paintGlobalSettings(page = document.getElementById('page-global-setting
 
 function renderSystemUIForm(s) {
   return `<section class="settings-panel"><header><span>SYSTEM</span><h2>系统设置</h2><b>全局运行参数</b></header>
-    <p class="settings-panel-help">单向仅计 VPS 发给客户端的出站流量；双向同时计源站回到 VPS 的入站与 VPS 发给客户端的出站流量。</p>
+    <p class="settings-panel-help">单向仅计 VPS 发给客户端的出站流量；双向按经过 Meridian 的代理载荷同时计算 VPS 接收与发送流量，例如反代 1 GB 视频约计 2 GB。</p>
     <span class="settings-label">计费方向</span><div class="settings-choice" id="traffic-billing-mode-choice"><button data-setting-choice="outbound" class="${s.traffic_billing_mode === 'outbound' ? 'active' : ''}">单向（仅下载）</button><button data-setting-choice="bidirectional" class="${s.traffic_billing_mode !== 'outbound' ? 'active' : ''}">双向（下载 + 上传）</button></div>
   </section>
   <section class="settings-panel"><header><span>TRAFFIC RESET</span><h2>流量周期</h2><b>可重置或累计</b></header>

--- a/web/static/js/pages/traffic.js
+++ b/web/static/js/pages/traffic.js
@@ -89,7 +89,7 @@ async function loadTrafficChart() {
     const billingMode = data.billing_mode === 'outbound' ? 'outbound' : 'bidirectional';
     const totalIn = logs.reduce((sum, log) => sum + Math.max(0, Number(log.bytes_in) || 0), 0);
     const totalOut = logs.reduce((sum, log) => sum + Math.max(0, Number(log.bytes_out) || 0), 0);
-    const billableRange = billingMode === 'outbound' ? totalOut : totalIn + totalOut;
+    const billableRange = billingMode === 'outbound' ? totalOut : 2 * (totalIn + totalOut);
     const totalRequests = logs.reduce((sum, log) => sum + Math.max(0, Number(log.requests) || 0), 0);
     const rangeLabel = trafficRangeLabel(hours);
     const rangeNote = document.getElementById('traffic-range-note');


### PR DESCRIPTION
## Summary

This is an incremental follow-up to #50. It is based directly on the current `snnabb/Meridian:master` and contains only the four commits added after the previous PR head (`89ff81c`). Upstream release metadata and README content are intentionally left unchanged.

### Included changes

- keep long dashboard trend tooltips readable without clipping or covering the pointer;
- close mobile trend tooltips when touch interaction leaves the chart;
- normalize Emby/Jellyfin Base URL prefixes before matching the reserved dynamic playback route;
- correct bidirectional VPS traffic billing across quotas, cycle totals, dashboard/history/realtime trends, the compatibility traffic view, and Telegram reports.

### Bidirectional billing semantics

```text
outbound      = bytes_out
bidirectional = 2 × (bytes_in + bytes_out)
```

The database continues to store raw directional bytes. Billing mode is applied when values are read, so changing the mode does not rewrite or destroy history. A proxied 1 GB media payload is therefore reported as approximately 2 GB in bidirectional mode: one VPS receive leg plus one VPS send leg.

Traffic that does not traverse Meridian is outside this accounting boundary. For example, VLESS/sing-box traffic and client-side traffic after a direct HTTP 302 redirect are not counted by Meridian.

### Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Node tests: 136/136
- `git diff --check upstream/master...HEAD`
- Linux amd64 build

The conflict resolutions preserve upstream's named-timezone handling, defensive frontend numeric normalization, current version, and documentation structure.