### PR TITLE
feat: allow custom installer panel port

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/insta
 # 安装；可在交互流程中配置面板 HTTPS 域名
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) install
 
+# 非交互安装并自定义管理面板端口
+bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) install \
+  --port 18090 -y
+
 # 非交互安装并配置面板域名
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) install \
-  --domain panel.example.com --email admin@example.com -y
+  --port 18090 --domain panel.example.com --email admin@example.com -y
 
 # 更新；自动备份、健康检查，失败时回滚
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) update
@@ -98,7 +102,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/insta
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh) uninstall
 ```
 
-Linux 可自动安装或复用 Nginx、Certbot，并为管理面板配置 HTTPS。生成的 Nginx 配置只代理管理端口，不读取或修改站点回源和独立监听端口。macOS 支持安装，但不支持自动域名配置。
+Linux 可自动安装或复用 Nginx、Certbot，并为管理面板配置 HTTPS。`--port` 支持 `1-65535`；首次安装默认使用 `9090`，对已有安装再次执行 `install --port PORT` 可切换面板端口。切换已有 HTTPS 面板时只更新 Meridian 管理的 `proxy_pass` 目标，会保留证书、443 配置和 Certbot 重定向。生成的 Nginx 配置只代理管理端口，不读取或修改站点回源和独立监听端口。macOS 支持安装，但不支持自动域名配置。
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Meridian 把多站点反代、UA 身份、流量管控和故障诊断整合进�
 bash <(curl -fsSL https://raw.githubusercontent.com/snnabb/Meridian/master/install.sh)
 ```
 
-脚本会进入四项菜单：安装、更新、修改管理员密码、卸载。首次安装会自动补齐 `curl`、证书、校验和文本处理等基础依赖；若 Release 带 Sigstore 签名，脚本会下载并校验固定版本的临时 cosign，再验证 `SHA256SUMS` 签名，无需用户预装 cosign。Linux systemd 部署默认使用独立的非 root 用户。
+脚本会进入四项菜单：安装、更新、修改管理员密码、卸载。选择“安装”后可直接输入管理面板端口；留空时首次安装默认使用 `9090`，已有安装则保留当前端口。首次安装会自动补齐 `curl`、证书、校验和文本处理等基础依赖；若 Release 带 Sigstore 签名，脚本会下载并校验固定版本的临时 cosign，再验证 `SHA256SUMS` 签名，无需用户预装 cosign。Linux systemd 部署默认使用独立的非 root 用户。
 
 安装完成后：
 

--- a/install.sh
+++ b/install.sh
@@ -2381,7 +2381,22 @@ Meridian 一键安装工具
   --purge          卸载时删除数据目录；不会删除备份、Nginx、Certbot 或证书
 
 不带参数运行时进入四项菜单。
+选择“安装”后可交互输入管理面板端口；直接回车时，首次安装使用 9090，已有安装保留当前端口。
 USAGE
+}
+
+prompt_panel_port() {
+    local answer
+    while :; do
+        read -r -p "请输入管理面板端口（1-65535，直接回车使用默认行为）: " answer
+        if [ -z "$answer" ]; then
+            return 0
+        fi
+        if REQUESTED_PORT=$(normalize_port "$answer"); then
+            return 0
+        fi
+        warn "面板端口无效: $answer（必须是 1-65535 的整数）"
+    done
 }
 
 main_menu() {
@@ -2396,7 +2411,10 @@ main_menu() {
     printf '  0) 退出\n\n'
     read -r -p "请选择 [0-4]: " choice
     case "$choice" in
-        1) do_install ;;
+        1)
+            prompt_panel_port
+            do_install
+            ;;
         2) do_update ;;
         3) do_password ;;
         4) do_uninstall ;;

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@ SERVICE_NAME="${MERIDIAN_SERVICE_NAME:-meridian}"
 NGINX_CONFIG="${MERIDIAN_NGINX_CONFIG:-/etc/nginx/conf.d/meridian-panel.conf}"
 NGINX_ROOT="${MERIDIAN_NGINX_ROOT:-/etc/nginx}"
 BIN_NAME="meridian"
+DEFAULT_PANEL_PORT=9090
 COSIGN_VERSION="v2.6.4"
 SERVICE_USER="meridian"
 SERVICE_GROUP="meridian"
@@ -31,6 +32,7 @@ ASSUME_YES="${MERIDIAN_ASSUME_YES:-0}"
 PURGE_DATA=0
 DOMAIN_MODE="ask"
 REQUESTED_DOMAIN=""
+REQUESTED_PORT=""
 CERTBOT_EMAIL=""
 INITIAL_SETUP_TOKEN=""
 SETUP_TOKEN_ORIGIN=""
@@ -152,6 +154,25 @@ validate_db_path() {
 
 valid_version() {
     [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]
+}
+
+valid_port() {
+    local port="${1:-}" normalized LC_ALL=C
+    [[ "$port" =~ ^[0-9]+$ ]] || return 1
+    normalized="${port#"${port%%[!0]*}"}"
+    [ -n "$normalized" ] || return 1
+    case "${#normalized}" in
+        1|2|3|4) return 0 ;;
+        5) [[ "$normalized" < "65536" ]] ;;
+        *) return 1 ;;
+    esac
+}
+
+normalize_port() {
+    local port="${1:-}"
+    valid_port "$port" || return 1
+    port="${port#"${port%%[!0]*}"}"
+    printf '%s\n' "$port"
 }
 
 version_gt() {
@@ -774,14 +795,15 @@ ensure_dynamic_route_key() {
 
 
 set_panel_env() {
-    local bind_addr="$1" domain="$2" proxies="$3" allow_insecure="$4" tmp_dir="$5" env_file tmp_file
+    local bind_addr="$1" domain="$2" proxies="$3" allow_insecure="$4" tmp_dir="$5" port="${6:-$(read_config_port)}" env_file tmp_file
     env_file=$(env_file_path) || return 1
+    port=$(normalize_port "$port") || return 1
     tmp_file="${tmp_dir}/panel.env"
     # $1 is an awk field reference, not a shell variable.
     # shellcheck disable=SC2016
-    as_root awk -F= '$1 != "PANEL_BIND_ADDR" && $1 != "PANEL_DOMAIN" && $1 != "TRUSTED_PROXY_CIDRS" && $1 != "ALLOW_INSECURE_HTTP" { print }' "$env_file" > "$tmp_file" || return 1
-    printf 'PANEL_BIND_ADDR=%s\nPANEL_DOMAIN=%s\nTRUSTED_PROXY_CIDRS=%s\nALLOW_INSECURE_HTTP=%s\n' \
-        "$bind_addr" "$domain" "$proxies" "$allow_insecure" >> "$tmp_file" || return 1
+    as_root awk -F= '$1 != "PORT" && $1 != "PANEL_BIND_ADDR" && $1 != "PANEL_DOMAIN" && $1 != "TRUSTED_PROXY_CIDRS" && $1 != "ALLOW_INSECURE_HTTP" { print }' "$env_file" > "$tmp_file" || return 1
+    printf 'PORT=%s\nPANEL_BIND_ADDR=%s\nPANEL_DOMAIN=%s\nTRUSTED_PROXY_CIDRS=%s\nALLOW_INSECURE_HTTP=%s\n' \
+        "$port" "$bind_addr" "$domain" "$proxies" "$allow_insecure" >> "$tmp_file" || return 1
     chmod 0600 "$tmp_file" || return 1
     install_env_file "$tmp_file" || return 1
 }
@@ -813,10 +835,10 @@ remove_loopback_proxies() {
 read_config_port() {
     local configured
     configured=$(read_env_value PORT)
-    if [[ "$configured" =~ ^[0-9]+$ ]] && [ "$configured" -ge 1 ] && [ "$configured" -le 65535 ]; then
+    if configured=$(normalize_port "$configured"); then
         printf '%s\n' "$configured"
     else
-        printf '9090\n'
+        printf '%s\n' "$DEFAULT_PANEL_PORT"
     fi
 }
 
@@ -856,7 +878,7 @@ ensure_service_user() {
 }
 
 prepare_data_and_config() {
-    local tmp_dir="$1" env_file secret upstream_header_key dynamic_route_key credential_key env_tmp
+    local tmp_dir="$1" env_file secret upstream_header_key dynamic_route_key credential_key env_tmp port
     validate_data_dir || return 1
     env_file=$(env_file_path) || return 1
     if as_root test -L "$env_file"; then
@@ -882,8 +904,10 @@ prepare_data_and_config() {
         credential_key=$(generate_distinct_secret "$secret" "$upstream_header_key" "$dynamic_route_key") || return 1
         INITIAL_SETUP_TOKEN=$(generate_distinct_secret "$secret" "$upstream_header_key" "$dynamic_route_key" "$credential_key") || return 1
         env_tmp="${tmp_dir}/meridian.env"
-        printf 'JWT_SECRET=%s\nUPSTREAM_HEADER_KEY=%s\nDYNAMIC_ROUTE_KEY=%s\nMERIDIAN_SECRET_KEY=%s\nSETUP_TOKEN=%s\nPORT=9090\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=127.0.0.1\nPANEL_DOMAIN=\nPANEL_ROUTE_DOMAIN=\nPANEL_TLS_ENABLED=false\nPANEL_TLS_CERT_FILE=\nPANEL_TLS_KEY_FILE=\nTRUSTED_PROXY_CIDRS=\nALLOW_INSECURE_HTTP=false\n' \
-            "$secret" "$upstream_header_key" "$dynamic_route_key" "$credential_key" "$INITIAL_SETUP_TOKEN" "$DATA_DIR" > "$env_tmp" || return 1
+        port="${REQUESTED_PORT:-$DEFAULT_PANEL_PORT}"
+        port=$(normalize_port "$port") || fail "面板端口无效: $port"
+        printf 'JWT_SECRET=%s\nUPSTREAM_HEADER_KEY=%s\nDYNAMIC_ROUTE_KEY=%s\nMERIDIAN_SECRET_KEY=%s\nSETUP_TOKEN=%s\nPORT=%s\nDB_PATH=%s/meridian.db\nPANEL_BIND_ADDR=127.0.0.1\nPANEL_DOMAIN=\nPANEL_ROUTE_DOMAIN=\nPANEL_TLS_ENABLED=false\nPANEL_TLS_CERT_FILE=\nPANEL_TLS_KEY_FILE=\nTRUSTED_PROXY_CIDRS=\nALLOW_INSECURE_HTTP=false\n' \
+            "$secret" "$upstream_header_key" "$dynamic_route_key" "$credential_key" "$INITIAL_SETUP_TOKEN" "$port" "$DATA_DIR" > "$env_tmp" || return 1
         chmod 0600 "$env_tmp" || return 1
         install_env_file "$env_tmp" || return 1
         SETUP_TOKEN_ORIGIN="generated"
@@ -1422,6 +1446,38 @@ server {
 NGINXEOF
 }
 
+update_managed_panel_proxy_port() {
+    local port="$1" output="$2"
+    port=$(normalize_port "$port") || return 1
+    as_root test -f "$NGINX_CONFIG" || return 1
+    as_root test -L "$NGINX_CONFIG" && return 1
+    as_root grep -Fqx "$NGINX_MARKER" "$NGINX_CONFIG" || return 1
+    # The marker is necessary but not sufficient: retain the same panel-vhost
+    # shape used by the installer before touching a managed file.
+    # shellcheck disable=SC2016
+    as_root grep -Fq 'proxy_set_header Host $host;' "$NGINX_CONFIG" || return 1
+
+    # Port changes must preserve Certbot's HTTPS servers and every other
+    # directive. Only a single numeric loopback proxy target from the managed
+    # panel template is eligible for replacement.
+    # shellcheck disable=SC2016
+    if ! LC_ALL=C as_root awk -v port="$port" '
+        {
+            line=$0
+            if (line ~ /^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:[0-9]+;([[:space:]]*#.*)?[[:space:]]*$/) {
+                proxy_count++
+                sub(/http:\/\/127\.0\.0\.1:[0-9]+;/, "http://127.0.0.1:" port ";", line)
+            }
+            print line
+        }
+        END { exit (proxy_count == 1 ? 0 : 42) }
+    ' "$NGINX_CONFIG" > "$output"; then
+        rm -f -- "$output"
+        warn "Nginx 配置中未找到唯一的 Meridian 面板回源目标，拒绝修改端口"
+        return 1
+    fi
+}
+
 migrate_managed_nginx_redaction() {
     local work_dir backup migrated log_line redaction_state insert_definitions=0 preserve_backup=0
     log_line=$(canonical_nginx_redacted_log_format)
@@ -1655,6 +1711,69 @@ restart_meridian_and_health() {
     wait_for_health 20
 }
 
+configure_panel_port() {
+    local requested_port="$1" port current_port work_dir bind_addr domain proxies allow_insecure config_tmp
+    port=$(normalize_port "$requested_port") || {
+        warn "面板端口无效: $requested_port"
+        return 1
+    }
+    current_port=$(read_config_port)
+    if [ "$port" = "$current_port" ]; then
+        info "面板端口保持不变: $current_port"
+        return 0
+    fi
+
+    bind_addr=$(read_env_value PANEL_BIND_ADDR)
+    domain=$(read_env_value PANEL_DOMAIN)
+    proxies=$(read_env_value TRUSTED_PROXY_CIDRS)
+    allow_insecure=$(read_env_value ALLOW_INSECURE_HTTP)
+
+    if [ -n "$domain" ]; then
+        validate_nginx_config_path
+        if ! as_root test -f "$NGINX_CONFIG" || as_root test -L "$NGINX_CONFIG" \
+            || ! as_root grep -Fqx "$NGINX_MARKER" "$NGINX_CONFIG"; then
+            warn "已配置面板域名，但 Nginx 配置不是安装器管理的文件，拒绝只修改后端端口"
+            return 1
+        fi
+    fi
+
+    work_dir=$(mktemp -d)
+    chmod 0700 "$work_dir"
+    snapshot_panel_state "$work_dir" || { rm -rf -- "$work_dir"; return 1; }
+    begin_panel_transaction "$work_dir"
+
+    if ! set_panel_env "$bind_addr" "$domain" "$proxies" "$allow_insecure" "$work_dir" "$port"; then
+        warn "面板端口配置失败，正在恢复原配置"
+        rollback_panel_transaction
+        return 1
+    fi
+
+    if [ -n "$domain" ]; then
+        config_tmp="${work_dir}/meridian-panel.conf"
+        if ! update_managed_panel_proxy_port "$port" "$config_tmp" \
+            || ! as_root install -o root -g root -m 0644 "$config_tmp" "${NGINX_CONFIG}.new" \
+            || ! as_root mv -f "${NGINX_CONFIG}.new" "$NGINX_CONFIG" \
+            || ! nginx_test_and_reload; then
+            as_root rm -f -- "${NGINX_CONFIG}.new" 2>/dev/null || true
+            warn "Nginx 端口配置检查失败，正在恢复原配置"
+            rollback_panel_transaction
+            return 1
+        fi
+    fi
+
+    if is_systemd; then
+        if ! restart_meridian_and_health; then
+            warn "Meridian 使用新面板端口启动失败，正在恢复原配置"
+            rollback_panel_transaction
+            return 1
+        fi
+    else
+        warn "未检测到 systemd：面板端口已写入 ${port}，请重启手动管理的 Meridian 进程后生效"
+    fi
+    commit_panel_transaction
+    ok "面板端口已切换: ${current_port} -> ${port}"
+}
+
 configure_panel_domain() {
     local domain="$1" email="$2" work_dir port proxies config_tmp
     validate_nginx_config_path
@@ -1854,6 +1973,10 @@ do_install() {
             return 1
         fi
         rm -rf -- "$tmp_dir"
+        if [ -n "$REQUESTED_PORT" ]; then
+            configure_panel_port "$REQUESTED_PORT" \
+                || fail "面板端口修改失败；原配置已恢复"
+        fi
         print_setup_token_notice || return 1
         apply_domain_choice 1
         return 0
@@ -2238,7 +2361,7 @@ usage() {
 Meridian 一键安装工具
 
 用法:
-  install.sh install [--domain example.com] [--email EMAIL] [--no-domain] [-y]
+  install.sh install [--port PORT] [--domain example.com] [--email EMAIL] [--no-domain] [-y]
       首次安装最新版本；已安装时只补充或重新配置管理面板域名。
   install.sh update [-y]
       更新到最新 Release，自动备份、健康检查并在失败时回滚。
@@ -2250,7 +2373,8 @@ Meridian 一键安装工具
       显示本帮助。
 
 选项:
-  --domain DOMAIN  仅为管理面板配置 HTTPS 域名，固定代理到 127.0.0.1:9090（或 PORT）
+  --port PORT      管理面板监听端口，范围 1-65535；首次安装默认 9090，已有安装可安全切换
+  --domain DOMAIN  仅为管理面板配置 HTTPS 域名，代理到 127.0.0.1:PORT
   --email EMAIL    Certbot 证书邮箱，可留空
   --no-domain      不配置或取消安装器管理的面板域名
   -y, --yes        非交互确认；安装未指定域名时保留现有配置，首次安装则使用 IP
@@ -2300,6 +2424,14 @@ run_cli() {
                 REQUESTED_DOMAIN=$(normalize_domain "$2")
                 valid_domain "$REQUESTED_DOMAIN" || fail "域名格式无效"
                 DOMAIN_MODE="configure"
+                shift
+                ;;
+            --port|-p)
+                [ "$action" = "install" ] || fail "--port 仅用于 install"
+                [ "$#" -ge 2 ] || fail "--port 需要一个端口"
+                [ -z "$REQUESTED_PORT" ] || fail "端口选项不能重复"
+                REQUESTED_PORT=$(normalize_port "$2") \
+                    || fail "面板端口无效: $2（必须是 1-65535 的整数）"
                 shift
                 ;;
             --email)

--- a/install.sh
+++ b/install.sh
@@ -163,7 +163,7 @@ valid_port() {
     [ -n "$normalized" ] || return 1
     case "${#normalized}" in
         1|2|3|4) return 0 ;;
-        5) [[ "$normalized" < "65536" ]] ;;
+        5) [ "$normalized" -le 65535 ] ;;
         *) return 1 ;;
     esac
 }

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1385,6 +1385,27 @@ if printf '%s' "$menu_text" | grep -Eq '^  [5-9]\)'; then
     exit 1
 fi
 
+# Interactive menu installation accepts a custom panel port and keeps the
+# command-line/default behavior when the prompt is left blank.
+menu_custom_port=$(
+    REQUESTED_PORT=''
+    do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT"; }
+    printf '1\n18090\n' | main_menu | tail -n 1
+)
+assert_eq 'PORT=18090' "$menu_custom_port" 'interactive menu port'
+menu_default_port=$(
+    REQUESTED_PORT=''
+    do_install() { printf 'PORT=%s\n' "${REQUESTED_PORT:-<default>}"; }
+    printf '1\n\n' | main_menu | tail -n 1
+)
+assert_eq 'PORT=<default>' "$menu_default_port" 'interactive menu default port'
+menu_retry_port=$(
+    REQUESTED_PORT=''
+    do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT"; }
+    printf '1\nnot-a-port\n19090\n' | main_menu | tail -n 1
+)
+assert_eq 'PORT=19090' "$menu_retry_port" 'interactive menu invalid port retry'
+
 # CLI parsing accepts both normalized custom ports and the short alias while
 # rejecting malformed values and actions that cannot change the listener.
 parsed_port=$(

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -343,6 +343,36 @@ migrated_nginx_hash=$(sha256_file "$NGINX_CONFIG")
 assert_eq "$migrated_nginx_hash" "$(sha256_file "$NGINX_CONFIG")" 'idempotent Nginx migration'
 assert_eq '1' "$(grep -c '^validate$' "$nginx_migration_log")" 'idempotent migration skips reload'
 
+# Changing the panel port must only touch the managed loopback proxy target;
+# Certbot's HTTPS, certificate, redirect, and unrelated directives survive.
+panel_port_before="${TEST_ROOT}/nginx-port-before.conf"
+panel_port_after="${TEST_ROOT}/nginx-port-after.conf"
+cp "$NGINX_CONFIG" "$panel_port_before"
+update_managed_panel_proxy_port 18090 "$panel_port_after" \
+    || { echo 'FAIL: managed Nginx port update failed' >&2; exit 1; }
+assert_contains "$panel_port_after" 'proxy_pass http://127.0.0.1:18090;'
+assert_not_contains "$panel_port_after" 'proxy_pass http://127.0.0.1:9090;'
+assert_contains "$panel_port_after" 'listen 443 ssl; # managed by Certbot'
+assert_contains "$panel_port_after" 'ssl_certificate /etc/letsencrypt/live/panel.example.com/fullchain.pem; # managed by Certbot'
+assert_contains "$panel_port_after" 'return 301 https://$host$request_uri;'
+awk '!($0 ~ /^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:[0-9]+;([[:space:]]*#.*)?[[:space:]]*$/)' \
+    "$panel_port_before" > "${TEST_ROOT}/nginx-port-before-without-proxy"
+awk '!($0 ~ /^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:[0-9]+;([[:space:]]*#.*)?[[:space:]]*$/)' \
+    "$panel_port_after" > "${TEST_ROOT}/nginx-port-after-without-proxy"
+cmp -s "${TEST_ROOT}/nginx-port-before-without-proxy" "${TEST_ROOT}/nginx-port-after-without-proxy" \
+    || { echo 'FAIL: Nginx port update changed directives outside proxy_pass' >&2; exit 1; }
+
+# Ambiguous managed files are rejected without leaving a partial output.
+cp "$panel_port_before" "$NGINX_CONFIG"
+printf '    proxy_pass http://127.0.0.1:19090;\n' >> "$NGINX_CONFIG"
+ambiguous_port_output="${TEST_ROOT}/nginx-port-ambiguous.output"
+if update_managed_panel_proxy_port 20090 "$ambiguous_port_output"; then
+    echo 'FAIL: ambiguous managed Nginx proxy targets were accepted' >&2
+    exit 1
+fi
+[ ! -e "$ambiguous_port_output" ] || { echo 'FAIL: ambiguous Nginx update left output residue' >&2; exit 1; }
+cp "$panel_port_before" "$NGINX_CONFIG"
+
 # Complete-looking redaction components are still rejected before any rewrite
 # or reload unless the map is semantically canonical and the log_format is the
 # exact safe definition. These fixtures all satisfied the former substring
@@ -613,6 +643,7 @@ update_nginx_validation_log="${TEST_ROOT}/update-nginx-validation.log"
 nginx_test_and_reload() { printf 'validate\n' >> "$update_nginx_validation_log"; }
 DOMAIN_MODE='ask'
 REQUESTED_DOMAIN=''
+REQUESTED_PORT='18090'
 CERTBOT_EMAIL=''
 rm -rf -- "$INSTALL_DIR" "$DATA_DIR" "$BACKUP_DIR" "$NGINX_ROOT"
 
@@ -623,6 +654,8 @@ fi
 assert_eq 'v9.9.9' "$(get_current_version)" 'first installed version'
 assert_file "${DATA_DIR}/.env"
 assert_eq '127.0.0.1' "$(read_env_value PANEL_BIND_ADDR)" 'fresh IP bind'
+assert_eq '18090' "$(read_env_value PORT)" 'fresh install custom panel port'
+assert_contains "${TEST_ROOT}/install-first.log" '127.0.0.1:18090'
 upstream_header_key=$(read_env_value UPSTREAM_HEADER_KEY)
 if [ "${#upstream_header_key}" -lt 32 ]; then
     echo 'FAIL: fresh install must generate UPSTREAM_HEADER_KEY' >&2
@@ -653,6 +686,65 @@ for hidden_secret in "$jwt_secret" "$upstream_header_key" "$dynamic_route_key"; 
         exit 1
     fi
 done
+
+# Re-running install on an existing non-systemd installation persists a new
+# port and clearly tells the operator that the manually managed process needs a
+# restart.
+REQUESTED_PORT='19090'
+DOMAIN_MODE='ask'
+if ! (do_install) >"${TEST_ROOT}/install-existing-port.log" 2>&1; then
+    cat "${TEST_ROOT}/install-existing-port.log" >&2
+    exit 1
+fi
+assert_eq '19090' "$(read_env_value PORT)" 'existing install custom panel port'
+assert_contains "${TEST_ROOT}/install-existing-port.log" '请重启手动管理的 Meridian 进程后生效'
+REQUESTED_PORT=''
+
+# A systemd-managed port switch updates the existing HTTPS vhost in place and
+# rolls back both files when the new service health check fails.
+port_integration_tmp=$(mktemp -d "${TEST_ROOT}/panel-port.XXXXXX")
+set_panel_env '127.0.0.1' 'panel.example.com' '' 'false' "$port_integration_tmp" 19090
+rm -rf -- "$port_integration_tmp"
+write_legacy_managed_nginx
+port_systemd_log="${TEST_ROOT}/panel-port-systemd.log"
+: > "$port_systemd_log"
+if ! (
+    is_systemd() { return 0; }
+    install_env_file() { cp "$1" "$(env_file_path)"; }
+    systemctl() { printf '%s\n' "$*" >> "$port_systemd_log"; }
+    nginx_test_and_reload() { printf 'validate\n' >> "$port_systemd_log"; }
+    wait_for_health() { return 0; }
+    configure_panel_port 20090
+) >"${TEST_ROOT}/panel-port-success.log" 2>&1; then
+    cat "${TEST_ROOT}/panel-port-success.log" >&2
+    exit 1
+fi
+assert_eq '20090' "$(read_env_value PORT)" 'systemd panel port switch'
+assert_contains "$NGINX_CONFIG" 'proxy_pass http://127.0.0.1:20090;'
+assert_contains "$NGINX_CONFIG" 'ssl_certificate /etc/letsencrypt/live/panel.example.com/fullchain.pem; # managed by Certbot'
+assert_contains "$NGINX_CONFIG" 'return 301 https://$host$request_uri;'
+assert_contains "$port_systemd_log" 'restart meridian'
+
+cp "${DATA_DIR}/.env" "${TEST_ROOT}/panel-port-rollback.env"
+cp "$NGINX_CONFIG" "${TEST_ROOT}/panel-port-rollback.nginx"
+if (
+    is_systemd() { return 0; }
+    install_env_file() { cp "$1" "$(env_file_path)"; }
+    systemctl() { return 0; }
+    nginx_test_and_reload() { return 0; }
+    wait_for_health() { return 1; }
+    configure_panel_port 21090
+) >"${TEST_ROOT}/panel-port-rollback.log" 2>&1; then
+    echo 'FAIL: failed panel port health check unexpectedly succeeded' >&2
+    exit 1
+fi
+cmp -s "${DATA_DIR}/.env" "${TEST_ROOT}/panel-port-rollback.env" \
+    || { echo 'FAIL: panel port rollback did not restore .env' >&2; exit 1; }
+cmp -s "$NGINX_CONFIG" "${TEST_ROOT}/panel-port-rollback.nginx" \
+    || { echo 'FAIL: panel port rollback did not restore Nginx' >&2; exit 1; }
+port_cleanup_tmp=$(mktemp -d "${TEST_ROOT}/panel-port-cleanup.XXXXXX")
+set_panel_env '127.0.0.1' '' '' 'false' "$port_cleanup_tmp" 20090
+rm -rf -- "$port_cleanup_tmp" "$NGINX_CONFIG"
 
 # Existing valid encryption keys are immutable; an explicitly empty legacy key
 # is repaired, while ambiguous or weak non-empty values fail without rewriting
@@ -1263,6 +1355,7 @@ do_uninstall >"${TEST_ROOT}/uninstall-purge.log" 2>&1
 assert_dir "$BACKUP_DIR"
 
 help_text=$(usage)
+assert_contains <(printf '%s' "$help_text") '--port PORT'
 for command_name in install update password uninstall; do
     printf '%s' "$help_text" | grep -q "install.sh ${command_name}"
 done
@@ -1283,6 +1376,33 @@ for menu_item in '1) 安装' '2) 更新到最新版' '3) 修改管理员密码' 
 done
 if printf '%s' "$menu_text" | grep -Eq '^  [5-9]\)'; then
     echo 'FAIL: menu exposes more than four operations' >&2
+    exit 1
+fi
+
+# CLI parsing accepts both normalized custom ports and the short alias while
+# rejecting malformed values and actions that cannot change the listener.
+parsed_port=$(
+    do_install() { printf '%s\n' "$REQUESTED_PORT"; }
+    run_cli install --port 00080
+)
+assert_eq '80' "$parsed_port" 'CLI port normalization'
+parsed_short_port=$(
+    do_install() { printf '%s\n' "$REQUESTED_PORT"; }
+    run_cli install -p 18090
+)
+assert_eq '18090' "$parsed_short_port" 'CLI short port option'
+for invalid_port in 0 65536 abc -1 1.5 999999999999999999999999999999999; do
+    if (run_cli install --port "$invalid_port") >"${TEST_ROOT}/invalid-port.log" 2>&1; then
+        printf 'FAIL: invalid port was accepted: %s\n' "$invalid_port" >&2
+        exit 1
+    fi
+done
+if (run_cli install --port 18090 --port 19090) >"${TEST_ROOT}/duplicate-port.log" 2>&1; then
+    echo 'FAIL: duplicate port option was accepted' >&2
+    exit 1
+fi
+if (run_cli update --port 18090) >"${TEST_ROOT}/update-port.log" 2>&1; then
+    echo 'FAIL: update accepted an install-only port option' >&2
     exit 1
 fi
 

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -354,7 +354,7 @@ assert_contains "$panel_port_after" 'proxy_pass http://127.0.0.1:18090;'
 assert_not_contains "$panel_port_after" 'proxy_pass http://127.0.0.1:9090;'
 assert_contains "$panel_port_after" 'listen 443 ssl; # managed by Certbot'
 assert_contains "$panel_port_after" 'ssl_certificate /etc/letsencrypt/live/panel.example.com/fullchain.pem; # managed by Certbot'
-assert_contains "$panel_port_after" 'return 301 https://$host$request_uri;'
+assert_contains "$panel_port_after" "return 301 https://\$host\$request_uri;"
 awk '!($0 ~ /^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:[0-9]+;([[:space:]]*#.*)?[[:space:]]*$/)' \
     "$panel_port_before" > "${TEST_ROOT}/nginx-port-before-without-proxy"
 awk '!($0 ~ /^[[:space:]]*proxy_pass[[:space:]]+http:\/\/127\.0\.0\.1:[0-9]+;([[:space:]]*#.*)?[[:space:]]*$/)' \
@@ -722,7 +722,7 @@ fi
 assert_eq '20090' "$(read_env_value PORT)" 'systemd panel port switch'
 assert_contains "$NGINX_CONFIG" 'proxy_pass http://127.0.0.1:20090;'
 assert_contains "$NGINX_CONFIG" 'ssl_certificate /etc/letsencrypt/live/panel.example.com/fullchain.pem; # managed by Certbot'
-assert_contains "$NGINX_CONFIG" 'return 301 https://$host$request_uri;'
+assert_contains "$NGINX_CONFIG" "return 301 https://\$host\$request_uri;"
 assert_contains "$port_systemd_log" 'restart meridian'
 
 cp "${DATA_DIR}/.env" "${TEST_ROOT}/panel-port-rollback.env"

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -709,6 +709,9 @@ write_legacy_managed_nginx
 port_systemd_log="${TEST_ROOT}/panel-port-systemd.log"
 : > "$port_systemd_log"
 if ! (
+    as_root() {
+        if [ "$1" = install ]; then run_test_root_command "$@"; else "$@"; fi
+    }
     is_systemd() { return 0; }
     install_env_file() { cp "$1" "$(env_file_path)"; }
     systemctl() { printf '%s\n' "$*" >> "$port_systemd_log"; }
@@ -728,6 +731,9 @@ assert_contains "$port_systemd_log" 'restart meridian'
 cp "${DATA_DIR}/.env" "${TEST_ROOT}/panel-port-rollback.env"
 cp "$NGINX_CONFIG" "${TEST_ROOT}/panel-port-rollback.nginx"
 if (
+    as_root() {
+        if [ "$1" = install ]; then run_test_root_command "$@"; else "$@"; fi
+    }
     is_systemd() { return 0; }
     install_env_file() { cp "$1" "$(env_file_path)"; }
     systemctl() { return 0; }

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1387,27 +1387,30 @@ fi
 
 # Interactive menu installation accepts a custom panel port and keeps the
 # command-line/default behavior when the prompt is left blank.
-menu_custom_port=$(
-    REQUESTED_PORT=''
-    do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT"; }
-    printf '1\n18090\n' | main_menu | tail -n 1
-)
+menu_input_file="${TEST_ROOT}/menu-input"
+menu_output_file="${TEST_ROOT}/menu-output"
+printf '1\n18090\n' > "$menu_input_file"
+REQUESTED_PORT=''
+do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT" > "$menu_output_file"; }
+main_menu < "$menu_input_file" > /dev/null
+menu_custom_port=$(cat "$menu_output_file")
 assert_eq 'PORT=18090' "$menu_custom_port" 'interactive menu port'
-menu_default_port=$(
-    REQUESTED_PORT=''
-    do_install() { printf 'PORT=%s\n' "${REQUESTED_PORT:-<default>}"; }
-    printf '1\n\n' | main_menu | tail -n 1
-)
+printf '1\n\n' > "$menu_input_file"
+REQUESTED_PORT=''
+do_install() { printf 'PORT=%s\n' "${REQUESTED_PORT:-<default>}" > "$menu_output_file"; }
+main_menu < "$menu_input_file" > /dev/null
+menu_default_port=$(cat "$menu_output_file")
 assert_eq 'PORT=<default>' "$menu_default_port" 'interactive menu default port'
-menu_retry_port=$(
-    REQUESTED_PORT=''
-    do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT"; }
-    printf '1\nnot-a-port\n19090\n' | main_menu | tail -n 1
-)
+printf '1\nnot-a-port\n19090\n' > "$menu_input_file"
+REQUESTED_PORT=''
+do_install() { printf 'PORT=%s\n' "$REQUESTED_PORT" > "$menu_output_file"; }
+main_menu < "$menu_input_file" > /dev/null
+menu_retry_port=$(cat "$menu_output_file")
 assert_eq 'PORT=19090' "$menu_retry_port" 'interactive menu invalid port retry'
 
 # CLI parsing accepts both normalized custom ports and the short alias while
 # rejecting malformed values and actions that cannot change the listener.
+REQUESTED_PORT=''
 parsed_port=$(
     do_install() { printf '%s\n' "$REQUESTED_PORT"; }
     run_cli install --port 00080


### PR DESCRIPTION
## 变更
- 支持 `install --port PORT` 和 `-p PORT`，范围为 1-65535，默认仍为 9090
- 首次安装和已有安装端口切换都更新 `.env`；systemd 会重启并执行健康检查
- 已配置 HTTPS 面板时只更新唯一的本机 `proxy_pass`，保留 Certbot 证书、443 和重定向配置
- 补充安装器回归测试和一键安装文档

## 验证
- `bash -n install.sh`
- `bash tests/install_test.sh`
- `node --test tests/*.test.js`
- 前端 JS `node --check`

本机 Go 1.24.4 无法运行项目要求的 Go 1.26.6；Docker 入口测试受本机 Docker BuildKit 配置限制。